### PR TITLE
[Optimization] Cache table length, 2x speedup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pluto is a fork of the Lua 5.4.4 programming language. Internally, it's mostly P
 Pluto will retain a heavy focus on portability, but it will be larger & less light-weight than Lua. I intend on adding features to this that'll make Lua (or in this case, Pluto) more general-purpose and bring more attention to the Lua programming language, which I deeply love. Pluto will not grow to the enormous size of Python, obviously, but the standard library will most definitely be expanded. So far, many operators have been added & overhauled. There are new virtual machine optimizations, new syntax such as lambda expressions & string indexing, and more that you can read below.
 
 ### Note
-This is a learner's project concerning the internals of Lua. I will often add and change things simply to learn more about my environment. As a result, there will be breaking changes very often. There may be bugs, and there will be design choices that people probably don't agree with. However, this will become a good base to write more Lua patches from. I do welcome other people in using Pluto as a reference for their own Lua patches — because Pluto offers some neat improvements over Lua already.
+Thanks to everyone who's provided a star towards Pluto. I do notice every single person that does so, and it provides me excellent motivation to continue working on Pluto. On this note, please do send PRs and plenty of bug reports if you stumble upon any. All help is appreciated.
 
 ## Breaking changes:
 - None.

--- a/README.md
+++ b/README.md
@@ -130,9 +130,7 @@ ipairs: ipairsaux, table, integer, nil
 ```
 When the latter `nil` TBC variable is never accessed, this optimization will occur.
 ### Table Length
-The length of tables (`#mytable`) is now automatically cached by Pluto after you request it for the first time. The cache is updated whenever a change is made to the table. Following this optimization, fetching table length is roughly twice as fast.
-
-The `table.getn` function has been provided in case a bug appears with the cache. However, it's unlikely a bug will appear.
+The length of tables (`#mytable`) is now automatically cached by Pluto after you request it for the first time. The cache is updated whenever a change is made to the table. Following this optimization, fetching table length is roughly twice as fast. The `table.getn` function has been provided in case a bug appears with the cache. However, it's unlikely a bug will appear.
 ## QoL Improvements
 These are modifications that don't really add something new, but improve existing behavior.
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ pairs: next, table, nil, nil
 ipairs: ipairsaux, table, integer, nil
 ```
 When the latter `nil` TBC variable is never accessed, this optimization will occur.
+### Table Length
+The length of tables (`#mytable`) is now automatically cached by Pluto after you request it for the first time. The cache is updated whenever a change is made to the table. Following this optimization, fetching table length is roughly twice as fast.
+
+The `table.getn` function has been provided in case a bug appears with the cache. However, it's unlikely a bug will appear.
 ## QoL Improvements
 These are modifications that don't really add something new, but improve existing behavior.
 

--- a/src/lapi.cpp
+++ b/src/lapi.cpp
@@ -929,6 +929,16 @@ LUA_API void lua_rawseti (lua_State *L, int idx, lua_Integer n) {
 }
 
 
+LUA_API void lua_setcachelen (lua_State *L, lua_Unsigned len, int idx) {
+  Table *t;
+  lua_lock(L);
+  api_checknelems(L, 1);
+  t = gettable(L, idx);
+  t->length = len;
+  lua_unlock(L);
+}
+
+
 LUA_API int lua_setmetatable (lua_State *L, int objindex) {
   TValue *obj;
   Table *mt;

--- a/src/lobject.h
+++ b/src/lobject.h
@@ -733,6 +733,7 @@ typedef struct Table {
   Node *lastfree;  /* any free position is before this position */
   struct Table *metatable;
   GCObject *gclist;
+  unsigned int length;
 } Table;
 
 

--- a/src/lobject.h
+++ b/src/lobject.h
@@ -733,7 +733,7 @@ typedef struct Table {
   Node *lastfree;  /* any free position is before this position */
   struct Table *metatable;
   GCObject *gclist;
-  unsigned int length;
+  lua_Unsigned length;  /* cached length of this table, as returned by luaH_getn */
 } Table;
 
 

--- a/src/ltable.cpp
+++ b/src/ltable.cpp
@@ -928,7 +928,6 @@ lua_Unsigned luaH_getn (Table *t) {
         t->alimit = limit - 1;
         setnorealasize(t);  /* now 'alimit' is not the real size */
       }
-      t->length = limit - 1;
       return limit - 1;
     }
     else {  /* must search for a boundary in [0, limit] */
@@ -938,17 +937,14 @@ lua_Unsigned luaH_getn (Table *t) {
         t->alimit = boundary;  /* use it as the new limit */
         setnorealasize(t);
       }
-      t->length = boundary;
       return boundary;
     }
   }
   /* 'limit' is zero or present in table */
   if (!limitequalsasize(t)) {  /* (2)? */
     /* 'limit' > 0 and array has more elements after 'limit' */
-    if (isempty(&t->array[limit])) {  /* 'limit + 1' is empty? */
-      t->length = limit;
+    if (isempty(&t->array[limit]))  /* 'limit + 1' is empty? */
       return limit;  /* this is the boundary */
-    }
     /* else, try last element in the array */
     limit = luaH_realasize(t);
     if (isempty(&t->array[limit - 1])) {  /* empty? */
@@ -956,7 +952,6 @@ lua_Unsigned luaH_getn (Table *t) {
          and it must be a valid new limit */
       unsigned int boundary = binsearch(t->array, t->alimit, limit);
       t->alimit = boundary;
-      t->length = boundary;
       return boundary;
     }
     /* else, new limit is present in the table; check the hash part */
@@ -964,14 +959,10 @@ lua_Unsigned luaH_getn (Table *t) {
   /* (3) 'limit' is the last element and either is zero or present in table */
   lua_assert(limit == luaH_realasize(t) &&
              (limit == 0 || !isempty(&t->array[limit - 1])));
-  if (isdummy(t) || isempty(luaH_getint(t, cast(lua_Integer, limit + 1)))) {
-    t->length = limit;
+  if (isdummy(t) || isempty(luaH_getint(t, cast(lua_Integer, limit + 1))))
     return limit;  /* 'limit + 1' is absent */
-  }
-  else { /* 'limit + 1' is also present */
-    t->length = hash_search(t, limit);
-    return t->length;
-  }
+  else  /* 'limit + 1' is also present */
+    return hash_search(t, limit);
 }
 
 

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -95,6 +95,7 @@ static int tremove (lua_State *L) {
     /* check whether 'pos' is in [1, size + 1] */
     luaL_argcheck(L, (lua_Unsigned)pos - 1u <= (lua_Unsigned)size, 1,
                      "position out of bounds");
+  lua_setcachelen(L, size - 1, 1);
   lua_geti(L, 1, pos);  /* result = t[pos] */
   for ( ; pos < size; pos++) {
     lua_geti(L, 1, pos + 1);

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -409,6 +409,13 @@ static int sort (lua_State *L) {
   return 0;
 }
 
+
+static int getn (lua_State *L) {
+  lua_pushinteger(aux_getn(L, 1, TAB_RW));
+  return 1;
+}
+
+
 /* }====================================================== */
 
 
@@ -420,6 +427,7 @@ static const luaL_Reg tab_funcs[] = {
   {"remove", tremove},
   {"move", tmove},
   {"sort", sort},
+  {"getn", getn},
   {NULL, NULL}
 };
 

--- a/src/lua.h
+++ b/src/lua.h
@@ -273,6 +273,7 @@ LUA_API void  (lua_rawseti) (lua_State *L, int idx, lua_Integer n);
 LUA_API void  (lua_rawsetp) (lua_State *L, int idx, const void *p);
 LUA_API int   (lua_setmetatable) (lua_State *L, int objindex);
 LUA_API int   (lua_setiuservalue) (lua_State *L, int idx, int n);
+LUA_API void  (lua_setcachelen) (lua_State *L, lua_Unsigned len, int idx);
 
 
 /*

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -1333,8 +1333,10 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         if (luaV_fastget(L, upval, key, slot, luaH_getshortstr)) {
           luaV_finishfastset(L, upval, slot, rc);
         }
-        else
+        else {
+          hvalue(s2v(ra))->length = 0;
           Protect(luaV_finishset(L, upval, rb, rc, slot));
+        }
         vmbreak;
       }
       vmcase(OP_SETTABLE) {

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -701,7 +701,10 @@ void luaV_objlen (lua_State *L, StkId ra, const TValue *rb) {
       Table *h = hvalue(rb);
       tm = fasttm(L, h->metatable, TM_LEN);
       if (tm) break;  /* metamethod? break switch to call it */
-      setivalue(s2v(ra), luaH_getn(h));  /* else primitive len */
+      if (!h->length) {
+        setivalue(s2v(ra), luaH_getn(h));  /* primitive len */
+      }
+      else setivalue(s2v(ra), h->length);
       return;
     }
     case LUA_VSHRSTR: {

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -701,10 +701,8 @@ void luaV_objlen (lua_State *L, StkId ra, const TValue *rb) {
       Table *h = hvalue(rb);
       tm = fasttm(L, h->metatable, TM_LEN);
       if (tm) break;  /* metamethod? break switch to call it */
-      if (!h->length) {
-        setivalue(s2v(ra), luaH_getn(h));  /* primitive len */
-      }
-      else setivalue(s2v(ra), h->length);
+      if (!h->length) h->length = luaH_getn(h);  /* cache length */
+      setivalue(s2v(ra), h->length);
       return;
     }
     case LUA_VSHRSTR: {

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -1349,6 +1349,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         }
         else
           Protect(luaV_finishset(L, s2v(ra), rb, rc, slot));
+        hvalue(s2v(ra))->length = 0; /* reset cache on modification */
         vmbreak;
       }
       vmcase(OP_SETI) {

--- a/tests/lenbench.lua
+++ b/tests/lenbench.lua
@@ -1,0 +1,11 @@
+local t = {}
+for i = 1, 100000 do
+    t[i - 2] = "aadw"
+    t[i + 1] = 444
+end
+
+local s = os.clock()
+for i = 1, 100000000 do
+    local len = #t
+end
+print(os.clock() - s)

--- a/tests/lentest.lua
+++ b/tests/lentest.lua
@@ -1,0 +1,10 @@
+local t = {}
+for i = 1, 1000 do
+    t[i] = "abc"
+end
+assert(#t == 1000, #t)
+
+for i = 1, 100 do
+    table.remove(t, i + math.random(1, 5))
+end
+assert(#t == 900, #t)

--- a/tests/lentest.lua
+++ b/tests/lentest.lua
@@ -8,3 +8,7 @@ for i = 1, 100 do
     table.remove(t, i + math.random(1, 5))
 end
 assert(#t == 900, #t)
+
+local metatest = setmetatable({}, { __len = function () return 5 end })
+assert(#metatest == 5, #metatest)
+print("Finished test.")


### PR DESCRIPTION
The vanilla length mechanism is left unchanged, but within this mechanism the result of luaH_getn is cached into the new Table.length field. Which means, each recalculation will be immediately cached. If the length field is not NULL or 0, then the cached field is returned. Otherwise, luaH_getn performs a primitive length operation.

More testing required, such that it may need to be manually decremented if table.remove is called. Garbage collection with weak tables as well.

While it would certainly be possible to avoid caching all-together and route for the removal of luaH_getn, in favor of manually managed length field, this would be excessively buggy due to complexity. For example, the luaH_finishset function of ltable.c is potentially recursive, which will require a complex method of knowing when, and when to not increment the length.

Furthermore, Lua has an exhaustive list of rules for the table length operator. These are tedious to test, and easy to break. It would require advanced rules of my own — basically recreating the luaH_getn function — to ensure 1:1 compatibility with Lua. While speed is an ideal, so is minimal bugs. Time spent fixing bugs can be reallocated in a more efficient manner. That makes this implementation a (potential) compromise between speed, compatibility, and complexity. 