### PR TITLE
Structured exception handling for Windows, basic.

### DIFF
--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -880,5 +880,10 @@
 #define ERROR_FOR_PREVENTION		1
 #endif // INFINITE_LOOP_PREVENTION
 
+#ifdef _WIN32
+#define USE_SEH_EXCEPTION_HANDLER // Undef to remove custom Pluto handler.
+// #undef USE_SEH_EXCEPTION_HANDLER
+#endif
+
 /* }================================================================== */
 #endif


### PR DESCRIPTION
Very simple SEH handling for Windows only. Implemented because it would make the debugging process just a little bit quicker, such to spot quick small errors, like what happened with the segfault fixed recently in f9c574c2e61f50fbe61ff22378f97f068179a72e. If someone ever uses this, then we can react to that bug report faster too. 

I theorize that you may be more experienced with implementing things like this, I am fairly unfamiliar with the Windows API. @Sainan Let me know what you think of this. If you would like to merge this, the below-mentioned intentional segfault needs to be fixed before anything. Repair in recent master commit. Otherwise I'll take the review and handle it appropriately.