### PR TITLE
Fix inconsistent use of class or struct causing MSVC build failure

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -80,8 +80,7 @@ typedef struct Token {
 #pragma warning( disable: 26495 )
 #endif
 
-class LexState {
-public:
+struct LexState {
   int current;  /* current character (charint) */
   int linenumber;  /* input line counter */
   int lastline;  /* line of last token 'consumed' */

--- a/src/lstate.h
+++ b/src/lstate.h
@@ -321,8 +321,7 @@ public:
 /*
 ** 'per thread' state
 */
-class lua_State {
-public:
+struct lua_State {
   CommonHeader;
   lu_byte status;
   lu_byte allowhook;


### PR DESCRIPTION
This is the simple fix. If you want to actually have them be "class", replace every instance of them and change the "struct" prefix to "class". If this is inconsistent, MSVC build will fail.