### PR TITLE
Add user_data to global_State

### DIFF
--- a/src/lstate.h
+++ b/src/lstate.h
@@ -295,6 +295,8 @@ typedef struct global_State {
   TString *strcache[STRCACHE_N][STRCACHE_M];  /* cache for strings in API */
   lua_WarnFunction warnf;  /* warning function */
   void *ud_warn;         /* auxiliary data to 'warnf' */
+
+  void* user_data;       /* a pointer to data you, the user, would like to specify */
 } global_State;
 
 class Registry {


### PR DESCRIPTION
This is pretty useful to have and afaik there's no easy way to tag some user-defined value or pointer onto a lua instance (unless you wanna count global variables).