### PR TITLE
Add new time functions to os api

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ This also supports ANSI color codes, however this is disabled by default in orde
 - `table.contains` function.
 - `string.endswith` function.
 - `string.startswith` function.
+- `os.unixseconds` function. Returns seconds since UNIX epoch.
+- `os.seconds` function. Returns seconds since implementation-specific epoch.
+- `os.millis` function. Returns milliseconds since implementation-specific epoch.
+- `os.nanos` function. Returns nanoseconds since implementation-specific epoch.
 
 ## C API Additions
 - `lua_setcachelen` function.

--- a/src/loslib.cpp
+++ b/src/loslib.cpp
@@ -10,6 +10,7 @@
 #include "lprefix.h"
 
 
+#include <chrono>
 #include <errno.h>
 #include <locale.h>
 #include <stdlib.h>
@@ -374,6 +375,30 @@ static int os_difftime (lua_State *L) {
   return 1;
 }
 
+
+static int os_unixseconds(lua_State *L) {
+  lua_pushinteger(L, (lua_Integer)std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
+  return 1;
+}
+
+
+static int os_seconds(lua_State* L) {
+	lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+	return 1;
+}
+
+
+static int os_millis(lua_State* L) {
+	lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+	return 1;
+}
+
+
+static int os_nanos(lua_State* L) {
+	lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+	return 1;
+}
+
 /* }====================================================== */
 
 
@@ -403,17 +428,21 @@ static int os_exit (lua_State *L) {
 
 
 static const luaL_Reg syslib[] = {
-  {"clock",     os_clock},
-  {"date",      os_date},
-  {"difftime",  os_difftime},
-  {"execute",   os_execute},
-  {"exit",      os_exit},
-  {"getenv",    os_getenv},
-  {"remove",    os_remove},
-  {"rename",    os_rename},
-  {"setlocale", os_setlocale},
-  {"time",      os_time},
-  {"tmpname",   os_tmpname},
+  {"clock",       os_clock},
+  {"date",        os_date},
+  {"difftime",    os_difftime},
+  {"execute",     os_execute},
+  {"exit",        os_exit},
+  {"getenv",      os_getenv},
+  {"remove",      os_remove},
+  {"rename",      os_rename},
+  {"setlocale",   os_setlocale},
+  {"time",        os_time},
+  {"tmpname",     os_tmpname},
+  {"unixseconds", os_unixseconds},
+  {"seconds",     os_seconds},
+  {"millis",      os_millis},
+  {"nanos",       os_nanos},
   {NULL, NULL}
 };
 

--- a/src/loslib.cpp
+++ b/src/loslib.cpp
@@ -383,20 +383,20 @@ static int os_unixseconds(lua_State *L) {
 
 
 static int os_seconds(lua_State* L) {
-	lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
-	return 1;
+  lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+  return 1;
 }
 
 
 static int os_millis(lua_State* L) {
-	lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
-	return 1;
+  lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+  return 1;
 }
 
 
 static int os_nanos(lua_State* L) {
-	lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
-	return 1;
+  lua_pushinteger(L, (lua_Integer)std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+  return 1;
 }
 
 /* }====================================================== */


### PR DESCRIPTION
These should all be nice additions. `os.time` seems to return the same as `os.unixseconds` on my machine. However, `os.time` makes no guarantees about which epoch is used, so I think `os.unixseconds` still has some value.