### PR TITLE
Fix ILP with REPEAT UNTIL loops.

### DIFF
--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -1688,6 +1688,20 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       }
       vmcase(OP_TEST) {
         int cond = !l_isfalse(s2v(ra));
+#ifdef PLUTO_ILP_ENABLE
+        int offset = GETARG_sJ(i);
+        if (offset <= 0) {
+          sequentialJumps++;
+        }
+        else sequentialJumps = 0;
+        if (sequentialJumps >= PLUTO_ILP_MAX_ITERATIONS) {
+          sequentialJumps = 0;
+#ifndef PLUTO_ILP_SILENT_BREAK
+          luaG_runerror(L, "infinite loop detected (exceeded max iterations: %d)", PLUTO_ILP_MAX_ITERATIONS);
+#endif
+          vmbreak;
+        }
+#endif // PLUTO_ILP_ENABLE
         docondjump();
         vmbreak;
       }


### PR DESCRIPTION
Note to self: Do not merge until development builds ensure no issues with existing userbases!

Fixes `repeat .. until` avoiding infinite loop prevention. Simply copy-pasted OP_JMP handling into OP_TEST. If it ain't broke, don't fix it.