### PR TITLE
Add _PVERSION, assert copyright in compiled executable, bump version to 0.2.0

### DIFF
--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -552,6 +552,9 @@ LUAMOD_API int luaopen_base (lua_State *L) {
   /* set global _VERSION */
   lua_pushliteral(L, LUA_VERSION);
   lua_setfield(L, -2, "_VERSION");
+  /* set global _PVERSION */
+  lua_pushliteral(L, PLUTO_VERSION);
+  lua_setfield(L, -2, "_PVERSION");
   return 1;
 }
 

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -165,7 +165,7 @@ static int docall (lua_State *L, int narg, int nres) {
 
 
 static void print_version (void) {
-  lua_writestring("Pluto 0.1.0", 12);
+  lua_writestring(LUA_COPYRIGHT, strlen(LUA_COPYRIGHT));
   lua_writeline();
 }
 

--- a/src/lua.h
+++ b/src/lua.h
@@ -13,6 +13,8 @@
 #include "luaconf.h"
 
 
+#define PLUTO_VERSION "Pluto 0.2.0"
+
 #define LUA_VERSION_MAJOR	"5"
 #define LUA_VERSION_MINOR	"4"
 #define LUA_VERSION_RELEASE	"4"
@@ -22,8 +24,8 @@
 
 #define LUA_VERSION	"Lua " LUA_VERSION_MAJOR "." LUA_VERSION_MINOR
 #define LUA_RELEASE	LUA_VERSION "." LUA_VERSION_RELEASE
-#define LUA_COPYRIGHT	LUA_RELEASE "  Copyright (C) 1994-2022 Lua.org, PUC-Rio"
-#define LUA_AUTHORS	"R. Ierusalimschy, L. H. de Figueiredo, W. Celes"
+#define LUA_COPYRIGHT	PLUTO_VERSION " Copyright (C) 2022 Ryan Starrett, based on " LUA_RELEASE " Copyright (C) 1994-2022 Lua.org, PUC-Rio"
+#define LUA_AUTHORS	"R. Starrett, R. Ierusalimschy, L. H. de Figueiredo, W. Celes"
 
 
 /* mark for precompiled code ('<esc>Lua') */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63328889/179032992-7756db2f-d5a6-442d-afb4-071f5fa08641.png)

This change is mainly just to introduce _PVERSION which we will hopefully bump a bit more often so users can have an idea of which features are available in their environment.