### PR TITLE
Use long jumps instead of C++ exceptions by default

### DIFF
--- a/src/ldo.cpp
+++ b/src/ldo.cpp
@@ -52,7 +52,7 @@
 */
 #if !defined(LUAI_THROW)				/* { */
 
-#if defined(__cplusplus) && !defined(LUA_USE_LONGJMP)	/* { */
+#if defined(__cplusplus) && defined(PLUTO_USE_THROW)	/* { */
 
 /* C++ exceptions */
 #define LUAI_THROW(L,c)		throw(c)

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -865,6 +865,10 @@
 // This will generally improve runtime performance but can add minutes to compile time, depending on the setup.
 //#define PLUTO_FORCE_JUMPTABLE
 
+// If defined, Pluto will use C++ exceptions to implement Lua longjumps.
+// This is generally slower and complicates exception handling.
+//#define PLUTO_USE_THROW
+
 /*
 ** {====================================================================
 ** Pluto configuration: Compatible Mode


### PR DESCRIPTION
```Lua
local start = os.nanos()
pcall(function()
  error()
end)
print(os.nanos() - start)
```

- C++ exceptions: Around 55700
- Long jumps: Around 30900

As you can see, long jumps are more performant, they don't complicate exception handling, and are acceptable due to this codebase still being very C-like, so they're the much better default choice.

Preliminary testing shows no issues. In fact, it resolved some issues due to exception handling being less complicated now.