### PR TITLE
Shorthand hack

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -190,6 +190,11 @@ TString *luaX_newstring (LexState *ls, const char *str, size_t l) {
 }
 
 
+LUAI_FUNC TString* luaX_newstring (LexState *ls, const char *str) {
+  return luaX_newstring(ls, str, strlen(str));
+}
+
+
 /*
 ** increment line number and skips newline sequence (any of
 ** \n, \r, \n\r, or \r\n)

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -132,6 +132,11 @@ const char *luaX_token2str_noq (LexState *ls, int token) {
 }
 
 
+const char* luaX_reserved2str (LexState *ls, int token) {
+  return luaX_tokens[token - FIRST_RESERVED];
+}
+
+
 static const char *txtToken (LexState *ls, int token) {
   switch (token) {
     case TK_NAME: case TK_STRING:

--- a/src/llex.h
+++ b/src/llex.h
@@ -154,6 +154,7 @@ LUAI_FUNC void luaX_init (lua_State *L);
 LUAI_FUNC void luaX_setinput (lua_State *L, LexState *ls, ZIO *z,
                               TString *source, int firstchar);
 LUAI_FUNC TString *luaX_newstring (LexState *ls, const char *str, size_t l);
+LUAI_FUNC TString* luaX_newstring (LexState *ls, const char *str);
 LUAI_FUNC void luaX_next (LexState *ls);
 LUAI_FUNC int luaX_lookahead (LexState *ls);
 [[noreturn]] LUAI_FUNC void luaX_syntaxerror (LexState *ls, const char *s);

--- a/src/llex.h
+++ b/src/llex.h
@@ -70,9 +70,10 @@ enum RESERVED {
   TK_CCAT,              /* concatenation               */
 };
 
+#define LAST_RESERVED TK_WHILE
 
 /* number of reserved words */
-#define NUM_RESERVED	(cast_int(TK_WHILE-FIRST_RESERVED + 1))
+#define NUM_RESERVED	(cast_int(LAST_RESERVED-FIRST_RESERVED + 1))
 
 
 typedef union {
@@ -82,10 +83,18 @@ typedef union {
 } SemInfo;  /* semantics information */
 
 
-typedef struct Token {
+struct Token {
   int token;
   SemInfo seminfo;
-} Token;
+
+  [[nodiscard]] bool IsReserved() const noexcept {
+    return token >= FIRST_RESERVED && token <= LAST_RESERVED;
+  }
+
+  [[nodiscard]] bool IsReservedNonValue() const noexcept {
+	return IsReserved() && token != TK_TRUE && token != TK_FALSE;
+  }
+};
 
 
 /*
@@ -150,3 +159,4 @@ LUAI_FUNC int luaX_lookahead (LexState *ls);
 [[noreturn]] LUAI_FUNC void luaX_syntaxerror (LexState *ls, const char *s);
 LUAI_FUNC const char *luaX_token2str (LexState *ls, int token);
 LUAI_FUNC const char *luaX_token2str_noq (LexState *ls, int token);
+LUAI_FUNC const char *luaX_reserved2str (LexState *ls, int token);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -341,7 +341,9 @@ static void check_match (LexState *ls, int what, int who, int where) {
 
 static TString *str_checkname (LexState *ls) {
   TString *ts;
-  check(ls, TK_NAME);
+  if (ls->t.token != TK_NAME && !ls->t.IsReservedNonValue()) {
+    error_expected(ls, TK_NAME);
+  }
   ts = ls->t.seminfo.ts;
   luaX_next(ls);
   return ts;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2557,6 +2557,12 @@ static void statement (LexState *ls) {
     case TK_PCASE: {
       throwerr(ls, "inappropriate 'case' statement.", "outside of 'switch' block.");
     }
+#ifndef PLUTO_COMPATIBLE_DEFAULT
+    case TK_DEFAULT:
+#endif
+    case TK_PDEFAULT: {
+      throwerr(ls, "inappropriate 'default' statement.", "outside of 'switch' block.");
+    }
 #ifndef PLUTO_COMPATIBLE_SWITCH
     case TK_SWITCH:
 #endif

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1126,7 +1126,7 @@ static void prenamedfield(LexState* ls, ConsControl* cc, const char* name) {
   FuncState* fs = ls->fs;
   int reg = ls->fs->freereg;
   expdesc tab, key, val;
-  codestring(&key, luaX_newstring(ls, name, strlen(name)));
+  codestring(&key, luaX_newstring(ls, name));
   cc->nh++;
   luaX_next(ls); /* skip name token */
   checknext(ls, '=');

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1419,28 +1419,24 @@ static void primaryexp (LexState *ls, expdesc *v) {
       singlevar(ls, v);
       return;
     }
+    case '}':
+    case '{': { // Unfinished table constructors.
+       if (ls->t.token == '{') {
+         throwerr(ls, "unfinished table constructor", "did you mean to close with '}'?");
+       }
+       else {
+         throwerr(ls, "unfinished table constructor", "did you mean to enter with '{'?");
+       }
+       return;
+    }
+    case '|': { // Potentially mistyped lambda expression. People may confuse '->' with '=>'.
+      while (testnext(ls, '|') || testnext(ls, TK_NAME) || testnext(ls, ','));
+      throwerr(ls, "unexpected symbol", "impromper or stranded lambda expression.");
+      return;
+    }
     default: {
-      switch (ls->t.token) {
-        case '}':
-        case '{': { // Unfinished table constructors.
-          if (ls->t.token == '{') {
-            throwerr(ls, "unfinished table constructor", "did you mean to close with '}'?");
-          }
-          else {
-            throwerr(ls, "unfinished table constructor", "did you mean to enter with '{'?");
-          }
-          return;
-        }
-        case '|': { // Potentially mistyped lambda expression. People may confuse '->' with '=>'.
-          while (testnext(ls, '|') || testnext(ls, TK_NAME) || testnext(ls, ','));
-          throwerr(ls, "unexpected symbol", "impromper or stranded lambda expression.");
-          return;
-        }
-        default: {
-          const char *token = luaX_token2str(ls, ls->t.token);
-          throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
-        }
-      }
+      const char *token = luaX_token2str(ls, ls->t.token);
+      throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
     }
   }
 }


### PR DESCRIPTION
This makes the following syntax valid:
```Lua
local t = {
  default = true
}
print(t.default)
```
As well as some improvements to the parser and lexer.

Preliminary testing shows no problems.