### PR TITLE
0.3.0

### DIFF
--- a/src/liolib.cpp
+++ b/src/liolib.cpp
@@ -755,8 +755,7 @@ static int filesize (lua_State *L) {
     lua_pushinteger(L, (lua_Integer)std::filesystem::file_size(f));
   }
   else {
-    lua_pushstring(L, "Argument 1 did not lead towards a valid file.");
-    lua_error(L);
+    luaL_error(L, "Argument 1 did not lead towards a valid file.");
   }
   return 1;
 }
@@ -791,10 +790,28 @@ static int makedir (lua_State *L) {
 }
 
 
+static int listdir (lua_State *L) {
+  auto f = luaL_checkstring(L, 1);
+  if (std::filesystem::is_directory(f)) {
+    size_t i = 0;
+    lua_newtable(L);
+    for (auto const& dir_entry : std::filesystem::directory_iterator { f })  {
+      lua_pushstring(L, dir_entry.path().generic_string().c_str());
+      lua_rawseti(L, -2, ++i);
+    }
+  }
+  else {
+    luaL_error(L, "Argument 1 is not a valid path to a directory.");
+  }
+  return 1;
+}
+
+
 /*
 ** functions for 'io' library
 */
 static const luaL_Reg iolib[] = {
+  {"listdir", listdir},
   {"makedir", makedir},
   {"absolute", absolute},
   {"copyto", copyto},

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -190,6 +190,11 @@ TString *luaX_newstring (LexState *ls, const char *str, size_t l) {
 }
 
 
+LUAI_FUNC TString* luaX_newstring (LexState *ls, const char *str) {
+  return luaX_newstring(ls, str, strlen(str));
+}
+
+
 /*
 ** increment line number and skips newline sequence (any of
 ** \n, \r, \n\r, or \r\n)

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -132,6 +132,11 @@ const char *luaX_token2str_noq (LexState *ls, int token) {
 }
 
 
+const char* luaX_reserved2str (LexState *ls, int token) {
+  return luaX_tokens[token - FIRST_RESERVED];
+}
+
+
 static const char *txtToken (LexState *ls, int token) {
   switch (token) {
     case TK_NAME: case TK_STRING:

--- a/src/llex.h
+++ b/src/llex.h
@@ -92,7 +92,7 @@ struct Token {
   }
 
   [[nodiscard]] bool IsReservedNonValue() const noexcept {
-	return IsReserved() && token != TK_TRUE && token != TK_FALSE;
+    return IsReserved() && token != TK_TRUE && token != TK_FALSE;
   }
 };
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -154,6 +154,7 @@ LUAI_FUNC void luaX_init (lua_State *L);
 LUAI_FUNC void luaX_setinput (lua_State *L, LexState *ls, ZIO *z,
                               TString *source, int firstchar);
 LUAI_FUNC TString *luaX_newstring (LexState *ls, const char *str, size_t l);
+LUAI_FUNC TString* luaX_newstring (LexState *ls, const char *str);
 LUAI_FUNC void luaX_next (LexState *ls);
 LUAI_FUNC int luaX_lookahead (LexState *ls);
 [[noreturn]] LUAI_FUNC void luaX_syntaxerror (LexState *ls, const char *s);

--- a/src/llex.h
+++ b/src/llex.h
@@ -70,9 +70,10 @@ enum RESERVED {
   TK_CCAT,              /* concatenation               */
 };
 
+#define LAST_RESERVED TK_WHILE
 
 /* number of reserved words */
-#define NUM_RESERVED	(cast_int(TK_WHILE-FIRST_RESERVED + 1))
+#define NUM_RESERVED	(cast_int(LAST_RESERVED-FIRST_RESERVED + 1))
 
 
 typedef union {
@@ -82,10 +83,18 @@ typedef union {
 } SemInfo;  /* semantics information */
 
 
-typedef struct Token {
+struct Token {
   int token;
   SemInfo seminfo;
-} Token;
+
+  [[nodiscard]] bool IsReserved() const noexcept {
+    return token >= FIRST_RESERVED && token <= LAST_RESERVED;
+  }
+
+  [[nodiscard]] bool IsReservedNonValue() const noexcept {
+	return IsReserved() && token != TK_TRUE && token != TK_FALSE;
+  }
+};
 
 
 /*
@@ -150,3 +159,4 @@ LUAI_FUNC int luaX_lookahead (LexState *ls);
 [[noreturn]] LUAI_FUNC void luaX_syntaxerror (LexState *ls, const char *s);
 LUAI_FUNC const char *luaX_token2str (LexState *ls, int token);
 LUAI_FUNC const char *luaX_token2str_noq (LexState *ls, int token);
+LUAI_FUNC const char *luaX_reserved2str (LexState *ls, int token);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -341,7 +341,9 @@ static void check_match (LexState *ls, int what, int who, int where) {
 
 static TString *str_checkname (LexState *ls) {
   TString *ts;
-  check(ls, TK_NAME);
+  if (ls->t.token != TK_NAME && !ls->t.IsReservedNonValue()) {
+    error_expected(ls, TK_NAME);
+  }
   ts = ls->t.seminfo.ts;
   luaX_next(ls);
   return ts;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2557,6 +2557,12 @@ static void statement (LexState *ls) {
     case TK_PCASE: {
       throwerr(ls, "inappropriate 'case' statement.", "outside of 'switch' block.");
     }
+#ifndef PLUTO_COMPATIBLE_DEFAULT
+    case TK_DEFAULT:
+#endif
+    case TK_PDEFAULT: {
+      throwerr(ls, "inappropriate 'default' statement.", "outside of 'switch' block.");
+    }
 #ifndef PLUTO_COMPATIBLE_SWITCH
     case TK_SWITCH:
 #endif

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1126,7 +1126,7 @@ static void prenamedfield(LexState* ls, ConsControl* cc, const char* name) {
   FuncState* fs = ls->fs;
   int reg = ls->fs->freereg;
   expdesc tab, key, val;
-  codestring(&key, luaX_newstring(ls, name, strlen(name)));
+  codestring(&key, luaX_newstring(ls, name));
   cc->nh++;
   luaX_next(ls); /* skip name token */
   checknext(ls, '=');

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1172,7 +1172,7 @@ static void listfield (LexState *ls, ConsControl *cc) {
 }
 
 
-void body (LexState *ls, expdesc *e, int ismethod, int line);
+static void body (LexState *ls, expdesc *e, int ismethod, int line);
 static void funcfield (LexState *ls, struct ConsControl *cc) {
   /* funcfield -> function NAME funcargs */
   FuncState *fs = ls->fs;
@@ -1289,7 +1289,7 @@ static void parlist (LexState *ls) {
 }
 
 
-void body (LexState *ls, expdesc *e, int ismethod, int line) {
+static void body (LexState *ls, expdesc *e, int ismethod, int line) {
   /* body ->  '(' parlist ')' block END */
   FuncState new_fs;
   BlockCnt bl;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1419,28 +1419,24 @@ static void primaryexp (LexState *ls, expdesc *v) {
       singlevar(ls, v);
       return;
     }
+    case '}':
+    case '{': { // Unfinished table constructors.
+       if (ls->t.token == '{') {
+         throwerr(ls, "unfinished table constructor", "did you mean to close with '}'?");
+       }
+       else {
+         throwerr(ls, "unfinished table constructor", "did you mean to enter with '{'?");
+       }
+       return;
+    }
+    case '|': { // Potentially mistyped lambda expression. People may confuse '->' with '=>'.
+      while (testnext(ls, '|') || testnext(ls, TK_NAME) || testnext(ls, ','));
+      throwerr(ls, "unexpected symbol", "impromper or stranded lambda expression.");
+      return;
+    }
     default: {
-      switch (ls->t.token) {
-        case '}':
-        case '{': { // Unfinished table constructors.
-          if (ls->t.token == '{') {
-            throwerr(ls, "unfinished table constructor", "did you mean to close with '}'?");
-          }
-          else {
-            throwerr(ls, "unfinished table constructor", "did you mean to enter with '{'?");
-          }
-          return;
-        }
-        case '|': { // Potentially mistyped lambda expression. People may confuse '->' with '=>'.
-          while (testnext(ls, '|') || testnext(ls, TK_NAME) || testnext(ls, ','));
-          throwerr(ls, "unexpected symbol", "impromper or stranded lambda expression.");
-          return;
-        }
-        default: {
-          const char *token = luaX_token2str(ls, ls->t.token);
-          throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
-        }
-      }
+      const char *token = luaX_token2str(ls, ls->t.token);
+      throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
     }
   }
 }

--- a/src/lua.h
+++ b/src/lua.h
@@ -13,7 +13,7 @@
 #include "luaconf.h"
 
 
-#define PLUTO_VERSION "Pluto 0.2.2"
+#define PLUTO_VERSION "Pluto 0.3.0"
 
 #define LUA_VERSION_MAJOR	"5"
 #define LUA_VERSION_MINOR	"4"

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -1987,6 +1987,10 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       vmcase(OP_TFORPREP) {
         const Instruction* callpc = pc + GETARG_Bx(i);
         i = *callpc;
+        if ((!ttisfunction(s2v(ra)))) {
+          setobjs2s(L, ra + 1, ra);
+          setfvalue(s2v(ra), luaB_next);
+        }
         if (ttypetag(s2v(ra)) == LUA_VLCF
               && ttistable(s2v(ra+1))
               && ttisnil(s2v(ra+3))


### PR DESCRIPTION
Opening to examine any merge conflicts.

- Resolves #64 
- Resolves #48 

New features:
- Inlined method creation.
- STR in STR expressions.
- KEY in INDEXABLE expressions.
- Generalized iteration, no need for `pairs`.
- `io.listdir`
- Reserved keywords as valid fields.
- Null-coalescing operator (w/ compound operator).
- `continue N` for manipulating outer loops.
- Improved `table.contains`, to return an index if applicable.
- Optional type-hinting, discarded by compiler.
- Safe accessor navigation, to avoid "attempt to index nil" errors for deeply nested fields.
- Some improvements and bugfixes :-).