### PR TITLE
Merge Pluto & Lua warning systems

### DIFF
--- a/src/lauxlib.cpp
+++ b/src/lauxlib.cpp
@@ -1085,7 +1085,7 @@ LUALIB_API lua_State *luaL_newstate (void) {
   lua_State *L = lua_newstate(l_alloc, NULL);
   if (l_likely(L)) {
     lua_atpanic(L, &panic);
-    lua_setwarnf(L, warnfoff, L);  /* default is warnings off */
+    lua_setwarnf(L, warnfon, L);  /* unlike lua, warnings are enabled by default in pluto */
   }
   return L;
 }

--- a/src/lauxlib.cpp
+++ b/src/lauxlib.cpp
@@ -1076,7 +1076,6 @@ static void warnfcont (void *ud, const char *message, int tocont) {
 static void warnfon (void *ud, const char *message, int tocont) {
   if (checkcontrol((lua_State *)ud, message, tocont))  /* control message? */
     return;  /* nothing else to be done */
-  lua_writestringerror("%s", "Lua warning: ");  /* start a new warning */
   warnfcont(ud, message, tocont);  /* finish processing */
 }
 

--- a/src/ljumptabgcc.h
+++ b/src/ljumptabgcc.h
@@ -16,7 +16,7 @@
 #define vmbreak		vmfetch(); vmdispatch(GET_OPCODE(i));
 
 
-static const void *const disptab[NUM_OPCODES] = {
+static const void *const disptab[NUM_OPCODES + 1] = {
 
 #if 0
 ** you can update the following list with this command:
@@ -109,5 +109,5 @@ static const void *const disptab[NUM_OPCODES] = {
 &&L_OP_VARARGPREP,
 &&L_OP_EXTRAARG,
 &&L_OP_IN,
-
+&&L_NUM_OPCODES,
 };

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -42,6 +42,12 @@
 #define hasmultret(k)		((k) == VCALL || (k) == VVARARG)
 
 
+/*
+** Invokes the lua_writestring macro with a std::string.
+*/
+#define write_std_string(std_string) lua_writestring(std_string.data(), std_string.size())
+
+
 /* because all strings are unified by the scanner, the parser
    can use pointer equality for string equality */
 #define eqstr(a,b)	((a) == (b))
@@ -154,15 +160,6 @@ static std::string make_warn(const char *s) {
   std::string rhere = make_here(ls, here);
   format_line_error(ls, error.c_str(), ls->GetLatestLine(), rhere.c_str());
   luaD_throw(ls->L, LUA_ERRSYNTAX);
-}
-
-
-/*
-** Invokes the lua_writestring macro with a std::string.
-*/
-static void write_std_string(const std::string& msg)
-{
-  lua_writestring(msg.data(), msg.size());
 }
 
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -139,7 +139,6 @@ static std::string make_warn(const char *s) {
   error.insert(0, std::string(RED));
   error.insert(error.find("warning:") + 8, std::string(BWHT));
   error.append(RESET);
-  error.append(" [-D]");
 #endif
   return error;
 }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -173,8 +173,7 @@ static void write_std_string(const std::string& msg)
 static void throw_warn (LexState *ls, const char *err, const char *here) {
   std::string error = make_warn(err);
   std::string rhere = make_here(ls, here);
-  write_std_string(format_line_error(ls, error.c_str(), ls->linebuff.c_str(), rhere.c_str()));
-  lua_writeline();
+  lua_warning(ls->L, format_line_error(ls, error.c_str(), ls->linebuff.c_str(), rhere.c_str()), 0);
 }
 
 

--- a/src/lstate.cpp
+++ b/src/lstate.cpp
@@ -430,8 +430,8 @@ void luaE_warnerror (lua_State *L, const char *where) {
   const char *msg = (ttisstring(errobj))
                   ? svalue(errobj)
                   : "error object is not a string";
-  /* produce warning "error in %s (%s)" (where, msg) */
-  luaE_warning(L, "error in ", 1);
+  /* produce "warning: error in %s (%s)" (where, msg) */
+  luaE_warning(L, "warning: error in ", 1);
   luaE_warning(L, where, 1);
   luaE_warning(L, " (", 1);
   luaE_warning(L, msg, 1);

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -95,7 +95,7 @@ static void print_usage (const char *badoption) {
   "  -l g=mod  require library 'mod' into global 'g'\n"
   "  -v        show version information\n"
   "  -E        ignore environment variables\n"
-  "  -W        turn run-time warnings on\n"
+  "  -W        turn warnings off\n"
   "  --        stop handling options\n"
   "  -         stop handling options and execute stdin\n"
   ,
@@ -344,7 +344,7 @@ static int runargs (lua_State *L, char **argv, int n) {
         break;
       }
       case 'W':
-        lua_warning(L, "@on", 0);  /* warnings on */
+        lua_warning(L, "@off", 0);  /* warnings off */
         break;
     }
   }


### PR DESCRIPTION
- Lua warnings are now enabled by default
    - `-W` now disables warnings instead of enabling them
- Pluto's parser warnings are now raised via global_State::warnf

---

Somewhat related, a script to see both types of warnings:
```LUA
local t = {}
local t = {}
setmetatable(t, {
	function __gc()
		error("epic")
	end
})
```