### PR TITLE
0.3.0 <- Add typehint warnings

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2543,7 +2543,6 @@ static void localstat (LexState *ls) {
     e.k = VVOID;
     nexps = 0;
   }
-  var = getlocalvardesc(fs, vidx);  /* get last variable */
   if (nvars == nexps &&  /* no adjustments? */
       var->vd.kind == RDKCONST &&  /* last variable is const? */
       luaK_exp2const(fs, &e, &var->k)) {  /* compile-time constant? */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2552,7 +2552,7 @@ static void localstat (LexState *ls) {
   }
   else {
     if (nexps == 1 &&
-        attr.typehint != -1 && /* has type hint? */
+        attr.typehint != 0xFF && /* has type hint? */
         vk_is_const(e.k) && /* assigning constant value? */
         !vk_typehint_equals(e.k, attr.typehint)) { /* type mismatch? */
       throw_warn(ls, "assigned value does not match hinted type", "type mismatch");

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1774,6 +1774,26 @@ struct LHS_assign {
 };
 
 
+[[nodiscard]] static bool vk_is_const(lu_byte kind) noexcept
+{
+  return kind >= VNIL && kind <= VKSTR;
+}
+
+
+[[nodiscard]] static bool vk_typehint_normalise(lu_byte kind) noexcept
+{
+  if (kind == VKFLT) return VKINT; /* normalise 'number' */
+  if (kind == VFALSE) return VTRUE; /* normalise 'boolean' */
+  return kind;
+}
+
+
+[[nodiscard]] static bool vk_typehint_equals(lu_byte a, lu_byte b) noexcept
+{
+  return vk_typehint_normalise(a) == vk_typehint_normalise(b);
+}
+
+
 /*
 ** check whether, in an assignment to an upvalue/local variable, the
 ** upvalue/local variable is begin used in a previous assignment to a
@@ -2065,12 +2085,6 @@ static const char* expandexpr (LexState *ls) {
       return getstr(ls->t.seminfo.ts);
     }
   }
-}
-
-
-[[nodiscard]] static bool vk_is_const(lu_byte kind) noexcept
-{
-  return kind >= VNIL && kind <= VKSTR;
 }
 
 
@@ -2450,20 +2464,6 @@ struct LocalAttribute
     lu_byte kind;
     lu_byte typehint = 0xFF;
 };
-
-
-[[nodiscard]] static bool vk_typehint_normalise(lu_byte kind) noexcept
-{
-  if (kind == VKFLT) return VKINT; /* normalise 'number' */
-  if (kind == VFALSE) return VTRUE; /* normalise 'boolean' */
-  return kind;
-}
-
-
-[[nodiscard]] static bool vk_typehint_equals(lu_byte a, lu_byte b) noexcept
-{
-  return vk_typehint_normalise(a) == vk_typehint_normalise(b);
-}
 
 
 [[nodiscard]] static LocalAttribute getlocalattribute (LexState *ls) {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2520,7 +2520,7 @@ static void localstat (LexState *ls) {
   int toclose = -1;  /* index of to-be-closed variable (if any) */
   Vardesc *var;  /* last variable */
   int vidx;  /* index of last variable */
-  LocalAttribute attr{};
+  LocalAttribute attr;
   int nvars = 0;
   int nexps;
   expdesc e;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -170,6 +170,7 @@ static void throw_warn (LexState *ls, const char *err, const char *here) {
   std::string error = make_warn(err);
   std::string rhere = make_here(ls, here);
   lua_warning(ls->L, format_line_error(ls, error.c_str(), ls->linebuff.c_str(), rhere.c_str()), 0);
+  ls->L->top -= 2; /* remove warning from stack */
 }
 
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2067,6 +2067,13 @@ static const char* expandexpr (LexState *ls) {
   }
 }
 
+
+[[nodiscard]] static bool vk_is_const(lu_byte kind) noexcept
+{
+  return kind >= VNIL && kind <= VKSTR;
+}
+
+
 static void switchstat (LexState *ls, int line) {
   FuncState *fs = ls->fs;
   BlockCnt sbl, cbl; // Switch & case blocks.
@@ -2114,7 +2121,7 @@ static void switchstat (LexState *ls, int line) {
     else {
       const auto expr = expandexpr(ls); // Raw text of the expression before the lexer skips tokens.
       simpleexp(ls, &lcase, true);
-      if (lcase.k < VNIL || lcase.k > VKSTR) { // Expression exceeds constant range.
+      if (!vk_is_const(lcase.k)) {
         ls->linebuff.clear();
         ls->linebuff += "case ";
         ls->linebuff += expr;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -427,7 +427,7 @@ int luaY_nvarstack (FuncState *fs) {
 ** Get the debug-information entry for current variable 'vidx'.
 */
 static LocVar *localdebuginfo (FuncState *fs, int vidx) {
-  Vardesc *vd = getlocalvardesc(fs,  vidx);
+  Vardesc *vd = getlocalvardesc(fs, vidx);
   if (vd->vd.kind == RDKCTC)
     return NULL;  /* no debug info. for constants */
   else {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2483,7 +2483,7 @@ struct LocalAttribute
       return { VDKREG, VKSTR };
     else if (strcmp(attr, "userdata") == 0)
       return { VDKREG };
-    else if (strcmp(attr, "boolean") == 0)
+    else if (strcmp(attr, "boolean") == 0 || strcmp(attr, "bool") == 0)
       return { VDKREG, VTRUE };
     else if (strcmp(attr, "nil") == 0)
       return { VDKREG, VNIL };

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1780,7 +1780,7 @@ struct LHS_assign {
 }
 
 
-[[nodiscard]] static bool vk_typehint_normalise(lu_byte kind) noexcept
+[[nodiscard]] static lu_byte vk_typehint_normalise(lu_byte kind) noexcept
 {
   if (kind == VKFLT) return VKINT; /* normalise 'number' */
   if (kind == VFALSE) return VTRUE; /* normalise 'boolean' */

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -102,6 +102,7 @@ typedef union Vardesc {
   struct {
     TValuefields;  /* constant value (if it is a compile-time constant) */
     lu_byte kind;
+    lu_byte typehint;
     lu_byte ridx;  /* register holding the variable */
     short pidx;  /* index of the variable in the Proto's 'locvars' array */
     TString *name;  /* variable name */


### PR DESCRIPTION
Adds parser warnings for cases like
```LUA
local a <string> = 69
```
and
```LUA
local a <string>
a = 69
```