### PR TITLE
Typehints Part III

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -106,6 +106,11 @@ struct Token {
 #endif
 
 struct LexState {
+  enum SourceInfoStrategy : lu_byte {
+    CURRENT = 0,
+    LAST,
+  };
+
   int current;  /* current character (charint) */
   int linenumber;  /* input line counter */
   int lastline;  /* line of last token 'consumed' */
@@ -142,6 +147,14 @@ struct LexState {
       }
     }
     return linenumber;
+  }
+
+  [[nodiscard]] const std::string& GetLineBuff(SourceInfoStrategy strat) const noexcept {
+    return strat == current ? linebuff : lastlinebuff;
+  }
+
+  [[nodiscard]] int GetLineNumber(SourceInfoStrategy strat) const noexcept {
+    return strat == CURRENT ? linenumber : lastline;
   }
 };
 

--- a/src/lobject.h
+++ b/src/lobject.h
@@ -6,6 +6,7 @@
 */
 
 #include <stdarg.h>
+#include <string>
 
 
 #include "llimits.h"
@@ -367,7 +368,7 @@ typedef struct GCObject {
 /*
 ** Header for a string value.
 */
-typedef struct TString {
+struct TString {
   CommonHeader;
   lu_byte extra;  /* reserved words for short strings; "has hash" for longs */
   lu_byte shrlen;  /* length for short strings */
@@ -377,7 +378,19 @@ typedef struct TString {
     struct TString *hnext;  /* linked list for hash table */
   } u;
   char contents[1];
-} TString;
+
+  [[nodiscard]] bool isShort() const noexcept {
+    return tt == LUA_VSHRSTR;
+  }
+
+  [[nodiscard]] size_t size() const noexcept {
+    return isShort() ? shrlen : u.lnglen;
+  }
+
+  [[nodiscard]] std::string toCpp() const {
+    return std::string(contents, size());
+  }
+};
 
 
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -477,6 +477,7 @@ static int new_localvar (LexState *ls, TString *name) {
                   dyd->actvar.size, Vardesc, USHRT_MAX, "local variables");
   var = &dyd->actvar.arr[dyd->actvar.n++];
   var->vd.kind = VDKREG;  /* default */
+  var->vd.typehint = 0xFF;
   var->vd.name = name;
   var->vd.linenumber = ls->linenumber;
   return dyd->actvar.n - 1 - fs->firstlocal;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -173,6 +173,12 @@ static void throw_warn (LexState *ls, const char *err, const char *here) {
   ls->L->top -= 2; /* remove warning from stack */
 }
 
+static void throw_warn(LexState* ls, const char* err) {
+  auto msg = luaG_addinfo(ls->L, err, ls->source, ls->linenumber);
+  lua_warning(ls->L, msg, 0);
+  ls->L->top -= 1; /* remove warning from stack */
+}
+
 
 /*
 ** This function will throw an exception and terminate the program.

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -452,7 +452,7 @@ static int new_localvar (LexState *ls, TString *name) {
   for (int i = fs->firstlocal; i < locals; i++) {
     Vardesc *desc = getlocalvardesc(fs,  i);
     LocVar *local = localdebuginfo(fs, i);
-    std::string n = std::string(getstr(name));
+    std::string n = name->toCpp();
     if ((n != "(for state)" && n != "(switch)") && (local && local->varname == name)) { // Got a match.
       L->SaveStackSize();
       throw_warn(ls,

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -460,11 +460,10 @@ static int new_localvar (LexState *ls, TString *name) {
     LocVar *local = localdebuginfo(fs, i);
     std::string n = name->toCpp();
     if ((n != "(for state)" && n != "(switch)") && (local && local->varname == name)) { // Got a match.
-      L->SaveStackSize();
       throw_warn(ls,
         "duplicate local declaration",
           luaO_fmt(L, "this shadows the value of the initial declaration on line %d.", desc->vd.linenumber));
-      L->RestoreStack();
+      L->top--; /* pop result of luaO_fmt */
     }
   }
 #endif

--- a/src/lstate.h
+++ b/src/lstate.h
@@ -341,25 +341,11 @@ struct lua_State {
   int oldpc;  /* last pc traced */
   int basehookcount;
   int hookcount;
-  int lastStackSize;  /* last saved stack size, for restoration */
   volatile l_signalT hookmask;
 
   // Lua registry abstration.
   [[nodiscard]] inline Registry GetReg() {
       return this;
-  }
-
-  // Save the size of the stack at this time.
-  inline void SaveStackSize() {
-    lastStackSize = lua_gettop(this);
-  }
-
-  // Reset the size of the stack to the last save.
-  inline void RestoreStack() {
-    if (lastStackSize >= 0) {
-      lua_settop(this, lastStackSize);
-      lastStackSize = -1;  // Avoid double-restoration on a potentially unknown value.
-    }
   }
 };
 


### PR DESCRIPTION
Parser warnings are greatly improved, and assignments of type-hinted locals to other type-hinted locals are now also checked.