### PR TITLE
Type propagation

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1573,7 +1573,7 @@ static void suffixedexp (LexState *ls, expdesc *v, lu_byte *prop = nullptr) {
         break;
       }
       case '(': case TK_STRING: case '{': {  /* funcargs */
-        if (v->k == VLOCAL)
+        if (prop != nullptr && v->k == VLOCAL)
           *prop = getlocalvardesc(ls->fs, v->u.var.vidx)->vd.typeprop;
         luaK_exp2nextreg(fs, v);
         funcargs(ls, v, line);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -409,13 +409,6 @@ static Vardesc *getlocalvardesc (FuncState *fs, int vidx) {
 }
 
 
-[[nodiscard]] static lu_byte vk_normalise(lu_byte kind) noexcept {
-    if (kind == VKFLT) return VKINT; /* normalise 'number' */
-    if (kind == VFALSE) return VTRUE; /* normalise 'boolean' */
-    return kind;
-}
-
-
 [[nodiscard]] static const char* vk_toTypeString(lu_byte kind) noexcept {
   switch (kind)
   {

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -65,6 +65,9 @@ typedef enum {
   VVARARG  /* vararg expression; info = instruction pc */
 } expkind;
 
+[[nodiscard]] constexpr bool vkisconst(lu_byte k) noexcept {
+  return k >= VNIL && k <= VKSTR;
+}
 
 #define vkisvar(k)	(VLOCAL <= (k) && (k) <= VINDEXSTR)
 #define vkisindexed(k)	(VINDEXED <= (k) && (k) <= VINDEXSTR)
@@ -103,6 +106,7 @@ typedef union Vardesc {
     TValuefields;  /* constant value (if it is a compile-time constant) */
     lu_byte kind;
     lu_byte typehint;
+    lu_byte typeprop; /* type propagation */
     lu_byte ridx;  /* register holding the variable */
     short pidx;  /* index of the variable in the Proto's 'locvars' array */
     TString *name;  /* variable name */


### PR DESCRIPTION
Now checks for type mismatch in the following cases:
- Assignment to type-hinted local from non-type-hinted local
- Assignment to type-hinted local from local function