### PR TITLE
Type hints for function return type

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1372,8 +1372,8 @@ static void body (LexState *ls, expdesc *e, int ismethod, int line, lu_byte *pro
   lu_byte rethint = gettypehint(ls);
   lu_byte p = 0xFF;
   statlist(ls, &p);
-  if (p != 0xFF && /* return type is known? */
-      rethint != 0xFF) { /* has type hint for return type? */
+  if (rethint != 0xFF && /* has type hint for return type? */
+      p != 0xFF) { /* return type is known? */
     std::string err = "function was hinted to return ";
     err.append(vk_toTypeString(rethint));
     err.append(" but actually returns ");

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -409,6 +409,32 @@ static Vardesc *getlocalvardesc (FuncState *fs, int vidx) {
 }
 
 
+[[nodiscard]] static lu_byte gettypehint(LexState *ls) noexcept {
+  /* TYPEHINT -> [':' Typename] */
+  if (testnext(ls, ':')) {
+    const char* tname = getstr(str_checkname(ls));
+    if (strcmp(tname, "number") == 0)
+      return VKINT ;
+    else if (strcmp(tname, "table") == 0)
+      return VNONRELOC;
+    else if (strcmp(tname, "string") == 0)
+      return VKSTR;
+    else if (strcmp(tname, "userdata") == 0)
+      return 0xFF;
+    else if (strcmp(tname, "boolean") == 0 || strcmp(tname, "bool") == 0)
+      return VTRUE;
+    else if (strcmp(tname, "nil") == 0)
+      return VNIL;
+    else if (strcmp(tname, "function") == 0)
+      return 0xFF;
+    else
+      luaK_semerror(ls,
+        luaO_pushfstring(ls->L, "unknown type hint '%s'", tname));
+  }
+  return 0xFF;
+}
+
+
 [[nodiscard]] static const char* vk_toTypeString(lu_byte kind) noexcept {
   switch (kind)
   {
@@ -2494,32 +2520,6 @@ static void localfunc (LexState *ls) {
   body(ls, &b, 0, ls->linenumber, &getlocalvardesc(fs, fvar)->vd.typeprop);  /* function created in next register */
   /* debug information will only see the variable after this point! */
   localdebuginfo(fs, fvar)->startpc = fs->pc;
-}
-
-
-[[nodiscard]] static lu_byte gettypehint(LexState *ls) noexcept {
-  /* TYPEHINT -> [':' Typename] */
-  if (testnext(ls, ':')) {
-    const char* tname = getstr(str_checkname(ls));
-    if (strcmp(tname, "number") == 0)
-      return VKINT ;
-    else if (strcmp(tname, "table") == 0)
-      return VNONRELOC;
-    else if (strcmp(tname, "string") == 0)
-      return VKSTR;
-    else if (strcmp(tname, "userdata") == 0)
-      return 0xFF;
-    else if (strcmp(tname, "boolean") == 0 || strcmp(tname, "bool") == 0)
-      return VTRUE;
-    else if (strcmp(tname, "nil") == 0)
-      return VNIL;
-    else if (strcmp(tname, "function") == 0)
-      return 0xFF;
-    else
-      luaK_semerror(ls,
-        luaO_pushfstring(ls->L, "unknown type hint '%s'", tname));
-  }
-  return 0xFF;
 }
 
 


### PR DESCRIPTION
- Changes type hint syntax from `<string>` to `: string`
- Allows type hints after parlist
- Shows warning if return type differs from hinted return type