### PR TITLE
0.3.0: Implement `break N` syntax support.

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -61,6 +61,7 @@
 */
 typedef struct BlockCnt {
   struct BlockCnt *previous;  /* chain */
+  int breaklist;  /* list of jumps out of this loop */
   int scopeend;  /* delimits the end of this scope, for 'continue' to jump before. */
   int firstlabel;  /* index of first label in this block */
   int firstgoto;  /* index of first pending goto in this block */
@@ -921,6 +922,7 @@ static void movegotosout (FuncState *fs, BlockCnt *bl) {
 
 
 static void enterblock (FuncState *fs, BlockCnt *bl, lu_byte isloop) {
+  bl->breaklist = NO_JUMP;
   bl->isloop = isloop;
   bl->scopeend = NO_JUMP;
   bl->nactvar = fs->nactvar;
@@ -956,8 +958,6 @@ static void leaveblock (FuncState *fs) {
   LexState *ls = fs->ls;
   int hasclose = 0;
   int stklevel = reglevel(fs, bl->nactvar);  /* level outside the block */
-  if (bl->isloop)  /* fix pending breaks? */
-    hasclose = createlabel(ls, luaS_newliteral(ls->L, "break"), 0, 0);
   if (!hasclose && bl->previous && bl->upval)
     luaK_codeABC(fs, OP_CLOSE, stklevel, 0, 0);
   fs->bl = bl->previous;
@@ -971,6 +971,7 @@ static void leaveblock (FuncState *fs) {
     if (bl->firstgoto < ls->dyd->gt.n)  /* pending gotos in outer block? */
       undefgoto(ls, &ls->dyd->gt.arr[bl->firstgoto]);  /* error */
   }
+  luaK_patchtohere(fs, bl->breaklist);
 }
 
 
@@ -2092,12 +2093,42 @@ static void gotostat (LexState *ls) {
 
 
 /*
-** Break statement. Semantically equivalent to "goto break".
+** Break statement. Very similiar to `continue` usage, but it jumps slightly more forward.
+**
+** Implementation Detail:
+**   Unlike normal Lua, it has been reverted from a label implementation back into a patchlist implementation.
+**   This allows reusage of the existing "continue" implementation, which has been time-tested extensively by now.
 */
 static void breakstat (LexState *ls) {
-  int line = ls->linenumber;
-  luaX_next(ls);  /* skip break */
-  newgotoentry(ls, luaS_newliteral(ls->L, "break"), line, luaK_jump(ls->fs));
+  FuncState *fs = ls->fs;
+  BlockCnt *bl = fs->bl;
+  int upval = 0;
+  luaX_next(ls); /* skip TK_BREAK */
+  lua_Integer backwards = 1;
+  if (ls->t.token == TK_INT) {
+    backwards = ls->t.seminfo.i;
+    luaX_next(ls);
+  }
+  while (bl) {
+    if (!bl->isloop) { /* not a loop, continue search */
+      upval |= bl->upval; /* amend upvalues for closing. */
+      bl = bl->previous; /* jump back current blocks to find the loop */
+    }
+    else { /* found a loop */
+      if (--backwards == 0) { /* this is our loop */
+        break;
+      }
+      else { /* continue search */
+        upval |= bl->upval;
+        bl = bl->previous;
+      }
+    };
+  }
+  if (bl) {
+    if (upval) luaK_codeABC(fs, OP_CLOSE, bl->nactvar, 0, 0); /* close upvalues */
+    luaK_concat(fs, &bl->breaklist, luaK_jump(fs));
+  }
+  else error_expected(ls, TK_BREAK);
 }
 
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -958,6 +958,8 @@ static void leaveblock (FuncState *fs) {
   LexState *ls = fs->ls;
   int hasclose = 0;
   int stklevel = reglevel(fs, bl->nactvar);  /* level outside the block */
+  if (bl->isloop)  /* fix pending breaks? */
+    hasclose = createlabel(ls, luaS_newliteral(ls->L, "break"), 0, 0);
   if (!hasclose && bl->previous && bl->upval)
     luaK_codeABC(fs, OP_CLOSE, stklevel, 0, 0);
   fs->bl = bl->previous;
@@ -2096,7 +2098,7 @@ static void gotostat (LexState *ls) {
 ** Break statement. Very similiar to `continue` usage, but it jumps slightly more forward.
 **
 ** Implementation Detail:
-**   Unlike normal Lua, it has been reverted from a label implementation back into a patchlist implementation.
+**   Unlike normal Lua, it has been reverted from a label implementation back into a mix between a label & patchlist implementation.
 **   This allows reusage of the existing "continue" implementation, which has been time-tested extensively by now.
 */
 static void breakstat (LexState *ls) {

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -255,6 +255,14 @@ do
     assert(sum == 5)
 end
 
+do
+    while true do
+        if true then
+            break
+        end
+    end
+end
+
 print "Testing switch statement."
 do
     local value = 5

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -215,6 +215,46 @@ print "Testing new 'in' expressions."
 if ("hel" in "hello") != true then error() end
 if ("abc" in "hello") != false then error() end
 
+print "Testing break N syntax."
+do
+    local sum = 0
+    for i = 1, 10 do
+        for ii = 1, 10 do
+            sum = sum + ii + i
+            break 1
+        end
+        sum = sum + i
+    end
+    assert(sum == 120)
+end
+
+do
+    local sum = 0
+    for i = 1, 10 do
+        for ii = 1, 10 do
+            sum = sum + ii + i
+            break 2
+        end
+        sum = sum + i
+    end
+    assert(sum == 2)
+end
+
+do
+    local sum = 0
+    for i = 1, 10 do
+        for ii = 1, 10 do
+            sum = sum + ii + i
+            for iii = 1, 10 do
+                sum = sum + iii + ii + i
+                break 3
+            end
+        end
+        sum = sum + i
+    end
+    assert(sum == 5)
+end
+
 print "Testing switch statement."
 do
     local value = 5


### PR DESCRIPTION
Reverts `break` back into a patchlist, which allows the existing `continue` implementation to be implemented in place with some minor modifications. This way, we know there will be (at least) minimal bugs, since we've tested `continue N` extensively by now.