### PR TITLE
0.3.0 typehint depths

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -150,7 +150,7 @@ static const char *txtToken (LexState *ls, int token) {
 
 
 [[noreturn]] static void lexerror (LexState *ls, const char *msg, int token) {
-  msg = luaG_addinfo(ls->L, msg, ls->source, ls->linenumber);
+  msg = luaG_addinfo(ls->L, msg, ls->source, ls->getLineNumber());
   if (token)
     luaO_pushfstring(ls->L, "%s near %s", msg, txtToken(ls, token));
   luaD_throw(ls->L, LUA_ERRSYNTAX);
@@ -205,14 +205,12 @@ static void inclinenumber (LexState *ls) {
   next(ls);  /* skip '\n' or '\r' */
   if (currIsNewline(ls) && ls->current != old)
     next(ls);  /* skip '\n\r' or '\r\n' */
-  if (++ls->linenumber >= MAX_INT)
-    lexerror(ls, "chunk has too many lines", 0);
+  ls->lines.emplace_back(std::string{});
 }
 
 
 void luaX_setinput (lua_State *L, LexState *ls, ZIO *z, TString *source,
                     int firstchar) {
-  ls->linebuff = std::string();
   ls->t.token = 0;
   ls->lasttoken = 0;
   ls->L = L;
@@ -220,8 +218,6 @@ void luaX_setinput (lua_State *L, LexState *ls, ZIO *z, TString *source,
   ls->lookahead.token = TK_EOS;  /* no look-ahead token */
   ls->z = z;
   ls->fs = NULL;
-  ls->linenumber = 1;
-  ls->lastline = 1;
   ls->source = source;
   ls->envn = luaS_newliteral(L, LUA_ENV);  /* get env name */
   luaZ_resizebuffer(ls->L, ls->buff, LUA_MINBUFFER);  /* initialize buffer */
@@ -330,7 +326,7 @@ static size_t skip_sep (LexState *ls) {
 
 
 static void read_long_string (LexState *ls, SemInfo *seminfo, size_t sep) {
-  int line = ls->linenumber;  /* initial line (for error message) */
+  int line = ls->getLineNumber();  /* initial line (for error message) */
   save_and_next(ls);  /* skip 2nd '[' */
   if (currIsNewline(ls))  /* string starts with a newline? */
     inclinenumber(ls);  /* skip it */
@@ -534,31 +530,11 @@ static int llex (LexState *ls, SemInfo *seminfo) {
     switch (ls->current) {
       case '\n': case '\r': {  /* Line breaks. */
         inclinenumber(ls);
-        if (ls->linebuff.length() > 1) { /* Remember the last statement to avoid empty lines in any debug info. */
-          ls->lastlinebuffnum = ls->linenumber - 1;
-          ls->lastlinebuff = ls->linebuff;
-          ls->linebuff.clear();
-          /*
-          ** Remove leading spaces, due to indentation.
-          ** This messes with the "^^^" string that's generated for each syntax error.
-          */
-          size_t index = ls->lastlinebuff.find_first_not_of(" \t");
-          if (index != std::string::npos) {
-            ls->lastlinebuff = ls->lastlinebuff.substr(index);
-          }
-          /*
-          ** Finally, employ a hard-lock on the largest string length.
-          ** This avoids excessively long errors, since we buffer the entire line.
-          */
-          if (ls->lastlinebuff.length() > 50) {
-            ls->lastlinebuff = ls->lastlinebuff.substr(0, 50) + "...";
-          }
-        }
         break;
       }
       case ' ': case '\f': case '\t': case '\v': {  /* spaces */
-        if (ls->linebuff.find_first_not_of(ls->current) != std::string::npos) {
-          ls->linebuff += ls->current;
+        if (ls->getLineBuff().find_first_not_of(ls->current) != std::string::npos) {
+          ls->appendLineBuff(ls->current);
         }
         next(ls);
         break;
@@ -566,13 +542,13 @@ static int llex (LexState *ls, SemInfo *seminfo) {
       case '-': {  /* '-' or '--' (comment) */
         next(ls);
         if (check_next1(ls, '=')) { /* compound op */
-          ls->linebuff += "-=";
+          ls->appendLineBuff("-=");
           ls->lasttoken = TK_CSUB;
           return '=';
         }
         else {
           if (ls->current != '-') {
-            ls->linebuff += '-';
+            ls->appendLineBuff('-');
             return '-';
           }
           /* else is a comment */
@@ -605,78 +581,78 @@ static int llex (LexState *ls, SemInfo *seminfo) {
       case '=': {
         next(ls);
         if (check_next1(ls, '=')) {
-          ls->linebuff += "==";
+          ls->appendLineBuff("==");
           return TK_EQ;  /* '==' */
         }
         else {
-          ls->linebuff += '=';
+          ls->appendLineBuff('=');
           return '=';
         }
       }
       case '<': {
         next(ls);
         if (check_next1(ls, '=')) {
-          ls->linebuff += "<=";
+          ls->appendLineBuff("<=");
           return TK_LE;  /* '<=' */
         }
         else if (check_next1(ls, '<')) {
           if (check_next1(ls, '=')) {  /* compound support */
-            ls->linebuff += "<<=";
+            ls->appendLineBuff("<<=");
             ls->lasttoken = TK_CSHL;  /* <<= */
             return '=';
           }
           else {
-            ls->linebuff += "<<";
+            ls->appendLineBuff("<<");
             return TK_SHL;  /* '<<' */
           }
         }
         else {
-          ls->linebuff += '<';
+          ls->appendLineBuff('<');
           return '<';
         }
       }
       case '>': {
         next(ls);
         if (check_next1(ls, '=')) {
-          ls->linebuff += ">=";
+          ls->appendLineBuff(">=");
           return TK_GE;  /* '>=' */
         }
         else if (check_next1(ls, '>')) {
           if (check_next1(ls, '=')) {  /* compound support */
-            ls->linebuff += ">>=";
+            ls->appendLineBuff(">>=");
             ls->lasttoken = TK_CSHR;  /* >>= */
             return '=';
           }
           else {
-            ls->linebuff += ">>";
+            ls->appendLineBuff(">>");
             return TK_SHR;  /* '>>' */
           }
         }
         else {
-          ls->linebuff += '>';
+          ls->appendLineBuff('>');
           return '>';
         }
       }
       case '/': {
         next(ls);
         if (check_next1(ls, '=')) {  /* compound support */
-          ls->linebuff += "/=";
+          ls->appendLineBuff("/=");
           ls->lasttoken = TK_CDIV;
           return '=';
         } else {
           if (check_next1(ls, '/')) {
             if (!check_next1(ls, '=')) {
-              ls->linebuff += "//";
+              ls->appendLineBuff("//");
               return TK_IDIV;  /* '//' */
             }
             else {  /* floor division compound support */
-              ls->linebuff += "//=";
+              ls->appendLineBuff("//=");
               ls->lasttoken = TK_CIDIV;
               return '=';
             }
           }
           else {
-            ls->linebuff += '/';
+            ls->appendLineBuff('/');
             return '/';
           }
         }
@@ -684,49 +660,49 @@ static int llex (LexState *ls, SemInfo *seminfo) {
       case ':': {
         next(ls);
         if (check_next1(ls, ':')) {
-          ls->linebuff += "::";
+          ls->appendLineBuff("::");
           return TK_DBCOLON;  /* '::' */
         }
         else {
-          ls->linebuff += ':';
+          ls->appendLineBuff(':');
           return ':';
         }
       }
       case '"': case '\'': {  /* short literal strings */
         read_string(ls, ls->current, seminfo);
-        ls->linebuff += "\"";
-        ls->linebuff += seminfo->ts->contents;
-        ls->linebuff += "\"";
+        ls->appendLineBuff("\"");
+        ls->appendLineBuff(seminfo->ts->contents);
+        ls->appendLineBuff("\"");
         return TK_STRING;
       }
       case '.': {  /* '.', '..', '...', or number */
         save_and_next(ls);
         if (check_next1(ls, '.')) {
           if (check_next1(ls, '.')) {
-            ls->linebuff += "...";
+            ls->appendLineBuff("...");
             return TK_DOTS;   /* '...' */
           }
           else {
             if (check_next1(ls, '=')) {
-              ls->linebuff += "..=";
+              ls->appendLineBuff("..=");
               ls->lasttoken = TK_CCAT;
               return '=';
             } else {
-              ls->linebuff += "..";
+              ls->appendLineBuff("..");
               return TK_CONCAT;   /* '..' */
             }
           }
         }
         else if (!lisdigit(ls->current)) {
-          ls->linebuff += '.';
+          ls->appendLineBuff('.');
           return '.';
         }
         else {
           int ret = read_numeral(ls, seminfo);
           if (ret == TK_INT)
-            ls->linebuff += std::to_string(seminfo->i);
+            ls->appendLineBuff(std::to_string(seminfo->i));
           else
-            ls->linebuff += std::to_string(seminfo->r);
+            ls->appendLineBuff(std::to_string(seminfo->r));
           return ret;
         }
       }
@@ -734,9 +710,9 @@ static int llex (LexState *ls, SemInfo *seminfo) {
       case '5': case '6': case '7': case '8': case '9': {
         int ret = read_numeral(ls, seminfo);
         if (ret == TK_INT)
-          ls->linebuff += std::to_string(seminfo->i);
+          ls->appendLineBuff(std::to_string(seminfo->i));
         else
-          ls->linebuff += std::to_string(seminfo->r);
+          ls->appendLineBuff(std::to_string(seminfo->r));
         return ret;
       }
       case '_': {  /* arbitrary underscores for more readable long numbers */
@@ -748,7 +724,7 @@ static int llex (LexState *ls, SemInfo *seminfo) {
           ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
                                   luaZ_bufflen(ls->buff));
           seminfo->ts = ts;
-          ls->linebuff += ts->contents;
+          ls->appendLineBuff(ts->contents);
           if (isreserved(ts))
             return ts->extra - 1 + FIRST_RESERVED;
           else {
@@ -759,12 +735,12 @@ static int llex (LexState *ls, SemInfo *seminfo) {
           if (lisdigit(ls->current)) {
             int ret = read_numeral(ls, seminfo);
             if (ret == TK_INT)
-              ls->linebuff += std::to_string(seminfo->i);
+              ls->appendLineBuff(std::to_string(seminfo->i));
             else
-              ls->linebuff += std::to_string(seminfo->r);
+              ls->appendLineBuff(std::to_string(seminfo->r));
             return ret;  /* arbitrary character detected in numeral */
           } else {
-            ls->linebuff += '_';
+            ls->appendLineBuff('_');
             return '_';  /* this is a normal underscore */
           }
         }
@@ -772,10 +748,10 @@ static int llex (LexState *ls, SemInfo *seminfo) {
       case '~': {
         next(ls);
         if (check_next1(ls, '=')) {
-          ls->linebuff += "~=";
+          ls->appendLineBuff("~=");
           return TK_NE;
         } else {
-          ls->linebuff += '~';
+          ls->appendLineBuff('~');
           return '~';
         }
       }
@@ -797,23 +773,23 @@ static int llex (LexState *ls, SemInfo *seminfo) {
       case '*': {  /* special case compound, need to support mul, exponent, and augmented mul */
         next(ls);
         if (check_next1(ls, '=')) {
-          ls->linebuff += "*=";
+          ls->appendLineBuff("*=");
           ls->lasttoken = TK_CMUL;
           return '=';  /* '*=' */
         }
         else if (check_next1(ls, '*')) { /*  got '**' */  
           if (check_next1(ls, '=')) {  /* compound support; **= */
-            ls->linebuff += "**=";
+            ls->appendLineBuff("**=");
             ls->lasttoken = TK_CPOW;
             return '=';
           }
           else {
-            ls->linebuff += "**";
+            ls->appendLineBuff("**");
             return TK_POW;  /* '**' */
           }
         }
         else {
-          ls->linebuff += '*';
+          ls->appendLineBuff('*');
           return '*';
         }
       }
@@ -827,12 +803,12 @@ static int llex (LexState *ls, SemInfo *seminfo) {
           if (llex_augmented(ls, c) != 1) {
             lexerror(ls, "unsupported augmented assignment", c);
           } else {
-            ls->linebuff += c;
-            ls->linebuff += '=';
+            ls->appendLineBuff(c);
+            ls->appendLineBuff('=');
             return '=';
           }
         } else {
-          ls->linebuff += c;
+          ls->appendLineBuff(c);
           return c;
         }
       }
@@ -849,7 +825,7 @@ static int llex (LexState *ls, SemInfo *seminfo) {
           ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
                                   luaZ_bufflen(ls->buff));
           seminfo->ts = ts;
-          ls->linebuff += ts->contents;
+          ls->appendLineBuff(ts->contents);
           if (isreserved(ts))  /* reserved word? */
             return ts->extra - 1 + FIRST_RESERVED;
           else {
@@ -859,7 +835,7 @@ static int llex (LexState *ls, SemInfo *seminfo) {
         else {  /* single-char tokens ('+', '*', '%', '{', '}', ...) */
           int c = ls->current;
           next(ls);
-          ls->linebuff += c;
+          ls->appendLineBuff(c);
           return c;
         }
       }
@@ -869,7 +845,7 @@ static int llex (LexState *ls, SemInfo *seminfo) {
 
 
 void luaX_next (LexState *ls) {
-  ls->lastline = ls->linenumber;
+  ls->lastline = ls->getLineNumber();
   if (ls->lookahead.token != TK_EOS) {  /* is there a look-ahead token? */
     ls->t = ls->lookahead;  /* use this one */
     ls->lookahead.token = TK_EOS;  /* and discharge it */

--- a/src/llex.h
+++ b/src/llex.h
@@ -150,7 +150,7 @@ struct LexState {
   }
 
   [[nodiscard]] const std::string& GetLineBuff(SourceInfoStrategy strat) const noexcept {
-    return strat == current ? linebuff : lastlinebuff;
+    return strat == CURRENT ? linebuff : lastlinebuff;
   }
 
   [[nodiscard]] int GetLineNumber(SourceInfoStrategy strat) const noexcept {

--- a/src/llex.h
+++ b/src/llex.h
@@ -5,8 +5,10 @@
 ** See Copyright Notice in lua.h
 */
 
-#include <string>
 #include <limits.h>
+
+#include <string>
+#include <vector>
 
 #include "lobject.h"
 #include "lzio.h"
@@ -106,13 +108,8 @@ struct Token {
 #endif
 
 struct LexState {
-  enum SourceInfoStrategy : lu_byte {
-    CURRENT = 0,
-    LAST,
-  };
-
   int current;  /* current character (charint) */
-  int linenumber;  /* input line counter */
+  std::vector<std::string> lines;
   int lastline;  /* line of last token 'consumed' */
   int lasttoken;  /* save the last compound binary operator, if exists */
   Token t;  /* current token */
@@ -121,40 +118,43 @@ struct LexState {
   struct lua_State *L;
   ZIO *z;  /* input stream */
   Mbuffer *buff;  /* buffer for tokens */
-  std::string linebuff; /* buffer for lines */
-  std::string lastlinebuff; /* buffer for the last line */
-  int lastlinebuffnum; /* last line number for lastlinebuff */
   Table *h;  /* to avoid collection/reuse strings */
   struct Dyndata *dyd;  /* dynamic structures used by the parser */
   TString *source;  /* current source name */
   TString *envn;  /* environment variable name */
 
-  // Return the last non-whitespace line.
-  const char *GetLatestLine() {
-    if (linebuff.find_first_not_of(" \t") == std::string::npos) {
-      if (lastlinebuff.find_first_not_of(" \t") != std::string::npos) {
-        return lastlinebuff.c_str();
-      }
-    }
-    return linebuff.c_str();
+  LexState()
+    : lines{ std::string{} }
+  {
   }
 
-  // Return the line number of the last latest line (see above).
-  int GetLastLineNumber() {
-    if (linebuff.find_first_not_of(" \t") == std::string::npos) {
-      if (lastlinebuff.find_first_not_of(" \t") != std::string::npos) {
-        return lastlinebuffnum;
-      }
-    }
-    return linenumber;
+  [[nodiscard]] int getLineNumber() const noexcept {
+    return (int)lines.size();
   }
 
-  [[nodiscard]] const std::string& GetLineBuff(SourceInfoStrategy strat) const noexcept {
-    return strat == CURRENT ? linebuff : lastlinebuff;
+  [[nodiscard]] int getLineNumberOfLastNonEmptyLine() const noexcept {
+     for (int line = getLineNumber(); line != 0; --line) {
+       if (!getLineString(line).empty()) {
+         return line;
+       }
+     }
+     return getLineNumber();
   }
 
-  [[nodiscard]] int GetLineNumber(SourceInfoStrategy strat) const noexcept {
-    return strat == CURRENT ? linenumber : lastline;
+  [[nodiscard]] const std::string& getLineString(int line) const {
+     return lines.at(line - 1);
+  }
+
+  [[nodiscard]] std::string& getLineBuff() {
+    return lines.back();
+  }
+
+  void appendLineBuff(const std::string& str) {
+    getLineBuff().append(str);
+  }
+
+  void appendLineBuff(char c) {
+    getLineBuff().push_back(c);
   }
 };
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1776,6 +1776,7 @@ static void simpleexp (LexState *ls, expdesc *v, bool caseexpr, TypeDesc *prop =
       break;
     }
     case '{': {  /* constructor */
+      if (prop) *prop = VT_TABLE;
       constructor(ls, v);
       return;
     }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1679,6 +1679,8 @@ static void simpleexp (LexState *ls, expdesc *v, bool caseexpr, TypeDesc *prop =
     case TK_FUNCTION: {
       luaX_next(ls);
       body(ls, v, 0, ls->linenumber, prop);
+      if (prop != nullptr)
+        prop->setFunction(prop->getType());
       return;
     }
     case '|': {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1356,7 +1356,8 @@ static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *pr
   TypeDesc p = HT_MIXED;
   statlist(ls, &p);
   if (rethint.getType() != HT_MIXED && /* has type hint for return type? */
-      p.getType() != HT_MIXED) { /* return type is known? */
+      p.getType() != HT_MIXED && /* return type is known? */
+      !rethint.isCompatibleWith(p)) { /* incompatible? */
     std::string err = "function was hinted to return ";
     err.append(rethint.toString());
     err.append(" but actually returns ");

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1459,13 +1459,18 @@ static void lambdabody (LexState *ls, expdesc *e, int line) {
 }
 
 
+static void expr_propagate(LexState *ls, expdesc* v, TypeDesc& td) {
+  expr(ls, v, &td);
+  exp_propagate(ls, *v, td);
+}
+
 static int explist (LexState *ls, expdesc *v, std::vector<TypeDesc>& prop) {
   /* explist -> expr { ',' expr } */
   int n = 1;  /* at least one expression */
-  expr(ls, v, &prop.emplace_back(VT_DUNNO));
+  expr_propagate(ls, v, prop.emplace_back(VT_DUNNO));
   while (testnext(ls, ',')) {
     luaK_exp2nextreg(ls->fs, v);
-    expr(ls, v, &prop.emplace_back(VT_DUNNO));
+    expr_propagate(ls, v, prop.emplace_back(VT_DUNNO));
     n++;
   }
   return n;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -441,6 +441,18 @@ static void exp_propagate(LexState* ls, const expdesc& e, TypeDesc& t) noexcept 
   if (e.k == VLOCAL) {
     t = getlocalvardesc(ls->fs, e.u.var.vidx)->vd.prop;
   }
+  else if (e.k == VCONST) {
+    TValue* val = &ls->dyd->actvar.arr[e.u.info].k;
+    switch (ttype(val))
+    {
+    case LUA_TNIL: t = VT_NIL; break;
+    case LUA_TBOOLEAN: t = VT_BOOL; break;
+    case LUA_TNUMBER: t = VT_NUMBER; break;
+    case LUA_TSTRING: t = VT_STR; break;
+    case LUA_TTABLE: t = VT_TABLE; break;
+    case LUA_TFUNCTION: t = VT_FUNC; break;
+    }
+  }
 }
 
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -423,8 +423,6 @@ static Vardesc *getlocalvardesc (FuncState *fs, int vidx) {
       return 0xFF;
     else if (strcmp(tname, "boolean") == 0 || strcmp(tname, "bool") == 0)
       return VTRUE;
-    else if (strcmp(tname, "nil") == 0)
-      return VNIL;
     else if (strcmp(tname, "function") == 0)
       return 0xFF;
     else
@@ -442,7 +440,6 @@ static Vardesc *getlocalvardesc (FuncState *fs, int vidx) {
   case VNONRELOC: return "table";
   case VKSTR: return "string";
   case VTRUE: case VFALSE: return "boolean";
-  case VNIL: return "nil";
   }
   return "ERROR";
 }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2750,8 +2750,10 @@ static void retstat (LexState *ls, TypeDesc *prop) {
   expdesc e;
   int nret;  /* number of values being returned */
   int first = luaY_nvarstack(fs);  /* first slot to be returned */
-  if (block_follow(ls, 1) || ls->t.token == ';')
+  if (block_follow(ls, 1) || ls->t.token == ';') {
     nret = 0;  /* return no values */
+    if (prop) *prop = VT_NIL;
+  }
   else {
     nret = explist(ls, &e, prop);  /* optional return values */
     if (hasmultret(e.k)) {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1531,7 +1531,7 @@ static void funcargs (LexState *ls, expdesc *f, int line, TypeDesc *funcdesc = n
         err.append(param.vd.hint.toString());
         err.append(" but provided with ");
         err.append(arg.toString());
-        throw_warn(ls, err.c_str(), "argument type mismatch");
+        throw_warn(ls, err.c_str(), "argument type mismatch", line);
       }
     }
   }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1079,6 +1079,9 @@ static void propagate_return_type(LexState* ls, TypeDesc* prop, TypeDesc ret) {
       ret.setNullable();
       *prop = ret;
     }
+    else if (ret.getType() == VT_NIL) {
+      prop->setNullable();
+    }
     else if (!prop->isCompatibleWith(ret)) {
       *prop = VT_MIXED; /* set return type to mixed */
       prop = nullptr; /* and don't update it again */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2139,6 +2139,7 @@ static void restassign (LexState *ls, struct LHS_assign *lh, int nvars) {
       else {
         luaK_setoneret(ls->fs, &e);  /* close last expression */
         if (lh->v.k == VLOCAL) { /* assigning to a local variable? */
+          exp_propagate(ls, e, prop);
           process_assign(ls, getlocalvardesc(ls->fs, lh->v.u.var.vidx), prop);
         }
         luaK_storevar(ls->fs, &lh->v, &e);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -500,7 +500,7 @@ static LocVar *localdebuginfo (FuncState *fs, int vidx) {
 ** Create a new local variable with the given 'name'. Return its index
 ** in the function.
 */
-static int new_localvar (LexState *ls, TString *name) {
+static int new_localvar (LexState *ls, TString *name, TypeDesc hint = VT_DUNNO) {
   lua_State *L = ls->L;
   FuncState *fs = ls->fs;
   Dyndata *dyd = ls->dyd;
@@ -525,7 +525,7 @@ static int new_localvar (LexState *ls, TString *name) {
                   dyd->actvar.size, Vardesc, USHRT_MAX, "local variables");
   var = &dyd->actvar.arr[dyd->actvar.n++];
   var->vd.kind = VDKREG;  /* default */
-  var->vd.hint = VT_DUNNO;
+  var->vd.hint = hint;
   var->vd.prop = VT_DUNNO;
   var->vd.name = name;
   var->vd.linenumber = ls->linenumber;
@@ -1343,7 +1343,9 @@ static void parlist (LexState *ls) {
     do {
       switch (ls->t.token) {
         case TK_NAME: {
-          new_localvar(ls, str_checkname(ls, true));
+          auto parname = str_checkname(ls, true);
+          auto parhint = gettypehint(ls);
+          new_localvar(ls, parname, parhint);
           nparams++;
           break;
         }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2237,21 +2237,6 @@ inline bool testnext2 (LexState *ls, int token1, int token2) {
 }
 
 
-static const char* expandexpr (LexState *ls) {
-  switch (ls->t.token) {
-    case '{': {
-      return "{}";
-    }
-    case TK_FUNCTION: {
-      return "function (";
-    }
-    default: {
-      return getstr(ls->t.seminfo.ts);
-    }
-  }
-}
-
-
 static void switchstat (LexState *ls, int line) {
   FuncState *fs = ls->fs;
   BlockCnt sbl, cbl; // Switch & case blocks.

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1520,7 +1520,8 @@ static void funcargs (LexState *ls, expdesc *f, int line, TypeDesc *funcdesc = n
   if (funcdesc) {
     for (int i = 0; i != funcdesc->getNumParams(); ++i) {
       Vardesc& param = funcdesc->getParam(ls, i);
-      if (param.vd.hint.getType() == VT_DUNNO)continue; /* skip parameters without type hint */
+      if (param.vd.hint.getType() == VT_DUNNO)
+        continue; /* skip parameters without type hint */
       TypeDesc arg = VT_NIL;
       if (i < (int)argdescs.size())
         arg = argdescs.at(i);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1523,8 +1523,11 @@ static void funcargs (LexState *ls, expdesc *f, int line, TypeDesc *funcdesc = n
       if (param.vd.hint.getType() == VT_DUNNO)
         continue; /* skip parameters without type hint */
       TypeDesc arg = VT_NIL;
-      if (i < (int)argdescs.size())
+      if (i < (int)argdescs.size()) {
         arg = argdescs.at(i);
+        if (arg.getType() == VT_DUNNO)
+          continue; /* skip arguments without propagated type */
+      }
       if (!param.vd.hint.isCompatibleWith(arg)) {
         std::string err = "Function's ";;
         err.append(param.vd.name->contents, param.vd.name->size());

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1407,7 +1407,7 @@ static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *pr
     throw_warn(ls, err.c_str(), line);
   }
   if (prop) { /* propagate type of function */
-    prop->setFunction(new_fs.f->numparams, new_fs.firstlocal, p.getType());
+    prop->setFunction(new_fs.f->numparams, new_fs.firstlocal, p.getType(), p.isNullable());
   }
   new_fs.f->lastlinedefined = ls->linenumber;
   check_match(ls, TK_END, TK_FUNCTION, line);
@@ -1641,7 +1641,7 @@ static void suffixedexp (LexState *ls, expdesc *v, TypeDesc *prop = nullptr) {
         if (prop != nullptr && v->k == VLOCAL) {
           auto fvar = getlocalvardesc(ls->fs, v->u.var.vidx);
           if (fvar->vd.prop.getType() == VT_FUNC) { /* just in case... */
-            *prop = fvar->vd.prop.getReturnType();
+            prop->fromReturn(fvar->vd.prop);
           }
         }
         luaK_exp2nextreg(fs, v);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -456,7 +456,7 @@ static void exp_propagate(LexState* ls, const expdesc& e, TypeDesc& t) noexcept 
 }
 
 
-static void process_assign(LexState* ls, Vardesc* var, TypeDesc td, int line) {
+static void process_assign(LexState* ls, Vardesc* var, const TypeDesc& td, int line) {
   auto hinted = var->vd.hint.getType() != VT_DUNNO;
   auto knownvalue = td.getType() != VT_DUNNO;
   auto incompatible = !var->vd.hint.isCompatibleWith(td);
@@ -524,7 +524,7 @@ static LocVar *localdebuginfo (FuncState *fs, int vidx) {
 ** Create a new local variable with the given 'name'. Return its index
 ** in the function.
 */
-static int new_localvar (LexState *ls, TString *name, TypeDesc hint = VT_DUNNO) {
+static int new_localvar (LexState *ls, TString *name, const TypeDesc& hint = VT_DUNNO) {
   lua_State *L = ls->L;
   FuncState *fs = ls->fs;
   Dyndata *dyd = ls->dyd;
@@ -1097,7 +1097,7 @@ static int block_follow (LexState *ls, int withuntil) {
 }
 
 
-static void propagate_return_type(TypeDesc *prop, TypeDesc ret) {
+static void propagate_return_type(TypeDesc *prop, TypeDesc&& ret) {
   if (prop->getType() != VT_DUNNO) { /* had previous return path(s)? */
     if (prop->getType() == VT_NIL) {
       ret.setNullable();

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -151,7 +151,7 @@ public:
   }
 
   void setFunction(TypeDesc ret_typ) noexcept {
-    setFunction(getType());
+    setFunction(ret_typ.getType());
   }
 
   [[nodiscard]] ValType getType() const noexcept {

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -152,8 +152,10 @@ public:
   {
   }
 
-  void setFunction(int numparams, int firstlocal, ValType ret_typ) noexcept {
-    this->data = ((ret_typ << 4) | VT_FUNC);
+  void setFunction(int numparams, int firstlocal, ValType ret_typ, bool ret_nullable) noexcept {
+    this->data = VT_FUNC;
+    this->data |= (ret_typ << 4);
+    this->data |= (ret_nullable << 7);
     this->numparams = numparams;
     this->firstlocal = firstlocal;
   }
@@ -174,8 +176,16 @@ public:
     return (ValType)((data >> 4) & 0b111);
   }
 
+  [[nodiscard]] bool isReturnNullable() const noexcept {
+    return (data >> 7) & 1;
+  }
+
   [[nodiscard]] int getNumParams() const noexcept {
       return numparams;
+  }
+
+  void fromReturn(TypeDesc& retdesc) noexcept {
+    data = (retdesc.data >> 4);
   }
 
   [[nodiscard]] Vardesc& getParam(LexState* ls, int i) const noexcept;
@@ -199,6 +209,9 @@ public:
       auto rt = getReturnType();
       if (rt != VT_DUNNO) {
         str.push_back('(');
+        if (isReturnNullable()) {
+          str.push_back('?');
+        }
         str.append(vt_toString(rt));
         str.push_back(')');
       }

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -135,7 +135,7 @@ class TypeDesc
 private:
   /*
   ** 4 bits for type. if function, another 4 bits for return type.
-  ** type consists of 3 bits for ValType, and 
+  ** type consists of 3 bits for ValType, and 1 bit for nullable.
   */
   lu_byte data;
   static_assert((NUL_VAL_TYPES - 1) <= 0b111);

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -190,7 +190,7 @@ public:
 
   [[nodiscard]] Vardesc& getParam(LexState* ls, int i) const noexcept;
 
-  [[nodiscard]] bool isCompatibleWith(TypeDesc b) const noexcept {
+  [[nodiscard]] bool isCompatibleWith(const TypeDesc& b) const noexcept {
     const auto b_t = b.getType();
     return (getType() == b_t)
         ? (isNullable() || !b.isNullable()) /* if same type, b can't be nullable if a isn't nullable */

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -102,30 +102,30 @@ typedef struct expdesc {
 
 /* types of values, for type hinting and propagation */
 enum ValType : lu_byte {
-  HT_DUNNO = 0,
-  HT_MIXED,
-  HT_NIL,
-  HT_NUMBER,
-  HT_BOOL,
-  HT_STR,
-  HT_TABLE,
-  HT_FUNC,
+  VT_DUNNO = 0,
+  VT_MIXED,
+  VT_NIL,
+  VT_NUMBER,
+  VT_BOOL,
+  VT_STR,
+  VT_TABLE,
+  VT_FUNC,
 
-  NUM_HINTABLE_TYPES
+  NUL_VAL_TYPES
 };
 
 [[nodiscard]] inline const char* vt_toString(ValType vt) noexcept {
    switch (vt)
    {
-   case HT_DUNNO: return "dunno";
-   case HT_MIXED: return "mixed";
-   case HT_NIL: return "nil";
-   case HT_NUMBER: return "number";
-   case HT_BOOL: return "boolean";
-   case HT_STR: return "string";
-   case HT_TABLE: return "table";
-   case HT_FUNC: return "function";
-   case NUM_HINTABLE_TYPES: break;
+   case VT_DUNNO: return "dunno";
+   case VT_MIXED: return "mixed";
+   case VT_NIL: return "nil";
+   case VT_NUMBER: return "number";
+   case VT_BOOL: return "boolean";
+   case VT_STR: return "string";
+   case VT_TABLE: return "table";
+   case VT_FUNC: return "function";
+   case NUL_VAL_TYPES: break;
    }
    return "ERROR";
 }
@@ -138,7 +138,7 @@ private:
   ** type consists of 3 bits for ValType, and 
   */
   lu_byte data;
-  static_assert((NUM_HINTABLE_TYPES - 1) <= 0b111);
+  static_assert((NUL_VAL_TYPES - 1) <= 0b111);
 
 public:
   TypeDesc(ValType vt, bool nullable = false)
@@ -147,7 +147,7 @@ public:
   }
 
   void setFunction(ValType ret_typ) noexcept {
-    data = ((ret_typ << 4) | HT_FUNC);
+    data = ((ret_typ << 4) | VT_FUNC);
   }
 
   void setFunction(TypeDesc ret_typ) noexcept {
@@ -174,7 +174,7 @@ public:
     const auto b_t = b.getType();
     return (getType() == b_t)
         ? (isNullable() || !b.isNullable()) /* if same type, b can't be nullable if a isn't nullable */
-        : (b_t == HT_NIL && isNullable()) /* if different type, b might still be compatible if a is nullable and b is nil */
+        : (b_t == VT_NIL && isNullable()) /* if different type, b might still be compatible if a is nullable and b is nil */
         ;
   }
 
@@ -185,9 +185,9 @@ public:
       str.push_back('?');
     }
     str.append(vt_toString(vt));
-    if (vt == HT_FUNC) {
+    if (vt == VT_FUNC) {
       auto rt = getReturnType();
-      if (rt != HT_DUNNO) {
+      if (rt != VT_DUNNO) {
         str.push_back('(');
         str.append(vt_toString(rt));
         str.push_back(')');

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -102,7 +102,8 @@ typedef struct expdesc {
 
 /* types of values, for type hinting and propagation */
 enum ValType : lu_byte {
-  HT_MIXED = 0,
+  HT_DUNNO = 0,
+  HT_MIXED,
   HT_NIL,
   HT_NUMBER,
   HT_BOOL,
@@ -116,6 +117,7 @@ enum ValType : lu_byte {
 [[nodiscard]] inline const char* vt_toString(ValType vt) noexcept {
    switch (vt)
    {
+   case HT_DUNNO: return "dunno";
    case HT_MIXED: return "mixed";
    case HT_NIL: return "nil";
    case HT_NUMBER: return "number";
@@ -165,7 +167,7 @@ public:
     std::string str = vt_toString(vt);
     if (vt == HT_FUNC) {
       auto rt = getReturnType();
-      if (rt != HT_MIXED) {
+      if (rt != HT_DUNNO) {
         str.push_back('(');
         str.append(vt_toString(rt));
         str.push_back(')');


### PR DESCRIPTION
Changes to type hints:
- `: nil` type hints are no longer legal
- Adds nil-able type hints, such as `: ?string`
- localstat without initialising e.g. `local a: string` now warns, suggesting to use `local a: ?string` instead
- Function parameters can now be type-hinted and type compatibility is checked inside function and in function calls

And various fixes. The main goal here is to polish up type hints, so I implore you to try and find weird edge cases.