### PR TITLE
Support pseudo-unary '+'

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2221,6 +2221,7 @@ static void switchstat (LexState *ls, int line) {
     }
     else {
       const auto expr = expandexpr(ls); // Raw text of the expression before the lexer skips tokens.
+      testnext(ls, '+'); /* support pseudo-unary '+' */
       simpleexp(ls, &lcase, true);
       if (!vkisconst(lcase.k)) {
         ls->linebuff.clear();

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1805,6 +1805,18 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, lu_byte *prop = null
     luaK_prefix(ls->fs, uop, v, line);
   }
   else if (ls->t.token == TK_IF) ifexpr(ls, v);
+  else if (ls->t.token == '+') {
+    /* support pseudo-unary '+' by implying '0 + subexpr' */
+    init_exp(v, VKINT, 0);
+    v->u.ival = 0;
+    luaK_infix(ls->fs, OPR_ADD, v);
+
+    expdesc v2;
+    int line = ls->linenumber;
+	luaX_next(ls); /* skip '+' */
+	subexpr(ls, &v2, priority[OPR_ADD].right);
+    luaK_posfix(ls->fs, OPR_ADD, v, &v2, line);
+  }
   else {
     simpleexp(ls, v, false, prop);
     if (ls->t.token == TK_IN) {

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -235,6 +235,17 @@ do
         pluto_default:
         error()
     end
+    value = +3
+    pluto_switch value do
+        pluto_case +1:
+        pluto_case +2:
+        pluto_case +3:
+        pluto_case +4:
+        pluto_case +5:
+        break
+        pluto_default:
+        error()
+    end
     value = "foo"
     pluto_switch (value) do
         pluto_case "foo":


### PR DESCRIPTION
Not a huge change, just allows `+x` as counter-part for `-x`.

Generates code as if `0 + x` was typed.