### PR TITLE
Rework switch logic so default case also works as expected

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2305,12 +2305,6 @@ inline bool testnext2 (LexState *ls, int token1, int token2) {
 }
 
 
-[[nodiscard]] static TString* getCaseLabel(LexState* ls, size_t idx) {
-    std::string str = "pluto_case_";
-    str.append(std::to_string(idx));
-    return luaX_newstring(ls, str.c_str()); /* this is fine, it will reuse existing string */
-}
-
 static void switchstat (LexState *ls, int line) {
   int switchToken = gett(ls);
   luaX_next(ls); // Skip switch statement.
@@ -2398,8 +2392,8 @@ static void switchstat (LexState *ls, int line) {
   expdesc test;
   for (size_t i = 0; i != cases.size(); ++i) {
     test = save;
-	luaK_infix(fs, OPR_EQ, &test);
-	luaK_posfix(fs, OPR_EQ, &test, &cases.at(i).first, ls->getLineNumber());
+    luaK_infix(fs, OPR_EQ, &test);
+    luaK_posfix(fs, OPR_EQ, &test, &cases.at(i).first, ls->getLineNumber());
     luaK_patchlist(fs, test.u.info, cases.at(i).second);
   }
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2432,8 +2432,7 @@ static void switchstat (LexState *ls, int line) {
   if (default_case != nullptr)
     lgoto(ls, default_case);
 
-  // ::end_switch::
-  createlabel(ls, end_switch, ls->getLineNumber(), block_follow(ls, 0));
+  createlabel(ls, end_switch, ls->getLineNumber(), block_follow(ls, 0)); // ::end_switch::
 
   check_match(ls, TK_END, switchToken, line);
   leaveblock(fs);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2422,11 +2422,11 @@ static void switchstat (LexState *ls, int line) {
   }
 
   expdesc test;
-  for (size_t i = 0; i != cases.size(); ++i) {
+  for (auto& c : cases) {
     test = save;
     luaK_infix(fs, OPR_EQ, &test);
-    luaK_posfix(fs, OPR_EQ, &test, &cases.at(i).first, ls->getLineNumber());
-    luaK_patchlist(fs, test.u.info, cases.at(i).second);
+    luaK_posfix(fs, OPR_EQ, &test, &c.first, ls->getLineNumber());
+    luaK_patchlist(fs, test.u.info, c.second);
   }
 
   if (default_case != nullptr)

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2359,12 +2359,14 @@ static void switchstat (LexState *ls, int line) {
       || gett(ls) == TK_CASE
 #endif
       ) {
-    luaX_next(ls);
+    int case_line = ls->getLineNumber();
+
+    luaX_next(ls); /* Skip 'case' */
 
     first = save;
 
     expdesc lcase;
-    casecond(ls, ls->getLineNumber(), lcase);
+    casecond(ls, case_line, lcase);
 
     luaK_infix(fs, OPR_NE, &first);
     luaK_posfix(fs, OPR_NE, &first, &lcase, ls->getLineNumber());

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -536,7 +536,7 @@ static int new_localvar (LexState *ls, TString *name, const TypeDesc& hint = VT_
     Vardesc *desc = getlocalvardesc(fs,  i);
     LocVar *local = localdebuginfo(fs, i);
     std::string n = name->toCpp();
-    if ((n != "(for state)" && n != "(switch)") && (local && local->varname == name)) { // Got a match.
+    if ((n != "(for state)" && n != "(switch control value)") && (local && local->varname == name)) { // Got a match.
       throw_warn(ls,
         "duplicate local declaration",
           luaO_fmt(L, "this shadows the value of the initial declaration on line %d.", desc->vd.linenumber));

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -436,6 +436,16 @@ do
         t = false
     end
     assert(t == true)
+    t = 0
+    value = 3
+    pluto_switch value do
+        pluto_case 1:
+        pluto_default:
+        error()
+        pluto_case 3:
+        t = true
+    end
+    assert(t == true)
 end
 
 print "Testing table freezing."


### PR DESCRIPTION
This does introduce a bit of overhead due to the initial jump to begin switch, and the additional goto jump after the conditional jump. I think this is not too big a deal as correctness is more important, and I think skipping the "begin switch" jump will be very difficult with this primitive parser, but since we already do a conditional jump, we might be able to get that to jump directly into the correct case instead of conditionally skipping the goto instruction.