### PR TITLE
Optimise 'if x then goto'

### DIFF
--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -1124,20 +1124,24 @@ static int jumponcond (FuncState *fs, expdesc *e, int cond) {
 }
 
 
+LUAI_FUNC bool luaK_isalwaytrue(expdesc *e) {
+  return e->k == VK || e->k == VKFLT || e->k == VKINT || e->k == VKSTR || e->k == VTRUE;
+}
+
+
 /*
 ** Emit code to go through if 'e' is true, jump otherwise.
 */
 void luaK_goiftrue (FuncState *fs, expdesc *e) {
   int pc;  /* pc of new jump */
   luaK_dischargevars(fs, e);
-  switch (e->k) {
+  if (luaK_isalwaytrue(e)) {
+    pc = NO_JUMP;  /* always true; do nothing */
+  }
+  else switch (e->k) {
     case VJMP: {  /* condition? */
       negatecondition(fs, e);  /* jump when it is false */
       pc = e->u.info;  /* save jump position */
-      break;
-    }
-    case VK: case VKFLT: case VKINT: case VKSTR: case VTRUE: {
-      pc = NO_JUMP;  /* always true; do nothing */
       break;
     }
     default: {

--- a/src/lcode.h
+++ b/src/lcode.h
@@ -76,6 +76,7 @@ LUAI_FUNC void luaK_exp2val (FuncState *fs, expdesc *e);
 LUAI_FUNC int luaK_exp2RK (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_self (FuncState *fs, expdesc *e, expdesc *key);
 LUAI_FUNC void luaK_indexed (FuncState *fs, expdesc *t, expdesc *k);
+LUAI_FUNC bool luaK_isalwaytrue (expdesc *e);
 LUAI_FUNC void luaK_goiftrue (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_goiffalse (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_storevar (FuncState *fs, expdesc *var, expdesc *e);


### PR DESCRIPTION
I guess this is a bit foolish since Roberto gave up on this optimisation, but in the same vein as the switch statement, we can assemble a TEST instruction that will jump right into the desired code. Right now, only backwards jumps are optimised, since that's the only thing I know, but it shouldn't regress the performance of other cases.