### PR TITLE
Support non-ascii variable names

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -836,7 +836,7 @@ static int llex (LexState *ls, SemInfo *seminfo) {
           ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
                                   luaZ_bufflen(ls->buff));
           seminfo->ts = ts;
-          ls->appendLineBuff(ts->contents);
+          ls->appendLineBuff(ts->toCpp());
           if (isreserved(ts))  /* reserved word? */
             return ts->extra - 1 + FIRST_RESERVED;
           else {

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -828,11 +828,19 @@ static int llex (LexState *ls, SemInfo *seminfo) {
         return TK_EOS;
       }
       default: {
-        if (lislalpha(ls->current)) {  /* identifier or reserved word? */
+        if (lislalpha(ls->current)
+#ifndef PLUTO_NO_UTF8
+            || (ls->current & 0b10000000)
+#endif
+          ) {  /* identifier or reserved word? */
           TString *ts;
           do {
             save_and_next(ls);
-          } while (lislalnum(ls->current));
+          } while (lislalnum(ls->current)
+#ifndef PLUTO_NO_UTF8
+              || (ls->current & 0b10000000)
+#endif
+            );
           ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
                                   luaZ_bufflen(ls->buff));
           seminfo->ts = ts;

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -861,6 +861,9 @@
 // If defined, Pluto will exclude code snippets from error messages to make them shorter.
 //#define PLUTO_SHORT_ERRORS
 
+// If defined, Pluto won't assume that files are UTF-8 encoded and restrict valid names.
+//#define PLUTO_NO_UTF8
+
 // If defined, Pluto will use a jumptable in the VM even if not compiled via GCC.
 // This will generally improve runtime performance but can add minutes to compile time, depending on the setup.
 //#define PLUTO_FORCE_JUMPTABLE

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -636,6 +636,12 @@ do
     walrus_test_helper(c := "hi")
 end
 
+print "Testing non-ascii variable names."
+do
+    local 😉 = "Hello"
+    assert(😉 == "Hello")
+end
+
 print "Testing compatibility."
 do
     local a = "Hi"


### PR DESCRIPTION
This assumes that .lua files are UTF-8 encoded. Added `PLUTO_NO_UTF8` config to disable.