### PR TITLE
Tokenise in a separate pass

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -215,7 +215,6 @@ struct LexState {
   int current;  /* current character (charint) */
   std::vector<std::string> lines;  /* A vector of all the lines processed by the lexer. */
   int lastline = 0;  /* line of last token 'consumed' */
-  int lasttoken;  /* save the last compound binary operator, if exists */
   Token laststat;  /* the last statement */
   size_t tidx = -1;
   std::vector<Token> tokens;

--- a/src/llex.h
+++ b/src/llex.h
@@ -90,6 +90,7 @@ typedef union {
 struct Token {
   int token;
   SemInfo seminfo;
+  int line;
 
   /*
   ** This could be implemented using operator overloading.
@@ -213,11 +214,12 @@ struct WarningConfig
 struct LexState {
   int current;  /* current character (charint) */
   std::vector<std::string> lines;  /* A vector of all the lines processed by the lexer. */
-  int lastline;  /* line of last token 'consumed' */
+  int lastline = 0;  /* line of last token 'consumed' */
   int lasttoken;  /* save the last compound binary operator, if exists */
   Token laststat;  /* the last statement */
+  size_t tidx = -1;
+  std::vector<Token> tokens;
   Token t;  /* current token */
-  Token lookahead;  /* look ahead token */
   struct FuncState *fs;  /* current function (parser) */
   struct lua_State *L;
   ZIO *z;  /* input stream */
@@ -237,7 +239,7 @@ struct LexState {
   }
 
   [[nodiscard]] int getLineNumber() const noexcept {
-    return (int)lines.size();
+    return tidx == -1 ? 1 : tokens.at(tidx).line;
   }
 
 
@@ -293,8 +295,9 @@ LUAI_FUNC void luaX_setinput (lua_State *L, LexState *ls, ZIO *z,
 LUAI_FUNC TString *luaX_newstring (LexState *ls, const char *str, size_t l);
 LUAI_FUNC TString* luaX_newstring (LexState *ls, const char *str);
 LUAI_FUNC void luaX_next (LexState *ls);
-LUAI_FUNC int luaX_lookahead (LexState *ls);
-LUAI_FUNC void luaX_rewind (LexState *ls, int token);
+LUAI_FUNC void luaX_prev (LexState *ls);
+LUAI_FUNC int luaX_lookahead(LexState* ls);
+LUAI_FUNC const Token& luaX_lookbehind(LexState* ls);
 [[noreturn]] LUAI_FUNC void luaX_syntaxerror (LexState *ls, const char *s);
 LUAI_FUNC const char *luaX_token2str (LexState *ls, int token);
 LUAI_FUNC const char *luaX_token2str_noq (LexState *ls, int token);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2164,8 +2164,8 @@ static void check_conflict (LexState *ls, struct LHS_assign *lh, expdesc *v) {
   returns a status (0 false, 1 true) and takes a pointer to set.
   this allows for seamless conditional implementation, avoiding a getcompoundop call for every Lua assignment.
 */
-static int getcompoundop (LexState *ls, BinOpr *op) {
-  switch (ls->lasttoken) {
+static int getcompoundop (lua_Integer i, BinOpr *op) {
+  switch (i) {
     case TK_CCAT: {
       *op = OPR_CONCAT;
       return 1;       /* concatenation */
@@ -2287,11 +2287,9 @@ static void restassign (LexState *ls, struct LHS_assign *lh, int nvars) {
   }
   else {  /* restassign -> '=' explist */
     BinOpr op;  /* binary operation from lexer state */
-    int token = ls->lasttoken; /* lexer state token */
-    if (token != 0 && getcompoundop(ls, &op) != 0) {  /* is there a saved binop? */
+    if (getcompoundop(ls->t.seminfo.i, &op) != 0) {  /* is there a saved binop? */
       check_condition(ls, nvars == 1, "unsupported tuple assignment");
       compoundassign(ls, &lh->v, op);  /* perform binop & assignment */
-      ls->lasttoken = 0;  /* clear last token from lexer state */
       return;  /* avoid default */
     }
     else if (testnext(ls, '=')) { /* no requested binop, continue */


### PR DESCRIPTION
This makes the entire source code and all tokens available at parse time, which aside from the obvious benefits for the parser, also resolves the problem that for code such as
```LUA
local if = 5
```
the current warning shows an incomplete sample:
```
test.lua:1: syntax error: expected an identifier.
         1 | local if
           | ^^^^^^^^ here: this needs a name.
```
but with this patch, the sample shows the full line:
```
test.lua:1: syntax error: expected an identifier.
         1 | local if = 5
           | ^^^^^^^^^^^^ here: this needs a name.
           |
```