### PR TITLE
Inline functions

### DIFF
--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -519,19 +519,7 @@ static int luaB_newuserdata (lua_State *L) {
 }
 
 
-/*
-  0.4.0 Changes:
-    - Deprecated in favor of os.sleep. Will be removed in 0.5.0.
-*/
-static int luaB_sleep (lua_State *L) {
-  std::chrono::milliseconds timespan(luaL_checkinteger(L, 1));
-  std::this_thread::sleep_for(timespan);
-  return 0;
-}
-
-
 static const luaL_Reg base_funcs[] = {
-  {"sleep", luaB_sleep},
   {"newuserdata", luaB_newuserdata},
   {"assert", luaB_assert},
   {"collectgarbage", luaB_collectgarbage},

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -42,7 +42,7 @@
 static const char *const luaX_tokens [] = {
     "and", "break", "do", "else", "elseif",
     "end", "false", "for", "function", "goto", "if",
-    "in", "local", "nil", "not", "or", "repeat",
+    "in", "local", "inline", "nil", "not", "or", "repeat",
     "pluto_switch", "pluto_case", "pluto_default", "pluto_continue", "pluto_when",
 #ifndef PLUTO_COMPATIBLE_SWITCH
     "switch",

--- a/src/llex.h
+++ b/src/llex.h
@@ -243,7 +243,6 @@ struct LexState {
     return tidx == -1 ? 1 : tokens.at(tidx).line;
   }
 
-
   /// Find a substring within the current line buffer.
   /// There is an overload that allows a line number as the first argument to search a specific line.
   [[nodiscard]] bool findWithinLine(const std::string& substr, int offset = 0) noexcept
@@ -282,6 +281,10 @@ struct LexState {
 
   void appendLineBuff(char c) {
     getLineBuff().push_back(c);
+  }
+
+  [[nodiscard]] bool isEvaluatingInlineFuncCall() const noexcept {
+    return inlinefunccall_bl != nullptr;
   }
 };
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -35,7 +35,7 @@ enum RESERVED {
   /* terminal symbols denoted by reserved words */
   TK_AND = FIRST_RESERVED, TK_BREAK,
   TK_DO, TK_ELSE, TK_ELSEIF, TK_END, TK_FALSE, TK_FOR, TK_FUNCTION,
-  TK_GOTO, TK_IF, TK_IN, TK_LOCAL, TK_NIL, TK_NOT, TK_OR, TK_REPEAT,
+  TK_GOTO, TK_IF, TK_IN, TK_LOCAL, TK_INLINE, TK_NIL, TK_NOT, TK_OR, TK_REPEAT,
   TK_PSWITCH, TK_PCASE, TK_PDEFAULT, TK_PCONTINUE, TK_PWHEN, // New compatibility keywords.
   /* New non-compatible keywords. */
 #ifndef PLUTO_COMPATIBLE_SWITCH

--- a/src/llex.h
+++ b/src/llex.h
@@ -230,6 +230,7 @@ struct LexState {
   WarningConfig warning;  /* Configuration class for compile-time warnings. */
   bool creating_multiple_variables = false;
   bool processing_funcargs = false;
+  void* inlinefunccall_bl = nullptr;
 
   LexState()
     : lines { std::string {} }

--- a/src/loslib.cpp
+++ b/src/loslib.cpp
@@ -154,27 +154,6 @@ static int os_execute (lua_State *L) {
 }
 
 
-/*
-  Deprecated:
-    - This will be removed in spite of io.remove, in 0.5.0.
-*/
-static int os_remove (lua_State *L) {
-  const char *filename = luaL_checkstring(L, 1);
-  return luaL_fileresult(L, remove(filename) == 0, filename);
-}
-
-
-/*
-  Deprecated:
-    - This will be removed in spite of io.rename, in 0.5.0.
-*/
-static int os_rename (lua_State *L) {
-  const char *fromname = luaL_checkstring(L, 1);
-  const char *toname = luaL_checkstring(L, 2);
-  return luaL_fileresult(L, rename(fromname, toname) == 0, NULL);
-}
-
-
 static int os_tmpname (lua_State *L) {
   char buff[LUA_TMPNAMBUFSIZE];
   int err;
@@ -451,8 +430,6 @@ static const luaL_Reg syslib[] = {
   {"execute",     os_execute},
   {"exit",        os_exit},
   {"getenv",      os_getenv},
-  {"remove",      os_remove},
-  {"rename",      os_rename},
   {"setlocale",   os_setlocale},
   {"time",        os_time},
   {"tmpname",     os_tmpname},

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3030,7 +3030,7 @@ static void exprstat (LexState *ls) {
 static void retstat (LexState *ls, TypeDesc *prop) {
   /* stat -> RETURN [explist] [';'] */
   FuncState *fs = ls->fs;
-  if (ls->inlinefunccall_bl) {
+  if (ls->isEvaluatingInlineFuncCall()) {
     luaK_concat(fs, &reinterpret_cast<BlockCnt*>(ls->inlinefunccall_bl)->breaklist, luaK_jump(fs));
     return;
   }

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -257,7 +257,7 @@ typedef union Vardesc {
     lu_byte kind;
     TypeDesc hint;
     TypeDesc prop; /* type propagation */
-    size_t statlist_tidx; /* for inline functions */
+    size_t parlist_tidx; /* for inline functions */
     lu_byte ridx;  /* register holding the variable */
     short pidx;  /* index of the variable in the Proto's 'locvars' array */
     TString *name;  /* variable name */

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -257,6 +257,7 @@ typedef union Vardesc {
     lu_byte kind;
     TypeDesc hint;
     TypeDesc prop; /* type propagation */
+    size_t statlist_tidx; /* for inline functions */
     lu_byte ridx;  /* register holding the variable */
     short pidx;  /* index of the variable in the Proto's 'locvars' array */
     TString *name;  /* variable name */

--- a/src/lua.h
+++ b/src/lua.h
@@ -13,7 +13,7 @@
 #include "luaconf.h"
 
 
-#define PLUTO_VERSION "Pluto 0.4.1"
+#define PLUTO_VERSION "Pluto 0.5.0"
 
 #define LUA_VERSION_MAJOR	"5"
 #define LUA_VERSION_MINOR	"4"

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -656,6 +656,22 @@ do
     assert(😉 == "Hello")
 end
 
+print "Testing inline functions."
+do
+    inline function inlinefunc_arg(a)
+        assert(a == "Hello")
+    end
+    inlinefunc_arg("Hello")
+
+    inline function inlinefunc_break(a)
+        if a then
+            return
+        end
+        assert(false)
+    end
+    inlinefunc_break(true)
+end
+
 print "Testing compatibility."
 do
     local a = "Hi"


### PR DESCRIPTION
TODO:
- [ ] Properly deal with `return` statements
- [ ] Deal with all call syntacies
- [ ] Make sure Proto does not appear in compiled bytecode to avoid file-size overhead
- [ ] Add compatibility options for `inline` keyword
- [x] Make default parameters work with inline functions
- [ ] Fix exceptions when performing multiple inline function calls

Possible bugs to check for:
- [ ] Make sure nested inline function calls work