### PR TITLE
Complex context

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -73,6 +73,7 @@ static const char *const luaX_tokens [] = {
 
 
 void LexState::popContext(ParserContext ctx) {
+  lua_assert(ctx != PARCTX_NONE);
   if (getContext() != ctx)
     luaX_syntaxerror(this, "parser context stack corrupted");
   parser_context_stck.pop();

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -72,6 +72,13 @@ static const char *const luaX_tokens [] = {
 [[noreturn]] static void lexerror (LexState *ls, const char *msg, int token);
 
 
+void LexState::popContext(ParserContext ctx) {
+  if (getContext() != ctx)
+    luaX_syntaxerror(this, "parser context stack corrupted");
+  parser_context_stck.pop();
+}
+
+
 static void save (LexState *ls, int c) {
   Mbuffer *b = ls->buff;
   if (luaZ_bufflen(b) + 1 > luaZ_sizebuffer(b)) {

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -643,6 +643,18 @@ do
         error()
     end
 
+    -- Complex Context: Walrus in function body of a lambda function that is passed an argument
+    local function executeFunc(f)
+        f()
+    end
+    executeFunc(function()
+        if c := 3 then
+            assert(c == 3)
+        else
+            error()
+        end
+    end)
+
     --[[local function walrus_test_helper(v1, v2)
         assert(v1 == "hi")
         assert(v2 == nil)


### PR DESCRIPTION
Fixes being unable to use the walrus operator in the body of a lambda function that is passed an argument due to the simplistic boolean system that controlled the availability of the operator.