### PR TITLE
Improving error messages a bit.

### DIFF
--- a/Pluto.vcxproj
+++ b/Pluto.vcxproj
@@ -187,6 +187,7 @@
     <ClCompile Include="src\lzio.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\ErrorMessage.hpp" />
     <ClInclude Include="src\lapi.h" />
     <ClInclude Include="src\lauxlib.h" />
     <ClInclude Include="src\lcode.h" />

--- a/Pluto.vcxproj.filters
+++ b/Pluto.vcxproj.filters
@@ -67,5 +67,6 @@
     <ClInclude Include="src\ltable.h" />
     <ClInclude Include="src\ljumptab.h" />
     <ClInclude Include="src\lcryptolib.hpp" />
+    <ClInclude Include="src\ErrorMessage.hpp" />
   </ItemGroup>
 </Project>

--- a/Pluto.vcxproj.user
+++ b/Pluto.vcxproj.user
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
 </Project>

--- a/src/ErrorMessage.hpp
+++ b/src/ErrorMessage.hpp
@@ -34,6 +34,7 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 
 		ErrorMessage& addSrcLine(int line)
 		{
+#ifndef PLUTO_SHORT_ERRORS
 			const auto line_string = this->ls->getLineString(line);
 			const auto init_len = this->content.length();
 			this->content.append("\n    ");
@@ -42,35 +43,42 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 			this->line_len = this->content.length() - init_len - 3;
 			this->src_len += line_string.length();
 			this->content.append(line_string);
+#endif
 			return *this;
 		}
 
 		ErrorMessage& addGenericHere(const std::string& msg) // TO-DO: Add '^^^' strings for specific keywords. Not accurate with a simple string search.
 		{
+#ifndef PLUTO_SHORT_ERRORS
 			this->content.push_back('\n');
 			this->content.append(std::string(this->line_len, ' ') + "| ");
 			this->content.append(HBLU + std::string(this->src_len, '^'));
 			this->content.append(" here: ");
 			this->content.append(msg + RESET);
+#endif
 			return *this;
 		}
 
 		ErrorMessage& addGenericHere()
 		{
+#ifndef PLUTO_SHORT_ERRORS
 			this->content.push_back('\n');
 			this->content.append(std::string(this->line_len, ' ') + "| ");
 			this->content.append(HBLU + std::string(this->src_len, '^'));
 			this->content.append(" here");
 			this->content.append(RESET);
+#endif
 			return *this;
 		}
 
 		ErrorMessage& addNote(const std::string& msg)
 		{
+#ifndef PLUTO_SHORT_ERRORS
 			const auto pad = std::string(this->line_len, ' ');
 			this->content.push_back('\n');
 			this->content.append(pad + HCYN + "+ note: " + RESET);
 			this->content.append(msg);
+#endif
 			return *this;
 		}
 

--- a/src/ErrorMessage.hpp
+++ b/src/ErrorMessage.hpp
@@ -6,7 +6,7 @@
 
 namespace Pluto // Decided to create the first instance of 'namespace' in this project. Figuring I'll put Pluto-related utility in here for now.
 {
-	struct Error
+	class Error
 	{
 	private:
 		LexState* ls;
@@ -77,6 +77,12 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 		void finalize()
 		{
 			lua_pushstring(ls->L, this->content.c_str());
+		}
+
+		[[noreturn]] void finalizeAndThrow()
+		{
+			this->finalize();
+			luaD_throw(ls->L, LUA_ERRSYNTAX);
 		}
 	};
 }

--- a/src/ErrorMessage.hpp
+++ b/src/ErrorMessage.hpp
@@ -89,12 +89,8 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 			lua_pushstring(ls->L, this->content.c_str());
 		}
 
-		[[noreturn]] void finalizeAndThrow(const bool clear_token = false)
+		[[noreturn]] void finalizeAndThrow()
 		{
-			if (clear_token) // luaK_semerror replacement.
-			{
-				ls->t.token = 0;
-			}
 			this->finalize();
 			luaD_throw(ls->L, LUA_ERRSYNTAX);
 		}

--- a/src/ErrorMessage.hpp
+++ b/src/ErrorMessage.hpp
@@ -26,13 +26,13 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 		{
 		}
 
-		Error* addMsg(const std::string& msg)
+		Error& addMsg(const std::string& msg)
 		{
 			this->content.append(msg);
-			return this;
+			return *this;
 		}
 
-		Error* addSrcLine(int line)
+		Error& addSrcLine(int line)
 		{
 			const auto line_string = this->ls->getLineString(line);
 			const auto init_len = this->content.length();
@@ -42,35 +42,35 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 			this->line_len = this->content.length() - init_len - 3;
 			this->src_len += line_string.length();
 			this->content.append(line_string);
-			return this;
+			return *this;
 		}
 
-		Error* addGenericHere(const std::string& msg) // TO-DO: Add '^^^' strings for specific keywords. Not accurate with a simple string search.
+		Error& addGenericHere(const std::string& msg) // TO-DO: Add '^^^' strings for specific keywords. Not accurate with a simple string search.
 		{
 			this->content.push_back('\n');
 			this->content.append(std::string(this->line_len, ' ') + "| ");
 			this->content.append(std::string(this->src_len, '^'));
 			this->content.append(" here: ");
 			this->content.append(msg);
-			return this;
+			return *this;
 		}
 
-		Error* addGenericHere()
+		Error& addGenericHere()
 		{
 			this->content.push_back('\n');
 			this->content.append(std::string(this->line_len, ' ') + "| ");
 			this->content.append(std::string(this->src_len, '^'));
 			this->content.append(" here");
-			return this;
+			return *this;
 		}
 
-		Error* addNote(const std::string& msg)
+		Error& addNote(const std::string& msg)
 		{
 			const auto pad = std::string(this->line_len, ' ');
 			this->content.push_back('\n');
 			this->content.append(pad + "+ note: ");
 			this->content.append(msg);
-			return this;
+			return *this;
 		}
 
 		// Pushes the string to the stack for luaD_throw to conveniently pick up.

--- a/src/ErrorMessage.hpp
+++ b/src/ErrorMessage.hpp
@@ -79,8 +79,12 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 			lua_pushstring(ls->L, this->content.c_str());
 		}
 
-		[[noreturn]] void finalizeAndThrow()
+		[[noreturn]] void finalizeAndThrow(const bool clear_token = false)
 		{
+			if (clear_token) // luaK_semerror replacement.
+			{
+				ls->t.token = 0;
+			}
 			this->finalize();
 			luaD_throw(ls->L, LUA_ERRSYNTAX);
 		}

--- a/src/ErrorMessage.hpp
+++ b/src/ErrorMessage.hpp
@@ -6,7 +6,7 @@
 
 namespace Pluto // Decided to create the first instance of 'namespace' in this project. Figuring I'll put Pluto-related utility in here for now.
 {
-	class Error
+	class ErrorMessage
 	{
 	private:
 		LexState* ls;
@@ -16,23 +16,23 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 	public:
 		std::string content{};
 
-		Error(LexState* ls)
+		ErrorMessage(LexState* ls)
 			: ls(ls)
 		{
 		}
 
-		Error(LexState* ls, const std::string& initial_msg)
+		ErrorMessage(LexState* ls, const std::string& initial_msg)
 			: ls(ls), content(initial_msg)
 		{
 		}
 
-		Error& addMsg(const std::string& msg)
+		ErrorMessage& addMsg(const std::string& msg)
 		{
 			this->content.append(msg);
 			return *this;
 		}
 
-		Error& addSrcLine(int line)
+		ErrorMessage& addSrcLine(int line)
 		{
 			const auto line_string = this->ls->getLineString(line);
 			const auto init_len = this->content.length();
@@ -45,7 +45,7 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 			return *this;
 		}
 
-		Error& addGenericHere(const std::string& msg) // TO-DO: Add '^^^' strings for specific keywords. Not accurate with a simple string search.
+		ErrorMessage& addGenericHere(const std::string& msg) // TO-DO: Add '^^^' strings for specific keywords. Not accurate with a simple string search.
 		{
 			this->content.push_back('\n');
 			this->content.append(std::string(this->line_len, ' ') + "| ");
@@ -55,7 +55,7 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 			return *this;
 		}
 
-		Error& addGenericHere()
+		ErrorMessage& addGenericHere()
 		{
 			this->content.push_back('\n');
 			this->content.append(std::string(this->line_len, ' ') + "| ");
@@ -64,7 +64,7 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 			return *this;
 		}
 
-		Error& addNote(const std::string& msg)
+		ErrorMessage& addNote(const std::string& msg)
 		{
 			const auto pad = std::string(this->line_len, ' ');
 			this->content.push_back('\n');

--- a/src/ErrorMessage.hpp
+++ b/src/ErrorMessage.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <string>
+
+#include "llex.h"
+
+namespace Pluto // Decided to create the first instance of 'namespace' in this project. Figuring I'll put Pluto-related utility in here for now.
+{
+	struct Error
+	{
+	private:
+		LexState* ls;
+		size_t src_len = 0; // The size of the source line itself.
+		size_t line_len = 0; // The buffer size needed to align a bar (|).
+
+	public:
+		std::string content{};
+
+		Error(LexState* ls)
+			: ls(ls)
+		{
+		}
+
+		Error(LexState* ls, const std::string& initial_msg)
+			: ls(ls), content(initial_msg)
+		{
+		}
+
+		Error* addMsg(const std::string& msg)
+		{
+			this->content.append(msg);
+			return this;
+		}
+
+		Error* addSrcLine(int line)
+		{
+			const auto line_string = this->ls->getLineString(line);
+			const auto init_len = this->content.length();
+			this->content.append("\n    ");
+			this->content.append(std::to_string(line));
+			this->content.append(" | ");
+			this->line_len = this->content.length() - init_len - 3;
+			this->src_len += line_string.length();
+			this->content.append(line_string);
+			return this;
+		}
+
+		Error* addGenericHere(const std::string& msg) // TO-DO: Add '^^^' strings for specific keywords. Not accurate with a simple string search.
+		{
+			this->content.push_back('\n');
+			this->content.append(std::string(this->line_len, ' ') + "| ");
+			this->content.append(std::string(this->src_len, '^'));
+			this->content.append(" here: ");
+			this->content.append(msg);
+			return this;
+		}
+
+		Error* addGenericHere()
+		{
+			this->content.push_back('\n');
+			this->content.append(std::string(this->line_len, ' ') + "| ");
+			this->content.append(std::string(this->src_len, '^'));
+			this->content.append(" here");
+			return this;
+		}
+
+		Error* addNote(const std::string& msg)
+		{
+			const auto pad = std::string(this->line_len, ' ');
+			this->content.push_back('\n');
+			this->content.append(pad + "+ note: ");
+			this->content.append(msg);
+			return this;
+		}
+
+		// Pushes the string to the stack for luaD_throw to conveniently pick up.
+		void finalize()
+		{
+			lua_pushstring(ls->L, this->content.c_str());
+		}
+	};
+}

--- a/src/ErrorMessage.hpp
+++ b/src/ErrorMessage.hpp
@@ -49,9 +49,9 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 		{
 			this->content.push_back('\n');
 			this->content.append(std::string(this->line_len, ' ') + "| ");
-			this->content.append(std::string(this->src_len, '^'));
+			this->content.append(HBLU + std::string(this->src_len, '^'));
 			this->content.append(" here: ");
-			this->content.append(msg);
+			this->content.append(msg + RESET);
 			return *this;
 		}
 
@@ -59,8 +59,9 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 		{
 			this->content.push_back('\n');
 			this->content.append(std::string(this->line_len, ' ') + "| ");
-			this->content.append(std::string(this->src_len, '^'));
+			this->content.append(HBLU + std::string(this->src_len, '^'));
 			this->content.append(" here");
+			this->content.append(RESET);
 			return *this;
 		}
 
@@ -68,7 +69,7 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 		{
 			const auto pad = std::string(this->line_len, ' ');
 			this->content.push_back('\n');
-			this->content.append(pad + "+ note: ");
+			this->content.append(pad + HCYN + "+ note: " + RESET);
 			this->content.append(msg);
 			return *this;
 		}
@@ -76,6 +77,7 @@ namespace Pluto // Decided to create the first instance of 'namespace' in this p
 		// Pushes the string to the stack for luaD_throw to conveniently pick up.
 		void finalize()
 		{
+			this->content.append(RESET);
 			lua_pushstring(ls->L, this->content.c_str());
 		}
 

--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -1595,7 +1595,7 @@ static void codeeq (FuncState *fs, BinOpr opr, expdesc *e1, expdesc *e2) {
 ** Apply prefix operation 'op' to expression 'e'.
 */
 void luaK_prefix (FuncState *fs, UnOpr op, expdesc *e, int line) {
-  static const expdesc ef = {VKINT, {0}, NO_JUMP, NO_JUMP};
+  static const expdesc ef = {VKINT, {0}, NO_JUMP, NO_JUMP, VT_DUNNO};
   luaK_dischargevars(fs, e);
   switch (op) {
     case OPR_MINUS: case OPR_BNOT:  /* use 'ef' as fake 2nd operand */

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -163,7 +163,7 @@ static const char *txtToken (LexState *ls, int token) {
   msg = luaG_addinfo(ls->L, msg, ls->source, ls->getLineNumber());
   if (token)
   {
-    Pluto::Error err{ ls, msg };
+    Pluto::ErrorMessage err{ ls, msg };
     if (ls->t.IsReserved())
     {
       err.addMsg(", but found reserved keyword ")

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -167,19 +167,19 @@ static const char *txtToken (LexState *ls, int token) {
     if (ls->t.IsReserved())
     {
       err.addMsg(", but found reserved keyword ")
-        ->addMsg(txtToken(ls, token))
-        ->addSrcLine(ls->getLineNumber())
-        ->addGenericHere("reserved keyword cannot be used in this context.")
-        ->addNote("Reserved keywords *can* be used outside of relevant contexts, but this is a relevant context!")
-        ->finalize();
+         .addMsg(txtToken(ls, token))
+         .addSrcLine(ls->getLineNumber())
+         .addGenericHere("reserved keyword cannot be used in this context.")
+         .addNote("Reserved keywords *can* be used outside of relevant contexts, but this is a relevant context!")
+         .finalize();
     }
     else
     {
       err.addMsg(" near ")
-        ->addMsg(txtToken(ls, token))
-        ->addSrcLine(ls->getLineNumber())
-        ->addGenericHere()
-        ->finalize();
+         .addMsg(txtToken(ls, token))
+         .addSrcLine(ls->getLineNumber())
+         .addGenericHere()
+         .finalize();
     }
   }
   luaD_throw(ls->L, LUA_ERRSYNTAX);

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -163,7 +163,8 @@ static const char *txtToken (LexState *ls, int token) {
   msg = luaG_addinfo(ls->L, msg, ls->source, ls->getLineNumber());
   if (token)
   {
-    Pluto::ErrorMessage err{ ls, msg };
+    Pluto::ErrorMessage err{ ls, HRED "syntax error: " BWHT};
+    err.addMsg(msg);
     if (ls->t.IsReserved())
     {
       err.addMsg(", but found reserved keyword ")

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -27,6 +27,8 @@
 #include "ltable.h"
 #include "lzio.h"
 
+#include "ErrorMessage.hpp"
+
 
 
 #define next(ls)	(ls->current = zgetc(ls->z))
@@ -160,7 +162,26 @@ static const char *txtToken (LexState *ls, int token) {
 [[noreturn]] static void lexerror (LexState *ls, const char *msg, int token) {
   msg = luaG_addinfo(ls->L, msg, ls->source, ls->getLineNumber());
   if (token)
-    luaO_pushfstring(ls->L, "%s near %s", msg, txtToken(ls, token));
+  {
+    Pluto::Error err{ ls, msg };
+    if (ls->t.IsReserved())
+    {
+      err.addMsg(", but found reserved keyword ")
+        ->addMsg(txtToken(ls, token))
+        ->addSrcLine(ls->getLineNumber())
+        ->addGenericHere("reserved keyword cannot be used in this context.")
+        ->addNote("Reserved keywords *can* be used outside of relevant contexts, but this is a relevant context!")
+        ->finalize();
+    }
+    else
+    {
+      err.addMsg(" near ")
+        ->addMsg(txtToken(ls, token))
+        ->addSrcLine(ls->getLineNumber())
+        ->addGenericHere()
+        ->finalize();
+    }
+  }
   luaD_throw(ls->L, LUA_ERRSYNTAX);
 }
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -204,7 +204,7 @@ struct WarningConfig
     }
   }
 
-  const char* getWarningName(const WarningType w) const noexcept
+  [[nodiscard]] const char* getWarningName(const WarningType w) const noexcept
   {
     return luaX_warnNames[(int)w].c_str();
   }
@@ -255,7 +255,7 @@ struct LexState {
   }
 
   [[nodiscard]] int getLineNumber() const noexcept {
-    return tidx == -1 ? 1 : tokens.at(tidx).line;
+    return tidx == (size_t)-1 ? 1 : tokens.at(tidx).line;
   }
 
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -275,7 +275,7 @@ struct LexState {
   }
 
   // Does the last relevant source line call for warning silence?
-  [[nodiscard]] bool callsForSilence(int line, WarningType warning_type)
+  [[nodiscard]] bool shouldEmitWarning(int line, WarningType warning_type)
   {
     const auto& linebuff = this->getLineString(line);
     const auto& lastattr = line > 1 ? this->getLineString(line - 1) : linebuff;

--- a/src/llex.h
+++ b/src/llex.h
@@ -93,13 +93,6 @@ struct Token {
   SemInfo seminfo;
   int line;
 
-  /*
-  ** This could be implemented using operator overloading.
-  ** I dislike this approach because it's unnecessarily ambiguous. 
-  ** I tend to avoid overloading as a whole, because it's typically unclear.
-  **
-  ** - Ryan
-  */
   [[nodiscard]] bool Is(int t) const noexcept
   {
     return token == t;

--- a/src/llex.h
+++ b/src/llex.h
@@ -203,6 +203,11 @@ struct WarningConfig
       }
     }
   }
+
+  const char* getWarningName(const WarningType w) const noexcept
+  {
+    return luaX_warnNames[(int)w].c_str();
+  }
 };
 
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -269,6 +269,14 @@ struct LexState {
     return str.find(substr, offset) != std::string::npos;
   }
 
+  // Does the last relevant source line call for warning silence?
+  [[nodiscard]] bool callsForSilence(int line, WarningType warning_type)
+  {
+    const auto& linebuff = this->getLineString(line);
+    const auto& lastattr = line > 1 ? this->getLineString(line - 1) : linebuff;
+    return lastattr.find("@pluto_warnings: disable-next") == std::string::npos && this->warning.Get(warning_type);
+  }
+
   [[nodiscard]] int getLineNumberOfLastNonEmptyLine() const noexcept {
     for (int line = getLineNumber(); line != 0; --line) {
       if (!getLineString(line).empty()) {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -106,9 +106,13 @@ static void expr (LexState *ls, expdesc *v, TypeDesc *prop = nullptr, bool no_co
 /*
 ** Throws a warning into standard output, which will not close the program.
 */
-static void throw_warn (LexState *ls, const char *err, const char *here, int line, WarningType warningType) {
+static void throw_warn (LexState *ls, const char *raw_err, const char *here, int line, WarningType warningType) {
+  std::string err(raw_err);
   if (ls->callsForSilence(line, warningType)) {
     Pluto::ErrorMessage msg{ ls, luaG_addinfo(ls->L, YEL "warning: " BWHT, ls->source, line) };
+    err.append(" [");
+    err.append(ls->warning.getWarningName(warningType));
+    err.push_back(']');
     msg.addMsg(err)
       .addSrcLine(line)
       .addGenericHere(here)
@@ -118,7 +122,7 @@ static void throw_warn (LexState *ls, const char *err, const char *here, int lin
   }
 }
 
-static void throw_warn(LexState *ls, const char *err, const char *here, WarningType warningType) {
+static void throw_warn(LexState *ls, const char* err, const char *here, WarningType warningType) {
   return throw_warn(ls, err, here, ls->getLineNumber(), warningType);
 }
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -306,7 +306,7 @@ static void check_match (LexState *ls, int what, int who, int where) {
             .addMsg(")")
             .addSrcLine(ls->getLineNumberOfLastNonEmptyLine())
             .addGenericHere()
-            .finalizeAndThrow(true);
+            .finalizeAndThrow();
         }
       }
     }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -90,7 +90,7 @@ static void expr (LexState *ls, expdesc *v, TypeDesc *prop = nullptr, bool no_co
 */
 [[noreturn]] static void throwerr (LexState *ls, const char *err, const char *here, int line) {
   err = luaG_addinfo(ls->L, err, ls->source, line);
-  Pluto::ErrorMessage msg{ ls, "syntax error: " }; // We'll only throw syntax errors if 'throwerr' is called
+  Pluto::ErrorMessage msg{ ls, HRED "syntax error: " BWHT }; // We'll only throw syntax errors if 'throwerr' is called
   msg.addMsg(err)
     .addSrcLine(line)
     .addGenericHere(here)
@@ -108,7 +108,7 @@ static void expr (LexState *ls, expdesc *v, TypeDesc *prop = nullptr, bool no_co
 */
 static void throw_warn (LexState *ls, const char *err, const char *here, int line, WarningType warningType) {
   if (ls->callsForSilence(line, warningType)) {
-    Pluto::ErrorMessage msg{ ls, luaG_addinfo(ls->L, "warning: ", ls->source, line) };
+    Pluto::ErrorMessage msg{ ls, luaG_addinfo(ls->L, YEL "warning: " BWHT, ls->source, line) };
     msg.addMsg(err)
       .addSrcLine(line)
       .addGenericHere(here)
@@ -277,7 +277,7 @@ static void check_match (LexState *ls, int what, int who, int where) {
           }
         }
         default: {
-          Pluto::ErrorMessage err{ ls, "syntax error: " }; // Doesn't use throwerr since I replicated old code. Couldn't find problematic code to repro error, so went safe.
+          Pluto::ErrorMessage err{ ls, RED "syntax error: " BWHT }; // Doesn't use throwerr since I replicated old code. Couldn't find problematic code to repro error, so went safe.
           err.addMsg(luaX_token2str(ls, what))
             .addMsg(" expected (to close ")
             .addMsg(luaX_token2str(ls, who))

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -305,7 +305,7 @@ static void check_match (LexState *ls, int what, int who, int where) {
 
 static TString *str_checkname (LexState *ls, bool strict = false) {
   TString *ts;
-  if (!isnametkn(ls)) {
+  if (!isnametkn(ls, strict)) {
     error_expected(ls, TK_NAME);
   }
   ts = ls->t.seminfo.ts;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -90,7 +90,7 @@ static void expr (LexState *ls, expdesc *v, TypeDesc *prop = nullptr, bool no_co
 */
 [[noreturn]] static void throwerr (LexState *ls, const char *err, const char *here, int line) {
   err = luaG_addinfo(ls->L, err, ls->source, line);
-  Pluto::Error msg{ ls, "syntax error: " }; // We'll only throw syntax errors if 'throwerr' is called
+  Pluto::ErrorMessage msg{ ls, "syntax error: " }; // We'll only throw syntax errors if 'throwerr' is called
   msg.addMsg(err)
     .addSrcLine(line)
     .addGenericHere(here)
@@ -108,7 +108,7 @@ static void expr (LexState *ls, expdesc *v, TypeDesc *prop = nullptr, bool no_co
 */
 static void throw_warn (LexState *ls, const char *err, const char *here, int line, WarningType warningType) {
   if (ls->callsForSilence(line, warningType)) {
-    Pluto::Error msg{ ls, luaG_addinfo(ls->L, "warning: ", ls->source, line) };
+    Pluto::ErrorMessage msg{ ls, luaG_addinfo(ls->L, "warning: ", ls->source, line) };
     msg.addMsg(err)
       .addSrcLine(line)
       .addGenericHere(here)
@@ -277,7 +277,7 @@ static void check_match (LexState *ls, int what, int who, int where) {
           }
         }
         default: {
-          Pluto::Error err{ ls, "syntax error: " }; // Doesn't use throwerr since I replicated old code. Couldn't find problematic code to repro error, so went safe.
+          Pluto::ErrorMessage err{ ls, "syntax error: " }; // Doesn't use throwerr since I replicated old code. Couldn't find problematic code to repro error, so went safe.
           err.addMsg(luaX_token2str(ls, what))
             .addMsg(" expected (to close ")
             .addMsg(luaX_token2str(ls, who))

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -267,47 +267,20 @@ static void check_match (LexState *ls, int what, int who, int where) {
     if (where == ls->getLineNumber())  /* all in the same line? */
       error_expected(ls, what);  /* do not need a complex message */
     else {
-      switch (what) {
-        case TK_END: {
-          switch (who) {
-            case TK_IF: {
-              throwerr(ls,
-                "missing 'end' to terminate 'if' statement.", "this was the last statement.", ls->getLineNumberOfLastNonEmptyLine());
-            }
-            case TK_DO: {
-              throwerr(ls,
-                "missing 'end' to terminate 'do' block.", "this was the last statement.", ls->getLineNumberOfLastNonEmptyLine());
-            }
-            case TK_FOR: {
-              throwerr(ls,
-                "missing 'end' to terminate 'for' block.", "this was the last statement.", ls->getLineNumberOfLastNonEmptyLine());
-            }
-            case TK_WHILE: {
-              throwerr(ls,
-                "missing 'end' to terminate 'while' block.", "this was the last statement.", ls->getLineNumberOfLastNonEmptyLine());
-            }
-            case TK_FUNCTION: {
-              throwerr(ls,
-                "missing 'end' to terminate 'function' block.", "this was the last statement.", ls->getLineNumberOfLastNonEmptyLine());
-            }
-            default: {
-              throwerr(ls,
-                "missing 'end' to terminate block.", "missing termination.", ls->getLineNumberOfLastNonEmptyLine());
-            }
-          }
-        }
-        default: {
-          Pluto::ErrorMessage err{ ls, RED "syntax error: " BWHT }; // Doesn't use throwerr since I replicated old code. Couldn't find problematic code to repro error, so went safe.
-          err.addMsg(luaX_token2str(ls, what))
-            .addMsg(" expected (to close ")
-            .addMsg(luaX_token2str(ls, who))
-            .addMsg(" at line ")
-            .addMsg(std::to_string(where))
-            .addMsg(")")
-            .addSrcLine(ls->getLineNumberOfLastNonEmptyLine())
-            .addGenericHere()
-            .finalizeAndThrow();
-        }
+      if (what == TK_END) {
+        throwerr(ls, luaO_fmt(ls->L, "missing 'end' to terminate matching %s block", luaX_token2str(ls, who)), "this was the last statement.", ls->getLineNumberOfLastNonEmptyLine());
+      }
+      else {
+        Pluto::ErrorMessage err{ ls, RED "syntax error: " BWHT }; // Doesn't use throwerr since I replicated old code. Couldn't find problematic code to repro error, so went safe.
+        err.addMsg(luaX_token2str(ls, what))
+          .addMsg(" expected (to close ")
+          .addMsg(luaX_token2str(ls, who))
+          .addMsg(" at line ")
+          .addMsg(std::to_string(where))
+          .addMsg(")")
+          .addSrcLine(ls->getLineNumberOfLastNonEmptyLine())
+          .addGenericHere()
+          .finalizeAndThrow();
       }
     }
   }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -416,7 +416,7 @@ static void process_assign(LexState* ls, Vardesc* var, const TypeDesc& td, int l
       ls->L->top--;
     }
     else {  /* Throw a generic mismatch warning. */
-      throw_warn(ls, err.c_str(), "type mismatch", line, TYPE_MISMATCH);
+      throw_warn(ls, "variable type mismatch", err.c_str(), line, TYPE_MISMATCH);
     }
   }
 #endif

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -286,7 +286,7 @@ static void check_match (LexState *ls, int what, int who, int where) {
             .addMsg(")")
             .addSrcLine(ls->getLineNumberOfLastNonEmptyLine())
             .addGenericHere()
-            .finalizeAndThrow();
+            .finalizeAndThrow(true);
         }
       }
     }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -108,7 +108,7 @@ static void expr (LexState *ls, expdesc *v, TypeDesc *prop = nullptr, bool no_co
 */
 static void throw_warn (LexState *ls, const char *raw_err, const char *here, int line, WarningType warningType) {
   std::string err(raw_err);
-  if (ls->callsForSilence(line, warningType)) {
+  if (ls->shouldEmitWarning(line, warningType)) {
     Pluto::ErrorMessage msg{ ls, luaG_addinfo(ls->L, YEL "warning: " BWHT, ls->source, line) };
     err.append(" [");
     err.append(ls->warning.getWarningName(warningType));
@@ -128,7 +128,7 @@ static void throw_warn(LexState *ls, const char* err, const char *here, WarningT
 
 // TO-DO: Warning suppression attribute support for this overload. Don't know where it's used atm.
 static void throw_warn(LexState *ls, const char *err, int line, WarningType warningType) {
-  if (ls->callsForSilence(line, warningType)) {
+  if (ls->shouldEmitWarning(line, warningType)) {
     auto msg = luaG_addinfo(ls->L, err, ls->source, line);
     lua_warning(ls->L, msg, 0);
     ls->L->top -= 1; /* remove warning from stack */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -34,6 +34,8 @@
 #include "ltable.h"
 #include "lauxlib.h"
 
+#include "ErrorMessage.hpp"
+
 
 
 /* maximum number of local variables per function (must be smaller
@@ -83,86 +85,16 @@ static void expr (LexState *ls, expdesc *v, TypeDesc *prop = nullptr, bool no_co
 
 
 /*
-** Formats an error with the appropriate source code snippet.
-*/
-static const char *format_line_error (LexState *ls, const char *msg, const char *token, const char *here, int line) {
-  std::string pad_str(std::to_string(line).length(), ' ');
-  const char *pad = pad_str.c_str();
-  const char *text = luaG_addinfo(ls->L, msg, ls->source, line);
-#ifdef PLUTO_SHORT_ERRORS
-#ifdef PLUTO_USE_COLORED_OUTPUT
-  text = luaO_fmt(ls->L, "%s%s%s", YEL, text, RESET);
-#endif // PLUTO_USE_COLORED_OUTPUT
-  return text;
-#endif
-#ifndef PLUTO_USE_COLORED_OUTPUT
-  text = luaO_fmt(ls->L, "%s\n\t%s%d | %s\n\t%s%s | %s\n\t%s%s |",
-                          text, pad, line, token, pad, pad, here, pad, pad);
-#else // PLUTO_USE_COLORED_OUTPUT
-  text = luaO_fmt(ls->L, "%s%s%s\n\t%s%d | %s\n\t%s%s | %s\n\t%s%s |",
-                          YEL, text, RESET, pad, line, token, pad, pad, here, pad, pad);
-#endif // PLUTO_USED_COLORED_OUTPUT
-  return text;
-}
-
-
-/*
-** Applies coloring (if permitted) to 's'.
-*/
-static std::string make_here(const std::string& linebuff, const char *s) {
-  std::string here = std::string(linebuff.size(), '^');
-  here.append(" here: ");
-#ifdef PLUTO_USE_COLORED_OUTPUT
-  here.insert(0, std::string(RED));
-  here.append(s);
-  here.append(RESET);
-#else
-  here.append(s);
-#endif
-  return here;
-}
-
-
-/*
-** Applies coloring (if permitted) to an invalid synax error message.
-*/
-static std::string make_err(const char *s) {
-  std::string error = std::string(s);
-  error.insert(0, "syntax error: ");
-#ifdef PLUTO_USE_COLORED_OUTPUT
-  error.insert(0, std::string(RED));
-  error.insert(19, std::string(BWHT));
-  error.append(RESET);
-#endif
-  return error;
-}
-
-
-/*
-** Applies coloring (if permitted) to a warning message.
-*/
-static std::string make_warn(const char *s) {
-  std::string error = std::string(s);
-  error.insert(0, "warning: ");
-#ifdef PLUTO_USE_COLORED_OUTPUT
-  error.insert(0, std::string(RED));
-  error.insert(error.find("warning:") + 8, std::string(BWHT));
-  error.append(RESET);
-#endif
-  return error;
-}
-
-
-/*
 ** Throws an exception into Lua, which will promptly close the program.
 ** This is only called for vital errors, like lexer and/or syntax problems.
 */
 [[noreturn]] static void throwerr (LexState *ls, const char *err, const char *here, int line) {
-  const std::string& linebuff = ls->getLineString(line);
-  std::string error = make_err(err);
-  std::string rhere = make_here(linebuff, here);
-  format_line_error(ls, error.c_str(), linebuff.c_str(), rhere.c_str(), line);
-  luaD_throw(ls->L, LUA_ERRSYNTAX);
+  err = luaG_addinfo(ls->L, err, ls->source, line);
+  Pluto::Error msg{ ls, "syntax error: " }; // We'll only throw syntax errors if 'throwerr' is called
+  msg.addMsg(err)
+    .addSrcLine(line)
+    .addGenericHere(here)
+    .finalizeAndThrow();
 }
 
 [[noreturn]] static void throwerr (LexState *ls, const char *err, const char *here) {
@@ -178,10 +110,13 @@ static void throw_warn (LexState *ls, const char *err, const char *here, int lin
   const std::string& linebuff = ls->getLineString(line);
   const std::string& lastattr = line > 1 ? ls->getLineString(line - 1) : linebuff;
   if (lastattr.find("@pluto_warnings: disable-next") == std::string::npos && ls->warning.Get(warningType)) {
-    std::string error = make_warn(err);
-    std::string rhere = make_here(linebuff, here);
-    lua_warning(ls->L, format_line_error(ls, error.c_str(), linebuff.c_str(), rhere.c_str(), line), 0);
-    ls->L->top -= 2; /* remove warning from stack */
+    Pluto::Error msg{ ls, luaG_addinfo(ls->L, "warning: ", ls->source, line) };
+    msg.addMsg(err)
+      .addSrcLine(line)
+      .addGenericHere(here)
+      .finalize();
+    lua_warning(ls->L, msg.content.c_str(), 0);
+    ls->L->top -= 2; // Pluto::Error::finalize & luaG_addinfo
   }
 }
 
@@ -352,10 +287,16 @@ static void check_match (LexState *ls, int what, int who, int where) {
           }
         }
         default: {
-          std::string err = make_err("%s expected (to close %s at line %d)");
-          luaK_semerror(ls,
-            luaO_fmt(ls->L, err.c_str(),
-              luaX_token2str(ls, what), luaX_token2str(ls, who), where));
+          Pluto::Error err{ ls, "syntax error: " }; // Doesn't use throwerr since I replicated old code. Couldn't find problematic code to repro error, so went safe.
+          err.addMsg(luaX_token2str(ls, what))
+            .addMsg(" expected (to close ")
+            .addMsg(luaX_token2str(ls, who))
+            .addMsg(" at line ")
+            .addMsg(std::to_string(where))
+            .addMsg(")")
+            .addSrcLine(ls->getLineNumberOfLastNonEmptyLine())
+            .addGenericHere()
+            .finalizeAndThrow();
         }
       }
     }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -107,9 +107,7 @@ static void expr (LexState *ls, expdesc *v, TypeDesc *prop = nullptr, bool no_co
 ** Throws a warning into standard output, which will not close the program.
 */
 static void throw_warn (LexState *ls, const char *err, const char *here, int line, WarningType warningType) {
-  const std::string& linebuff = ls->getLineString(line);
-  const std::string& lastattr = line > 1 ? ls->getLineString(line - 1) : linebuff;
-  if (lastattr.find("@pluto_warnings: disable-next") == std::string::npos && ls->warning.Get(warningType)) {
+  if (ls->callsForSilence(line, warningType)) {
     Pluto::Error msg{ ls, luaG_addinfo(ls->L, "warning: ", ls->source, line) };
     msg.addMsg(err)
       .addSrcLine(line)
@@ -126,20 +124,12 @@ static void throw_warn(LexState *ls, const char *err, const char *here, WarningT
 
 // TO-DO: Warning suppression attribute support for this overload. Don't know where it's used atm.
 static void throw_warn(LexState *ls, const char *err, int line, WarningType warningType) {
-  const std::string& linebuff = ls->getLineString(line);
-  const std::string& lastattr = line > 1 ? ls->getLineString(line - 1) : linebuff;
-  if (lastattr.find("@pluto_warnings: disable-next") == std::string::npos && ls->warning.Get(warningType)) {
+  if (ls->callsForSilence(line, warningType)) {
     auto msg = luaG_addinfo(ls->L, err, ls->source, line);
     lua_warning(ls->L, msg, 0);
     ls->L->top -= 1; /* remove warning from stack */
   }
 }
-
-/*
-static void throw_warn(LexState *ls, const char *err) {
-  return throw_warn(ls, err, ls->getLineNumber());
-}
-*/
 #endif
 
 

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -766,88 +766,6 @@
 
 /*
 ** {====================================================================
-** Pluto color macros.
-** =====================================================================}
-*/
-
-#define ESC "\x1B"
-
-#define BLK ESC "[0;30m"
-#define RED ESC "[0;31m"
-#define GRN ESC "[0;32m"
-#define YEL ESC "[0;33m"
-#define BLU ESC "[0;34m"
-#define MAG ESC "[0;35m"
-#define CYN ESC "[0;36m"
-#define WHT ESC "[0;37m"
-
-//Regular bold text
-#define BBLK ESC "[1;30m"
-#define BRED ESC "[1;31m"
-#define BGRN ESC "[1;32m"
-#define BYEL ESC "[1;33m"
-#define BBLU ESC "[1;34m"
-#define BMAG ESC "[1;35m"
-#define BCYN ESC "[1;36m"
-#define BWHT ESC "[1;37m"
-
-//Regular underline text
-#define UBLK ESC "[4;30m"
-#define URED ESC "[4;31m"
-#define UGRN ESC "[4;32m"
-#define UYEL ESC "[4;33m"
-#define UBLU ESC "[4;34m"
-#define UMAG ESC "[4;35m"
-#define UCYN ESC "[4;36m"
-#define UWHT ESC "[4;37m"
-
-//Regular background
-#define BLKB ESC "[40m"
-#define REDB ESC "[41m"
-#define GRNB ESC "[42m"
-#define YELB ESC "[43m"
-#define BLUB ESC "[44m"
-#define MAGB ESC "[45m"
-#define CYNB ESC "[46m"
-#define WHTB ESC "[47m"
-
-//High intensty background 
-#define BLKHB ESC "[0;100m"
-#define REDHB ESC "[0;101m"
-#define GRNHB ESC "[0;102m"
-#define YELHB ESC "[0;103m"
-#define BLUHB ESC "[0;104m"
-#define MAGHB ESC "[0;105m"
-#define CYNHB ESC "[0;106m"
-#define WHTHB ESC "[0;107m"
-
-//High intensty text
-#define HBLK ESC "[0;90m"
-#define HRED ESC "[0;91m"
-#define HGRN ESC "[0;92m"
-#define HYEL ESC "[0;93m"
-#define HBLU ESC "[0;94m"
-#define HMAG ESC "[0;95m"
-#define HCYN ESC "[0;96m"
-#define HWHT ESC "[0;97m"
-
-//Bold high intensity text
-#define BHBLK ESC "[1;90m"
-#define BHRED ESC "[1;91m"
-#define BHGRN ESC "[1;92m"
-#define BHYEL ESC "[1;93m"
-#define BHBLU ESC "[1;94m"
-#define BHMAG ESC "[1;95m"
-#define BHCYN ESC "[1;96m"
-#define BHWHT ESC "[1;97m"
-
-//Reset
-#define RESET ESC "[0m"
-#define CRESET ESC "[0m"
-#define COLOR_RESET ESC "[0m"
-
-/*
-** {====================================================================
 ** Pluto configuration
 ** =====================================================================}
 */
@@ -965,5 +883,151 @@
 #endif
 
 #endif // PLUTO_VMDUMP
+
+/*
+** {====================================================================
+** Pluto color macros.
+** =====================================================================}
+*/
+
+#ifdef PLUTO_USE_COLORED_OUTPUT // Don't need to write any 'ifdef' macro logic inside of Pluto::ErrorMessage.
+#define ESC "\x1B"
+
+#define BLK ESC "[0;30m"
+#define RED ESC "[0;31m"
+#define GRN ESC "[0;32m"
+#define YEL ESC "[0;33m"
+#define BLU ESC "[0;34m"
+#define MAG ESC "[0;35m"
+#define CYN ESC "[0;36m"
+#define WHT ESC "[0;37m"
+
+//Regular bold text
+#define BBLK ESC "[1;30m"
+#define BRED ESC "[1;31m"
+#define BGRN ESC "[1;32m"
+#define BYEL ESC "[1;33m"
+#define BBLU ESC "[1;34m"
+#define BMAG ESC "[1;35m"
+#define BCYN ESC "[1;36m"
+#define BWHT ESC "[1;37m"
+
+//Regular underline text
+#define UBLK ESC "[4;30m"
+#define URED ESC "[4;31m"
+#define UGRN ESC "[4;32m"
+#define UYEL ESC "[4;33m"
+#define UBLU ESC "[4;34m"
+#define UMAG ESC "[4;35m"
+#define UCYN ESC "[4;36m"
+#define UWHT ESC "[4;37m"
+
+//Regular background
+#define BLKB ESC "[40m"
+#define REDB ESC "[41m"
+#define GRNB ESC "[42m"
+#define YELB ESC "[43m"
+#define BLUB ESC "[44m"
+#define MAGB ESC "[45m"
+#define CYNB ESC "[46m"
+#define WHTB ESC "[47m"
+
+//High intensty background 
+#define BLKHB ESC "[0;100m"
+#define REDHB ESC "[0;101m"
+#define GRNHB ESC "[0;102m"
+#define YELHB ESC "[0;103m"
+#define BLUHB ESC "[0;104m"
+#define MAGHB ESC "[0;105m"
+#define CYNHB ESC "[0;106m"
+#define WHTHB ESC "[0;107m"
+
+//High intensty text
+#define HBLK ESC "[0;90m"
+#define HRED ESC "[0;91m"
+#define HGRN ESC "[0;92m"
+#define HYEL ESC "[0;93m"
+#define HBLU ESC "[0;94m"
+#define HMAG ESC "[0;95m"
+#define HCYN ESC "[0;96m"
+#define HWHT ESC "[0;97m"
+
+//Bold high intensity text
+#define BHBLK ESC "[1;90m"
+#define BHRED ESC "[1;91m"
+#define BHGRN ESC "[1;92m"
+#define BHYEL ESC "[1;93m"
+#define BHBLU ESC "[1;94m"
+#define BHMAG ESC "[1;95m"
+#define BHCYN ESC "[1;96m"
+#define BHWHT ESC "[1;97m"
+
+//Reset
+#define RESET ESC "[0m"
+#define CRESET ESC "[0m"
+#define COLOR_RESET ESC "[0m"
+#else // PLUTO_USE_COLORED_OUTPUT
+#define ESC ""
+#define BLK ESC
+#define RED ESC
+#define GRN ESC
+#define YEL ESC
+#define BLU ESC
+#define MAG ESC
+#define CYN ESC
+#define WHT ESC
+#define BBLK ESC
+#define BRED ESC
+#define BGRN ESC
+#define BYEL ESC
+#define BBLU ESC
+#define BMAG ESC
+#define BCYN ESC
+#define BWHT ESC
+#define UBLK ESC
+#define URED ESC
+#define UGRN ESC
+#define UYEL ESC
+#define UBLU ESC
+#define UMAG ESC
+#define UCYN ESC
+#define UWHT ESC
+#define BLKB ESC
+#define REDB ESC
+#define GRNB ESC
+#define YELB ESC
+#define BLUB ESC
+#define MAGB ESC
+#define CYNB ESC
+#define WHTB ESC
+#define BLKHB ESC
+#define REDHB ESC
+#define GRNHB ESC
+#define YELHB ESC
+#define BLUHB ESC
+#define MAGHB ESC
+#define CYNHB ESC
+#define WHTHB ESC
+#define HBLK ESC
+#define HRED ESC
+#define HGRN ESC
+#define HYEL ESC
+#define HBLU ESC
+#define HMAG ESC
+#define HCYN ESC
+#define HWHT ESC
+#define BHBLK ESC
+#define BHRED ESC
+#define BHGRN ESC
+#define BHYEL ESC
+#define BHBLU ESC
+#define BHMAG ESC
+#define BHCYN ESC
+#define BHWHT ESC
+#define RESET ESC
+#define CRESET ESC
+#define COLOR_RESET ESC
+#endif // PLUTO_USE_COLORED_OUTPUT
+
 
 /* }================================================================== */


### PR DESCRIPTION
- [x] Improve instances of generic error messages.
- [x] Make `Pluto::ErrorMessage` compatible with short errors.
- [x] Make `Pluto::ErrorMessage` compatible with the colored error feature.  
- [x] Improve existing implementations of parser error messages, their code is garbage in comparison right now.

Closes #122