### PR TITLE
Support building with Sun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /src/*.exe
 /src/*.dll
 /src/*.a
+/src/*.lib
 /tbytecode.script
 /luac.out
 /tests/quick.lua

--- a/src/.sun
+++ b/src/.sun
@@ -1,0 +1,4 @@
++*.cpp
+-lua.cpp
+-luac.cpp
+static

--- a/src/dynamic.sun
+++ b/src/dynamic.sun
@@ -1,0 +1,2 @@
++*.cpp
+dynamic

--- a/src/dynamic.sun
+++ b/src/dynamic.sun
@@ -1,2 +1,4 @@
 +*.cpp
+-lua.cpp
+-luac.cpp
 dynamic

--- a/src/pluto.sun
+++ b/src/pluto.sun
@@ -1,0 +1,3 @@
+require .
+name pluto
++lua.cpp

--- a/src/plutoc.sun
+++ b/src/plutoc.sun
@@ -1,0 +1,3 @@
+require .
+name plutoc
++luac.cpp


### PR DESCRIPTION
As of the latest Sun commit, I'd say it's ready for building Pluto. I've set up the following:

- static library: `sun`
- dynamic/shared library: `sun dynamic`
- "pluto" executable (lua.cpp): `sun pluto`
- "plutoc" executable (luac.cpp): `sun plutoc`

Although I wouldn't yet use it for GH Actions since it's not entirely clear to me where the workers would get the Sun executable from.