### PR TITLE
Optimize instances of `table.insert(t, 0)`

### DIFF
--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -58,7 +58,7 @@ static void checktab (lua_State *L, int arg, int what) {
 }
 
 
-static int tinsert (lua_State *L) {
+LUAI_FUNC int tinsert (lua_State *L) {
   lua_Integer pos;  /* where to insert new element */
   lua_Integer e = aux_getn(L, 1, TAB_RW);
   e = luaL_intop(+, e, 1);  /* first empty element */

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -2185,9 +2185,9 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
 #ifdef PLUTO_ILP_HOOK_FUNCTION
         if (fvalue(s2v(ra)) == PLUTO_ILP_HOOK_FUNCTION) sequentialJumps = 0;
 #endif
-        if (fvalue(s2v(ra)) == tinsert && ttistable(s2v(ra - 1))) {
+        if (fvalue(s2v(ra)) == tinsert && ttistable(s2v(ra + 1))) {
           if (!ttisnil(s2v(ra + 2)) && ttisnil(s2v(ra + 3))) {
-            Table* table = hvalue(s2v(ra - 1));
+            Table* table = hvalue(s2v(ra + 1));
             luaH_setint(L, table, luaH_getn(table) + 1, s2v(ra + 2));
           }
         }

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -2188,7 +2188,8 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         if (fvalue(s2v(ra)) == tinsert && ttistable(s2v(ra + 1))) {
           if (ttisnil(s2v(ra + 3))) {
             Table* table = hvalue(s2v(ra + 1));
-            luaH_setint(L, table, luaH_getn(table) + 1, s2v(ra + 2));
+			if (!table->length) table->length = luaH_getn(table);  /* ensure table has cached length */
+            luaH_setint(L, table, ++table->length, s2v(ra + 2));
           }
         }
         else {

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -2185,12 +2185,10 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
 #ifdef PLUTO_ILP_HOOK_FUNCTION
         if (fvalue(s2v(ra)) == PLUTO_ILP_HOOK_FUNCTION) sequentialJumps = 0;
 #endif
-        if (fvalue(s2v(ra)) == tinsert && ttistable(s2v(ra + 1))) {
-          if (ttisnil(s2v(ra + 3))) {
-            Table* table = hvalue(s2v(ra + 1));
-			if (!table->length) table->length = luaH_getn(table);  /* ensure table has cached length */
-            luaH_setint(L, table, ++table->length, s2v(ra + 2));
-          }
+        if (fvalue(s2v(ra)) == tinsert && ttistable(s2v(ra + 1)) && ttisnil(s2v(ra + 3))) {
+          Table* table = hvalue(s2v(ra + 1));
+          if (!table->length) table->length = luaH_getn(table);  /* ensure table has cached length */
+          luaH_setint(L, table, ++table->length, s2v(ra + 2));
         }
         else {
           if ((newci = luaD_precall(L, ra, nresults)) == NULL)  /* C call; nothing else to be done */

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -2186,7 +2186,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         if (fvalue(s2v(ra)) == PLUTO_ILP_HOOK_FUNCTION) sequentialJumps = 0;
 #endif
         if (fvalue(s2v(ra)) == tinsert && ttistable(s2v(ra + 1))) {
-          if (!ttisnil(s2v(ra + 2)) && ttisnil(s2v(ra + 3))) {
+          if (ttisnil(s2v(ra + 3))) {
             Table* table = hvalue(s2v(ra + 1));
             luaH_setint(L, table, luaH_getn(table) + 1, s2v(ra + 2));
           }

--- a/tests/bench/tinsert.lua
+++ b/tests/bench/tinsert.lua
@@ -1,0 +1,21 @@
+local t
+
+t = os.clock()
+do
+	local b = {}
+	for i = 1, 1000000 do
+		table.insert(b, "hello")
+	end
+end
+t = os.clock() - t
+print(t)
+
+t = os.clock()
+do
+	local b = {}
+	for i = 1, 1000000 do
+		b[#b + 1] = "hello"
+	end
+end
+t = os.clock() - t
+print(t)


### PR DESCRIPTION
The behavior of OP_CALL inside of the vm dispatch loop is modified to manually perform `t[#t + 1] = v` whenever table.insert is used with two parameters. Yields a 3x speed increase.