### PR TITLE
Optimize instances of `table.insert(x, y)`

### DIFF
--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -58,7 +58,7 @@ static void checktab (lua_State *L, int arg, int what) {
 }
 
 
-static int tinsert (lua_State *L) {
+LUAI_FUNC int tinsert (lua_State *L) {
   lua_Integer pos;  /* where to insert new element */
   lua_Integer e = aux_getn(L, 1, TAB_RW);
   e = luaL_intop(+, e, 1);  /* first empty element */

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -1174,6 +1174,7 @@ void luaV_finishOp (lua_State *L) {
 */
 LUAI_FUNC int luaB_next (lua_State *L);
 LUAI_FUNC int luaB_ipairsaux (lua_State *L);
+LUAI_FUNC int tinsert(lua_State * L);
 
 
 #ifdef PLUTO_VMDUMP
@@ -2184,16 +2185,23 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
 #ifdef PLUTO_ILP_HOOK_FUNCTION
         if (fvalue(s2v(ra)) == PLUTO_ILP_HOOK_FUNCTION) sequentialJumps = 0;
 #endif
-        if ((newci = luaD_precall(L, ra, nresults)) == NULL)  /* C call; nothing else to be done */
-        {
-          updatetrap(ci);
-          vmDumpOut("; call cfunc (nresults=" << nresults << " nparams=" << nresults << ")");
+        if (fvalue(s2v(ra)) == tinsert && ttistable(s2v(ra + 1)) && ttisnil(s2v(ra + 3))) {
+          Table* table = hvalue(s2v(ra + 1));
+          if (!table->length) table->length = luaH_getn(table);  /* ensure table has cached length */
+          luaH_setint(L, table, ++table->length, s2v(ra + 2));
         }
-        else  /* Lua call: run function in this same C frame */
-        {
-          vmDumpOut("; call lfunc (nresults=" << nresults << " nparams=" << nresults << ")");
-          ci = newci;
-          goto startfunc;
+        else {
+          if ((newci = luaD_precall(L, ra, nresults)) == NULL)  /* C call; nothing else to be done */
+          {
+            updatetrap(ci);
+            vmDumpOut("; call cfunc (nresults=" << nresults << " nparams=" << nresults << ")");
+          }
+          else  /* Lua call: run function in this same C frame */
+          {
+            vmDumpOut("; call lfunc (nresults=" << nresults << " nparams=" << nresults << ")");
+            ci = newci;
+            goto startfunc;
+          }
         }
         vmbreak;
       }

--- a/tests/bench/tinsert.lua
+++ b/tests/bench/tinsert.lua
@@ -1,0 +1,21 @@
+local t
+
+t = os.clock()
+do
+	local b = {}
+	for i = 1, 1000000 do
+		table.insert(b, "hello")
+	end
+end
+t = os.clock() - t
+print(t)
+
+t = os.clock()
+do
+	local b = {}
+	for i = 1, 1000000 do
+		b[#b + 1] = "hello"
+	end
+end
+t = os.clock() - t
+print(t)


### PR DESCRIPTION
Alters handling of OP_CALL inside of vm dispatch loop to manually insert element when `table.insert(x, y)` is used with two arguments. Yields a 3x increase in performance.