### PR TITLE
Improve unknown attribute error

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2783,9 +2783,12 @@ static int getlocalattribute (LexState *ls) {
       return RDKCONST;  /* read-only variable */
     else if (strcmp(attr, "close") == 0)
       return RDKTOCLOSE;  /* to-be-closed variable */
-    else
+    else {
+      luaX_prev(ls); // back to '>'
+      luaX_prev(ls); // back to attribute
       luaK_semerror(ls,
         luaO_pushfstring(ls->L, "unknown attribute '%s'", attr));
+    }
   }
   return VDKREG;  /* regular variable */
 }


### PR DESCRIPTION
Very minor thing, but
```Lua
local test <deez
>
```
will indicate that the error is on line 2. This patch will put the lexer on the right token before reporting the error.