### PR TITLE
Improve lexerror

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -167,11 +167,12 @@ static const char *txtToken (LexState *ls, int token) {
     err.addMsg(msg);
     if (ls->t.IsReserved())
     {
-      err.addMsg(", but found reserved keyword ")
-         .addMsg(txtToken(ls, token))
-         .addSrcLine(ls->getLineNumber())
-         .addGenericHere("reserved keyword cannot be used in this context.")
-         .addNote("Reserved keywords *can* be used outside of relevant contexts, but this is a relevant context!")
+      std::string str = txtToken(ls, token);
+      err.addMsg(", but found ")
+         .addMsg(str);
+      str.append(" cannot be used in this context.");
+      err.addSrcLine(ls->getLineNumber())
+         .addGenericHere(str)
          .finalize();
     }
     else


### PR DESCRIPTION
Attempting to fix #141 while not introducing regressions.

---
```Lua
for t end
```
```
syntax error: test.lua:1: '=' or 'in' expected, but found 'end'
    1 | for t end
      | ^^^^^^^^^ here: 'end' cannot be used in this context.
```
---

```Lua
local function f(if) end
```
```
test.lua:1: <name> or '...' expected, but found 'if'
    1 | local function f(if) end
      | ^^^^^^^^^^^^^^^^^^^^^^^^ here: 'if' cannot be used in this context.
```