### PR TITLE
Deprecate pluto_case & pluto_default

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -45,16 +45,11 @@ static const char *const luaX_tokens [] = {
     "and", "break", "do", "else", "elseif",
     "end", "false", "for", "function", "goto", "if",
     "in", "local", "nil", "not", "or", "repeat",
-    "as",
-    "pluto_switch", "pluto_case", "pluto_default", "pluto_continue", "pluto_when",
+    "case", "default", "as",
+    "pluto_switch", "pluto_continue", "pluto_when",
+    "pluto_case", "pluto_default",
 #ifndef PLUTO_COMPATIBLE_SWITCH
     "switch",
-#endif
-#ifndef PLUTO_COMPATIBLE_CASE
-    "case",
-#endif
-#ifndef PLUTO_COMPATIBLE_DEFAULT
-    "default",
 #endif
 #ifndef PLUTO_COMPATIBLE_CONTINUE
     "continue",

--- a/src/llex.h
+++ b/src/llex.h
@@ -37,17 +37,12 @@ enum RESERVED {
   TK_AND = FIRST_RESERVED, TK_BREAK,
   TK_DO, TK_ELSE, TK_ELSEIF, TK_END, TK_FALSE, TK_FOR, TK_FUNCTION,
   TK_GOTO, TK_IF, TK_IN, TK_LOCAL, TK_NIL, TK_NOT, TK_OR, TK_REPEAT,
-  TK_AS, // New narrow keywords.
-  TK_PSWITCH, TK_PCASE, TK_PDEFAULT, TK_PCONTINUE, TK_PWHEN, // New compatibility keywords.
+  TK_CASE, TK_DEFAULT, TK_AS, // New narrow keywords.
+  TK_PSWITCH, TK_PCONTINUE, TK_PWHEN, // New compatibility keywords.
+  TK_PCASE, TK_PDEFAULT, // Deprecated compatibility keywords.
   /* New non-compatible keywords. */
 #ifndef PLUTO_COMPATIBLE_SWITCH
   TK_SWITCH,
-#endif
-#ifndef PLUTO_COMPATIBLE_CASE
-  TK_CASE,
-#endif
-#ifndef PLUTO_COMPATIBLE_DEFAULT
-  TK_DEFAULT,
 #endif
 #ifndef PLUTO_COMPATIBLE_CONTINUE
   TK_CONTINUE,
@@ -118,15 +113,11 @@ struct Token {
   [[nodiscard]] bool IsNarrow() const noexcept
   {
     return token == TK_IN
-      || token == TK_AS
-      || token == TK_PDEFAULT
-#ifndef PLUTO_COMPATIBLE_DEFAULT
-      || token == TK_DEFAULT
-#endif
-      || token == TK_PCASE
-#ifndef PLUTO_COMPATIBLE_CASE
       || token == TK_CASE
-#endif
+      || token == TK_DEFAULT
+      || token == TK_AS
+      || token == TK_PCASE
+      || token == TK_PDEFAULT
       ;
   }
 };
@@ -146,6 +137,7 @@ enum WarningType : int
   TYPE_MISMATCH,
   UNREACHABLE_CODE,
   EXCESSIVE_ARGUMENTS,
+  WT_DEPRECATED,
 
   NUM_WARNING_TYPES
 };
@@ -157,6 +149,7 @@ static const std::vector<std::string> luaX_warnNames = {
   "type-mismatch",
   "unreachable-code",
   "excessive-arguments",
+  "deprecated",
 };
 
 

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -817,10 +817,6 @@
 #define PLUTO_COMPATIBLE_SWITCH
 
 // If defined, only 'pluto_... you get the idea.
-#define PLUTO_COMPATIBLE_CASE
-
-#define PLUTO_COMPATIBLE_DEFAULT
-
 #define PLUTO_COMPATIBLE_CONTINUE
 
 #define PLUTO_COMPATIBLE_WHEN

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -279,216 +279,216 @@ print "Testing switch statement."
 do
     local value = 5
     pluto_switch (value) do
-        pluto_case 5:
+        case 5:
         break
-        pluto_default:
+        default:
         error()
     end
     value = 3
     pluto_switch value do
-        pluto_case 1:
-        pluto_case 2:
-        pluto_case 3:
-        pluto_case 4:
-        pluto_case 5:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
         break
-        pluto_default:
+        default:
         error()
     end
     do
         local casecond <const> = 3
         pluto_switch value do
-            pluto_case casecond:
+            case casecond:
             break
-            pluto_default:
+            default:
             error()
         end
     end
     do
         local casecond = 3
         pluto_switch value do
-            pluto_case casecond:
+            case casecond:
             break
-            pluto_default:
+            default:
             error()
         end
     end
     do
         local casecond <const> = 3
         pluto_switch value do
-            pluto_default:
+            default:
             error()
-            pluto_case casecond:
+            case casecond:
         end
     end
     do
         local casecond = 3
         pluto_switch value do
-            pluto_default:
+            default:
             error()
-            pluto_case casecond:
+            case casecond:
         end
     end
     value = +3
     pluto_switch value do
-        pluto_case +1:
-        pluto_case +2:
-        pluto_case +3:
-        pluto_case +4:
-        pluto_case +5:
+        case +1:
+        case +2:
+        case +3:
+        case +4:
+        case +5:
         break
-        pluto_default:
+        default:
         error()
     end
     value = "foo"
     pluto_switch (value) do
-        pluto_case "foo":
+        case "foo":
         break
-        pluto_default:
+        default:
         error()
     end
     pluto_switch (value) do
-        pluto_case "abc":
-        pluto_case "124":
-        pluto_case nil:
-        pluto_case false:
-        pluto_case true:
-        pluto_case "23420948239":
-        pluto_case "foo":
-        pluto_case 1238123:
-        pluto_case -2409384029842:
-        pluto_case "awweee":
+        case "abc":
+        case "124":
+        case nil:
+        case false:
+        case true:
+        case "23420948239":
+        case "foo":
+        case 1238123:
+        case -2409384029842:
+        case "awweee":
         break
-        pluto_default:
+        default:
         error()
     end
     value = nil
     pluto_switch (value) do
-        pluto_case -1:
-        pluto_case nil:
-        pluto_case -2:
+        case -1:
+        case nil:
+        case -2:
         break
-        pluto_default:
+        default:
         error()
     end
     value = -24389
     pluto_switch (value) do
-        pluto_case "aawdkawmlwadmlaw":
-        pluto_case "q49324932":
-        pluto_case nil:
-        pluto_case "130-91230921":
-        pluto_case false:
-        pluto_case 231923:
-        pluto_case true:
-        pluto_case -234234:
-        pluto_case -24389:
-        pluto_case 23429:
-        pluto_case "bar":
-        pluto_case "foobar":
-        pluto_case "barfoo":
+        case "aawdkawmlwadmlaw":
+        case "q49324932":
+        case nil:
+        case "130-91230921":
+        case false:
+        case 231923:
+        case true:
+        case -234234:
+        case -24389:
+        case 23429:
+        case "bar":
+        case "foobar":
+        case "barfoo":
         break
-        pluto_default: 
+        default: 
         error()
     end
     value = -1
     pluto_switch (value) do
-        pluto_case "aawdkawmlwadmlaw":
-        pluto_case "q49324932":
-        pluto_case nil:
-        pluto_case "130-91230921":
-        pluto_case false:
-        pluto_case 231923:
-        pluto_case true:
-        pluto_case -234234:
-        pluto_case -24389:
-        pluto_case 23429:
-        pluto_case "bar":
-        pluto_case "foobar":
-        pluto_case "barfoo":
+        case "aawdkawmlwadmlaw":
+        case "q49324932":
+        case nil:
+        case "130-91230921":
+        case false:
+        case 231923:
+        case true:
+        case -234234:
+        case -24389:
+        case 23429:
+        case "bar":
+        case "foobar":
+        case "barfoo":
         error()
     end
     value = -3.14
     pluto_switch (value) do
-        pluto_case "aawdkawmlwadmlaw":
-        pluto_case "q49324932":
-        pluto_case nil:
-        pluto_case "130-91230921":
-        pluto_case false:
-        pluto_case -3.14:
-        pluto_case true:
-        pluto_case -234234:
-        pluto_case -24389:
-        pluto_case 23429:
-        pluto_case "bar":
-        pluto_case "foobar":
-        pluto_case "barfoo":
+        case "aawdkawmlwadmlaw":
+        case "q49324932":
+        case nil:
+        case "130-91230921":
+        case false:
+        case -3.14:
+        case true:
+        case -234234:
+        case -24389:
+        case 23429:
+        case "bar":
+        case "foobar":
+        case "barfoo":
         break
     end
     value = -3.3
     pluto_switch (value) do
-        pluto_case "aawdkawmlwadmlaw":
-        pluto_case "q49324932":
-        pluto_case nil:
-        pluto_case "130-91230921":
-        pluto_case false:
-        pluto_case -3.15:
-        pluto_case true:
-        pluto_case -234234:
-        pluto_case -24389:
-        pluto_case 23429:
-        pluto_case "bar":
-        pluto_case "foobar":
-        pluto_case "barfoo":
+        case "aawdkawmlwadmlaw":
+        case "q49324932":
+        case nil:
+        case "130-91230921":
+        case false:
+        case -3.15:
+        case true:
+        case -234234:
+        case -24389:
+        case 23429:
+        case "bar":
+        case "foobar":
+        case "barfoo":
         error()
     end
     t = 0
     value = -3.15
     pluto_switch (value) do
-        pluto_case "aawdkawmlwadmlaw":
-        pluto_case "q49324932":
-        pluto_case nil:
-        pluto_case "130-91230921":
-        pluto_case false:
-        pluto_case -3.15:
-        pluto_case true:
-        pluto_case -234234:
-        pluto_case -24389:
-        pluto_case 23429:
-        pluto_case "bar":
-        pluto_case "foobar":
-        pluto_case "barfoo":
+        case "aawdkawmlwadmlaw":
+        case "q49324932":
+        case nil:
+        case "130-91230921":
+        case false:
+        case -3.15:
+        case true:
+        case -234234:
+        case -24389:
+        case 23429:
+        case "bar":
+        case "foobar":
+        case "barfoo":
         t = true
     end
     assert(t == true)
     t = 0
     value = -3.15
     pluto_switch (value) do
-        pluto_case "aawdkawmlwadmlaw":
-        pluto_case "q49324932":
-        pluto_case nil:
-        pluto_case "130-91230921":
-        pluto_case false:
-        pluto_case -3.15:
-        pluto_case true:
-        pluto_case -234234:
-        pluto_case -24389:
-        pluto_case 23429:
-        pluto_case "bar":
-        pluto_case "foobar":
-        pluto_case "barfoo":
+        case "aawdkawmlwadmlaw":
+        case "q49324932":
+        case nil:
+        case "130-91230921":
+        case false:
+        case -3.15:
+        case true:
+        case -234234:
+        case -24389:
+        case 23429:
+        case "bar":
+        case "foobar":
+        case "barfoo":
         t = true
         break
-        pluto_default:
+        default:
         t = false
     end
     assert(t == true)
     t = 0
     value = 3
     pluto_switch value do
-        pluto_case 1:
-        pluto_default:
+        case 1:
+        default:
         error()
-        pluto_case 3:
+        case 3:
         t = true
     end
     assert(t == true)


### PR DESCRIPTION
This takes the steps as described in #140 for 0.5.0. Also added "deprecated" warning type and reordered some things for clarity & to promote the more likely cases.