### PR TITLE
Improve shadow warning

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -472,7 +472,7 @@ static int new_localvar (LexState *ls, TString *name, int line, const TypeDesc& 
     if ((n != "(for state)" && n != "(switch control value)") && (local && local->varname == name)) { // Got a match.
       throw_warn(ls,
         "duplicate local declaration",
-          luaO_fmt(L, "this shadows the value of the initial declaration on line %d.", desc->vd.line), VAR_SHADOW);
+          luaO_fmt(L, "this shadows the initial declaration of '%s' on line %d.", name->contents, desc->vd.line), VAR_SHADOW);
       L->top--; /* pop result of luaO_fmt */
       break;
     }


### PR DESCRIPTION
In a case like this:
```Lua
local k
-- ...
local t = {"deez"}
for k, v in t do
    print(k .. ": " .. v)
end
```
It would be somewhat ambiguous if "k" or "v" is shadowing, so I adjusted the warning to say the name of the variable in question:
```
test.lua:4: warning: duplicate local declaration [var-shadow]
    4 | for k, v in t do
      | ^^^^^^^^^^^^^^^^ here: this shadows the initial declaration of 'k' on line 1.
```