### PR TITLE
Fix io.open not using UTF-8 on Windows

### DIFF
--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -780,7 +780,7 @@
 // If defined, Pluto will exclude code snippets from error messages to make them shorter.
 //#define PLUTO_SHORT_ERRORS
 
-// If defined, Pluto won't assume that files are UTF-8 encoded and restrict valid names.
+// If defined, Pluto won't assume that source files are UTF-8 encoded and restrict valid symbol names.
 //#define PLUTO_NO_UTF8
 
 // If defined, Pluto will use a jumptable in the VM even if not compiled via GCC.


### PR DESCRIPTION
As explained in #158, io.listdir uses UTF-8 for resulting paths, but io.open does not accept UTF-8 encoded paths. I've also concluded that this issue only affects Windows systems, so this is me fixing the behaviour on Windows.