### PR TITLE
Fix asserts

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1963,7 +1963,6 @@ static void inexpr (LexState *ls, expdesc *v) {
   luaK_exp2nextreg(ls->fs, v);
   luaK_exp2nextreg(ls->fs, &v2);
   luaK_codeABC(ls->fs, OP_IN, v->u.info, v2.u.info, 0);
-  luaK_storevar(ls->fs, v, v);
 }
 
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1636,7 +1636,7 @@ static void safe_navigation(LexState *ls, expdesc *v) {
   {
     int old_free = fs->freereg;             
     int vreg = v->u.info;
-    int j = luaK_codeAsBx(fs, OP_JMP, 0, NO_JUMP);
+    int j = luaK_jump(fs);
     expdesc key;
     switch(ls->t.token) {
       case '[': {
@@ -1678,7 +1678,7 @@ static void safe_navigation(LexState *ls, expdesc *v) {
       luaK_codeABC(fs, OP_MOVE, vreg, v->u.info, 0);
       v->u.info = vreg;
     }
-    SETARG_sBx(fs->f->code[j], fs->pc-j - 1);
+    luaK_patchtohere(fs, j);
   }
 }
 


### PR DESCRIPTION
It's quite ugly when building with `LUAI_ASSERT`.

There still seems to be a consistent assert with in expressions:
```Lua
if ("hel" in "hello") != true then error() end
if ("abc" in "hello") != false then error() end
```