### PR TITLE
Add constexpr call syntax for preloaded libraries

### DIFF
--- a/Pluto.vcxproj.filters
+++ b/Pluto.vcxproj.filters
@@ -38,6 +38,7 @@
     <ClCompile Include="src\lbase64.cpp" />
     <ClCompile Include="src\lbase58.cpp" />
     <ClCompile Include="src\lbase32.cpp" />
+    <ClCompile Include="src\ljson.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\ltm.h" />
@@ -71,5 +72,6 @@
     <ClInclude Include="src\ljumptab.h" />
     <ClInclude Include="src\lcryptolib.hpp" />
     <ClInclude Include="src\ErrorMessage.hpp" />
+    <ClInclude Include="src\ljson.hpp" />
   </ItemGroup>
 </Project>

--- a/src/lauxlib.h
+++ b/src/lauxlib.h
@@ -37,6 +37,14 @@ typedef struct luaL_Reg {
 } luaL_Reg;
 
 
+namespace Pluto {
+  struct Preloaded {
+    const char* name;
+    const luaL_Reg* funcs;
+  };
+}
+
+
 #define LUAL_NUMSIZES	(sizeof(lua_Integer)*16 + sizeof(lua_Number))
 
 LUALIB_API void (luaL_checkversion_) (lua_State *L, lua_Number ver, size_t sz);

--- a/src/lbase32.cpp
+++ b/src/lbase32.cpp
@@ -21,6 +21,8 @@ static const luaL_Reg funcs[] = {
 	{nullptr, nullptr}
 };
 
+const Pluto::Preloaded Pluto::preloaded_base32{ "base32", funcs };
+
 LUAMOD_API int luaopen_base32(lua_State* L) {
 	luaL_newlib(L, funcs);
 	return 1;

--- a/src/lbase58.cpp
+++ b/src/lbase58.cpp
@@ -33,6 +33,8 @@ static const luaL_Reg funcs[] = {
 	{nullptr, nullptr}
 };
 
+const Pluto::Preloaded Pluto::preloaded_base58{ "base58", funcs };
+
 LUAMOD_API int luaopen_base58(lua_State* L) {
 	luaL_newlib(L, funcs);
 	return 1;

--- a/src/lbase64.cpp
+++ b/src/lbase64.cpp
@@ -34,6 +34,8 @@ static const luaL_Reg funcs[] = {
 	{nullptr, nullptr}
 };
 
+const Pluto::Preloaded Pluto::preloaded_base64{ "base64", funcs };
+
 LUAMOD_API int luaopen_base64(lua_State* L) {
 	luaL_newlib(L, funcs);
 	return 1;

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -83,7 +83,7 @@ static const char *b_str2int (const char *s, int base, lua_Integer *pn) {
 }
 
 
-static int luaB_tonumber (lua_State *L) {
+int luaB_tonumber (lua_State *L) {
   if (lua_isnoneornil(L, 2)) {  /* standard conversion? */
     if (lua_type(L, 1) == LUA_TNUMBER) {  /* already a number? */
       lua_settop(L, 1);  /* yes; return it */
@@ -504,7 +504,7 @@ static int luaB_xpcall (lua_State *L) {
 }
 
 
-static int luaB_tostring (lua_State *L) {
+int luaB_tostring (lua_State *L) {
   luaL_checkany(L, 1);
   luaL_tolstring(L, 1, NULL);
   return 1;

--- a/src/lcryptolib.cpp
+++ b/src/lcryptolib.cpp
@@ -319,6 +319,7 @@ static const luaL_Reg funcs[] = {
   {NULL, NULL}  
 };
 
+const Pluto::Preloaded Pluto::preloaded_crypto{ "crypto", funcs };
 
 LUAMOD_API int luaopen_crypto(lua_State *L)
 {

--- a/src/lcryptolib.cpp
+++ b/src/lcryptolib.cpp
@@ -57,7 +57,7 @@ static int joaat(lua_State *L)
   /* get input */
   size_t size;
   const char* data = luaL_checklstring(L, 1, &size);
- 
+
   /* do partial on input */
   size_t v3 = 0;
   uint32_t result = 0; /* initial = 0 */

--- a/src/linit.cpp
+++ b/src/linit.cpp
@@ -77,7 +77,7 @@ LUALIB_API void luaL_openlibs (lua_State *L)
   }
 
   for (lib = preloadedLibs; lib->func; lib++)
-  {  
+  {
     luaL_getsubtable(L, LUA_REGISTRYINDEX, LUA_PRELOAD_TABLE);
     lua_pushcfunction(L, lib->func);
     lua_setfield(L, -2, lib->name);

--- a/src/ljson.cpp
+++ b/src/ljson.cpp
@@ -31,6 +31,8 @@ static const luaL_Reg funcs[] = {
 	{nullptr, nullptr}
 };
 
+const Pluto::Preloaded Pluto::preloaded_json{ "json", funcs };
+
 LUA_API int luaopen_json(lua_State *L) {
 	luaL_newlib(L, funcs);
 	return 1;

--- a/src/ljson.hpp
+++ b/src/ljson.hpp
@@ -93,7 +93,7 @@ static soup::UniquePtr<soup::JsonNode> checkJson(lua_State* L, int i)
 			return obj;
 		}
 	}
-	luaL_typeerror(L, i, "JSON-castable type"); // this will probably raise a compiler warning if you're not using Pluto. Kinda cringe.
+	luaL_typeerror(L, i, "JSON-castable type");
 }
 
 static void pushFromJson(lua_State* L, const soup::JsonNode& node)

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -160,12 +160,13 @@ static const char *txtToken (LexState *ls, int token) {
 
 
 [[noreturn]] static void lexerror (LexState *ls, const char *msg, int token) {
+  const bool is_expected_token_error = (strcmp(msg, "syntax error") != 0);
   msg = luaG_addinfo(ls->L, msg, ls->source, ls->getLineNumber());
   if (token)
   {
     Pluto::ErrorMessage err{ ls, HRED "syntax error: " BWHT};
     err.addMsg(msg);
-    if (ls->t.IsReserved())
+    if (is_expected_token_error && ls->t.IsReserved())
     {
       std::string str = txtToken(ls, token);
       err.addMsg(", but found ")

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1758,22 +1758,22 @@ static void constexpr_call (LexState *ls, expdesc *v, lua_CFunction f) {
   if (ls->t.token != ')') {
     do {
       ++nargs;
-      switch (ls->t.token) {
-        case TK_STRING:
-          lua_pushlstring(L, ls->t.seminfo.ts->contents, ls->t.seminfo.ts->size());
+      auto argline = ls->getLineNumber();
+      expdesc argexp;
+      simpleexp(ls, &argexp, true);
+      switch (argexp.k) {
+        case VKSTR:
+          lua_pushlstring(L, argexp.u.strval->contents, argexp.u.strval->size());
           break;
-        case TK_INT:
-          lua_pushinteger(L, ls->t.seminfo.i);
+        case VKINT:
+          lua_pushinteger(L, argexp.u.ival);
           break;
-        case TK_FLT:
-          lua_pushnumber(L, ls->t.seminfo.r);
+        case VKFLT:
+          lua_pushnumber(L, argexp.u.nval);
           break;
-        default: {
-          const char* token = luaX_token2str(ls, ls->t.token);
-          throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
-        }
+        default:
+          throwerr(ls, "unexpected argument type in constexpr_call", "unexpected argument type", argline);
       }
-      luaX_next(ls);
     } while (testnext(ls, ','));
   }
   check_match(ls, ')', '(', line);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1761,6 +1761,12 @@ static void constexpr_call (LexState *ls, expdesc *v, lua_CFunction f) {
       case TK_STRING:
         lua_pushlstring(L, ls->t.seminfo.ts->contents, ls->t.seminfo.ts->size());
         break;
+      case TK_INT:
+        lua_pushinteger(L, ls->t.seminfo.i);
+        break;
+      case TK_FLT:
+        lua_pushnumber(L, ls->t.seminfo.r);
+        break;
       default: {
         const char* token = luaX_token2str(ls, ls->t.token);
         throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1755,25 +1755,27 @@ static void constexpr_call (LexState *ls, expdesc *v, lua_CFunction f) {
   lua_State *L = ls->L;
   lua_pushcfunction(L, f);
   int nargs = 0;
-  do {
-    ++nargs;
-    switch (ls->t.token) {
-      case TK_STRING:
-        lua_pushlstring(L, ls->t.seminfo.ts->contents, ls->t.seminfo.ts->size());
-        break;
-      case TK_INT:
-        lua_pushinteger(L, ls->t.seminfo.i);
-        break;
-      case TK_FLT:
-        lua_pushnumber(L, ls->t.seminfo.r);
-        break;
-      default: {
-        const char* token = luaX_token2str(ls, ls->t.token);
-        throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
+  if (ls->t.token != ')') {
+    do {
+      ++nargs;
+      switch (ls->t.token) {
+        case TK_STRING:
+          lua_pushlstring(L, ls->t.seminfo.ts->contents, ls->t.seminfo.ts->size());
+          break;
+        case TK_INT:
+          lua_pushinteger(L, ls->t.seminfo.i);
+          break;
+        case TK_FLT:
+          lua_pushnumber(L, ls->t.seminfo.r);
+          break;
+        default: {
+          const char* token = luaX_token2str(ls, ls->t.token);
+          throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
+        }
       }
-    }
-    luaX_next(ls);
-  } while (testnext(ls, ','));
+      luaX_next(ls);
+    } while (testnext(ls, ','));
+  }
   check_match(ls, ')', '(', line);
   int status = lua_pcall(L, nargs, 1, 0);
   lua_assert(status == LUA_OK);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1778,7 +1778,9 @@ static void constexpr_call (LexState *ls, expdesc *v, lua_CFunction f) {
   }
   check_match(ls, ')', '(', line);
   int status = lua_pcall(L, nargs, 1, 0);
-  lua_assert(status == LUA_OK);
+  if (status != LUA_OK) {
+    throwerr(ls, lua_tostring(L, -1), "error in constexpr_call", line);
+  }
   switch (lua_type(L, -1)) {
     case LUA_TNUMBER: {
       if (lua_isinteger(L, -1)) {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -21,6 +21,7 @@
 
 #include "lua.h"
 #include "lualib.h" // Pluto::all_preloaded
+#include "lapi.h" // api_incr_top
 #include "lcode.h"
 #include "ldebug.h"
 #include "ldo.h"
@@ -1770,6 +1771,12 @@ static void constexpr_call (LexState *ls, expdesc *v, lua_CFunction f) {
           break;
         case VKFLT:
           lua_pushnumber(L, argexp.u.nval);
+          break;
+        case VCONST:
+          lua_lock(L);
+          *s2v(L->top) = ls->dyd->actvar.arr[argexp.u.info].k;
+          api_incr_top(L);
+          lua_unlock(L);
           break;
         default:
           throwerr(ls, "unexpected argument type in constexpr_call", "unexpected argument type", argline);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1772,6 +1772,15 @@ static void constexpr_call (LexState *ls, expdesc *v, lua_CFunction f) {
         case VKFLT:
           lua_pushnumber(L, argexp.u.nval);
           break;
+        case VTRUE:
+          lua_pushboolean(L, true);
+          break;
+        case VFALSE:
+          lua_pushboolean(L, false);
+          break;
+        case VNIL:
+          lua_pushnil(L);
+          break;
         case VCONST:
           lua_lock(L);
           *s2v(L->top) = ls->dyd->actvar.arr[argexp.u.info].k;

--- a/src/lualib.h
+++ b/src/lualib.h
@@ -6,6 +6,7 @@
 */
 
 #include "lua.h"
+#include "lauxlib.h" // Pluto::Preloaded
 
 
 /* version suffix for environment variable names */
@@ -41,6 +42,25 @@ LUAMOD_API int (luaopen_debug) (lua_State *L);
 #define LUA_LOADLIBNAME	"package"
 LUAMOD_API int (luaopen_package) (lua_State *L);
 
+namespace Pluto {
+  extern const Preloaded preloaded_crypto;
+#ifdef PLUTO_USE_SOUP
+  extern const Preloaded preloaded_json;
+  extern const Preloaded preloaded_base32;
+  extern const Preloaded preloaded_base58;
+  extern const Preloaded preloaded_base64;
+#endif
+
+  inline const Preloaded* const all_preloaded[] = {
+    &preloaded_crypto,
+#ifdef PLUTO_USE_SOUP
+    &preloaded_json,
+    &preloaded_base32,
+    &preloaded_base58,
+    &preloaded_base64,
+#endif
+  };
+}
 
 LUAMOD_API int (luaopen_crypto) (lua_State *L);
 #ifdef PLUTO_USE_SOUP

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -560,7 +560,7 @@ do
     assert($crypto.fnv1a("hello world") == 8618312879776256743)
     assert($crypto.joaat("hello world") == 1045060183)
     assert($crypto.hexdigest(1045060183) == "0x3e4a5a57")
-    assert($crypto.joaat("hello world") == tonumber($crypto.hexdigest($crypto.joaat("hello world"))))
+    assert($crypto.joaat("hello world") == $tonumber($crypto.hexdigest($crypto.joaat("hello world"))))
 end
 do
     if _PSOUP then -- Soup is linked.

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -754,6 +754,18 @@ do
     assert((true .. false) == "truefalse")
 end
 
+print "Testing constant expressions."
+do
+    assert($crypto.joaat("Pluto") == 32037948)
+
+    -- They can be chained
+    assert($crypto.hexdigest($crypto.joaat("hello world")) == "0x3e4a5a57")
+
+    -- They accept compile-time constants as argument
+    local str <const> = "Pluto"
+    assert($crypto.joaat(str) == 32037948)
+end
+
 print "Testing compatibility."
 do
     local a = "Hi"

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -553,12 +553,14 @@ do
     assert(crypto.fnv1("hello world") == 0x7DCF62CDB1910E6F)
     assert(crypto.fnv1a("hello world") == 8618312879776256743)
     assert(crypto.joaat("hello world") == 1045060183)
+    assert(crypto.hexdigest(1045060183) == "0x3e4a5a57")
     assert(crypto.joaat("hello world") == tonumber(crypto.hexdigest(crypto.joaat("hello world"))))
     -- Constexpr
     assert($crypto.fnv1("hello world") == 0x7DCF62CDB1910E6F)
     assert($crypto.fnv1a("hello world") == 8618312879776256743)
     assert($crypto.joaat("hello world") == 1045060183)
     assert($crypto.hexdigest(1045060183) == "0x3e4a5a57")
+    assert($crypto.joaat("hello world") == tonumber($crypto.hexdigest($crypto.joaat("hello world"))))
 end
 do
     if _PSOUP then -- Soup is linked.

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -554,6 +554,11 @@ do
     assert(crypto.fnv1a("hello world") == 8618312879776256743)
     assert(crypto.joaat("hello world") == 1045060183)
     assert(crypto.joaat("hello world") == tonumber(crypto.hexdigest(crypto.joaat("hello world"))))
+    -- Constexpr
+    assert($crypto.fnv1("hello world") == 0x7DCF62CDB1910E6F)
+    assert($crypto.fnv1a("hello world") == 8618312879776256743)
+    assert($crypto.joaat("hello world") == 1045060183)
+    assert($crypto.hexdigest(1045060183) == "0x3e4a5a57")
 end
 do
     if _PSOUP then -- Soup is linked.


### PR DESCRIPTION
Might be somewhat cursed to use the parser's lua_State to call functions, but seems fine except for having no function name:
```
...: bad argument #1 to '?' (string expected, got no value)
    1 | local a = $crypto.joaat()
      | ^^^^^^^^^^^^^^^^^^^^^^^^^ here: error in constexpr_call
```