### PR TITLE
Further UTF-8 patches for Windows

### DIFF
--- a/src/lauxlib.cpp
+++ b/src/lauxlib.cpp
@@ -824,7 +824,7 @@ LUALIB_API int luaL_loadfilex (lua_State *L, const char *filename,
   }
   else {
     lua_pushfstring(L, "@%s", filename);
-    lf.f = fopen(filename, "r");
+    lf.f = luaL_fopen(filename, strlen(filename), "r", sizeof("r") - sizeof(char));
     if (lf.f == NULL) return errfile(L, "open", fnameindex);
   }
   lf.n = 0;

--- a/src/lauxlib.cpp
+++ b/src/lauxlib.cpp
@@ -769,7 +769,7 @@ std::wstring luaL_utf8_to_utf16(const char *utf8, size_t utf8_len) {
 std::string luaL_utf16_to_utf8(const wchar_t *utf16, size_t utf16_len) {
   std::string utf8;
   const int sizeRequired = WideCharToMultiByte(CP_UTF8, 0, utf16, (int)utf16_len, nullptr, 0, 0, 0);
-  if (sizeRequired != 0) {
+  if (l_likely(sizeRequired != 0)) {
     utf8 = std::string(sizeRequired, 0);
     WideCharToMultiByte(CP_UTF8, 0, utf16, (int)utf16_len, utf8.data(), sizeRequired, 0, 0);
   }

--- a/src/lauxlib.h
+++ b/src/lauxlib.h
@@ -8,6 +8,10 @@
 #include <stddef.h>
 #include <stdio.h>
 
+#ifdef _WIN32
+#include <string>
+#endif
+
 #include "luaconf.h"
 #include "lua.h"
 
@@ -84,6 +88,11 @@ LUALIB_API int (luaL_execresult) (lua_State *L, int stat);
 
 LUALIB_API int (luaL_ref) (lua_State *L, int t);
 LUALIB_API void (luaL_unref) (lua_State *L, int t, int ref);
+
+#ifdef _WIN32
+LUALIB_API std::wstring luaL_utf8_to_utf16(const char *utf8, size_t utf8_len);
+LUALIB_API std::string luaL_utf16_to_utf8(const wchar_t *utf16, size_t utf16_len);
+#endif
 
 LUALIB_API FILE* (luaL_fopen) (const char *filename, size_t filename_len,
                                const char *mode, size_t mode_len);

--- a/src/lauxlib.h
+++ b/src/lauxlib.h
@@ -85,6 +85,9 @@ LUALIB_API int (luaL_execresult) (lua_State *L, int stat);
 LUALIB_API int (luaL_ref) (lua_State *L, int t);
 LUALIB_API void (luaL_unref) (lua_State *L, int t, int ref);
 
+LUALIB_API FILE* (luaL_fopen) (const char *filename, size_t filename_len,
+                               const char *mode, size_t mode_len);
+
 LUALIB_API int (luaL_loadfilex) (lua_State *L, const char *filename,
                                                const char *mode);
 

--- a/src/liolib.cpp
+++ b/src/liolib.cpp
@@ -263,7 +263,7 @@ static LStream *newfile (lua_State *L) {
 
 static void opencheck (lua_State *L, const char *fname, const char *mode) {
   LStream *p = newfile(L);
-  p->f = fopen(fname, mode);
+  p->f = luaL_fopen(fname, strlen(fname), mode, strlen(mode));
   if (l_unlikely(p->f == NULL))
     luaL_error(L, "cannot open file '%s' (%s)", fname, strerror(errno));
 }

--- a/src/liolib.cpp
+++ b/src/liolib.cpp
@@ -9,7 +9,6 @@
 
 #include "lprefix.h"
 
-#include <string>
 #include <filesystem>
 #include <ctype.h>
 #include <errno.h>
@@ -22,10 +21,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-
-#ifdef _WIN32
-#include <Windows.h>
-#endif
 
 
 /* Basic error handling. Exceptions have better error messages than error_codes. */
@@ -274,19 +269,6 @@ static void opencheck (lua_State *L, const char *fname, const char *mode) {
 }
 
 
-#ifdef _WIN32
-[[nodiscard]] static std::wstring utf8_to_utf16(const char* utf8, size_t utf8_len) {
-  std::wstring utf16;
-  const int sizeRequired = MultiByteToWideChar(CP_UTF8, 0, utf8, (int)utf8_len, nullptr, 0);
-  if (l_likely(sizeRequired != 0)) {
-    utf16 = std::wstring(sizeRequired, 0);
-    MultiByteToWideChar(CP_UTF8, 0, utf8, (int)utf8_len, utf16.data(), sizeRequired);
-  }
-  return utf16;
-}
-#endif
-
-
 static int io_open (lua_State *L) {
   size_t filename_len, mode_len;
   const char *filename = luaL_checklstring(L, 1, &filename_len);
@@ -294,15 +276,7 @@ static int io_open (lua_State *L) {
   LStream *p = newfile(L);
   const char *md = mode;  /* to traverse/check mode */
   luaL_argcheck(L, l_checkmode(md), 2, "invalid mode");
-#ifdef _WIN32
-  // From what I could gather online, UTF-8 is the path encoding convention on *nix systems,
-  // so I've ultimately decided that we should just "fix" the fact that Windows doesn't use UTF-8.
-  std::wstring wfilename = utf8_to_utf16(filename, filename_len);
-  std::wstring wmode = utf8_to_utf16(mode, mode_len);
-  p->f = _wfopen(wfilename.c_str(), wmode.c_str());
-#else
-  p->f = fopen(filename, mode);
-#endif
+  p->f = luaL_fopen(filename, filename_len, mode, mode_len);
 
   if (p->f != nullptr)
   {

--- a/src/loadlib.cpp
+++ b/src/loadlib.cpp
@@ -432,7 +432,7 @@ static int ll_loadlib (lua_State *L) {
 
 
 static int readable (const char *filename) {
-  FILE *f = fopen(filename, "r");  /* try to open file */
+  FILE *f = luaL_fopen(filename, strlen(filename), "r", sizeof("r") - sizeof(char));  /* try to open file */
   if (f == NULL) return 0;  /* open failed */
   fclose(f);
   return 1;

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -13,17 +13,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <vector>
+#endif
+
 #include <signal.h>
 
 #include "lua.h"
 
 #include "lauxlib.h"
 #include "lualib.h"
-
-#ifdef _WIN32
-#include <vector>
-#include <Windows.h>
-#endif
 
 
 #if !defined(LUA_PROGNAME)
@@ -653,21 +652,11 @@ static int pmain (lua_State *L) {
 
 
 #ifdef _WIN32
-[[nodiscard]] static std::string utf16_to_utf8(const wchar_t* utf16, size_t utf16_len) {
-  std::string utf8;
-  const int sizeRequired = WideCharToMultiByte(CP_UTF8, 0, utf16, (int)utf16_len, nullptr, 0, 0, 0);
-  if (sizeRequired != 0) {
-      utf8 = std::string(sizeRequired, 0);
-    WideCharToMultiByte(CP_UTF8, 0, utf16, (int)utf16_len, utf8.data(), sizeRequired, 0, 0);
-  }
-  return utf8;
-}
-
 int wmain (int argc, wchar_t **wargv) {
   std::vector<char*> argv_arr; argv_arr.reserve(argc);
   std::vector<std::string> argv_buf; argv_buf.reserve(argc);
   for (int i = 0; i != argc; ++i) {
-    argv_arr.emplace_back(argv_buf.emplace_back(utf16_to_utf8(wargv[i], wcslen(wargv[i]))).data());
+    argv_arr.emplace_back(argv_buf.emplace_back(luaL_utf16_to_utf8(wargv[i], wcslen(wargv[i]))).data());
   }
   char **argv = &argv_arr[0];
 #else

--- a/src/luac.cpp
+++ b/src/luac.cpp
@@ -15,6 +15,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <vector>
+#endif
+
 #include "lua.h"
 #include "lauxlib.h"
 
@@ -196,8 +200,17 @@ static int pmain(lua_State* L)
  return 0;
 }
 
-int main(int argc, char* argv[])
-{
+#ifdef _WIN32
+int wmain (int argc, wchar_t **wargv) {
+  std::vector<char*> argv_arr; argv_arr.reserve(argc);
+  std::vector<std::string> argv_buf; argv_buf.reserve(argc);
+  for (int i = 0; i != argc; ++i) {
+    argv_arr.emplace_back(argv_buf.emplace_back(luaL_utf16_to_utf8(wargv[i], wcslen(wargv[i]))).data());
+  }
+  char **argv = &argv_arr[0];
+#else
+int main (int argc, char **argv) {
+#endif
  lua_State* L;
  int i=doargs(argc,argv);
  argc-=i; argv+=i;

--- a/src/luac.cpp
+++ b/src/luac.cpp
@@ -185,7 +185,7 @@ static int pmain(lua_State* L)
  if (listing) luaU_print(f,listing>1);
  if (dumping)
  {
-  FILE* D= (output==NULL) ? stdout : fopen(output,"wb");
+  FILE* D= (output==NULL) ? stdout : luaL_fopen(output,strlen(output),"wb",sizeof("wb")-sizeof(char));
   if (D==NULL) cannot("open");
   lua_lock(L);
   luaU_dump(L,f,writer,D,stripping);


### PR DESCRIPTION
Continuing to treat Windows' lack of UTF-8 path encoding as a bug, this makes the following things work on Windows systems:
- `require("ばかlib")` (dofile as well)
- `pluto ばか.pluto` (also verified this _just works_ on Linux)
- `plutoc ばか.pluto`