### PR TITLE
Allow compile-time constant for enum value

### DIFF
--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -713,6 +713,13 @@ do
     end
     assert(UNAR_INVALID == -1)
     assert(UNAR_ONE == +1)
+
+    enum ConstyEnum begin
+        CST_VAL = 1,
+        CPY_VAL = CST_VAL,
+    end
+    assert(CST_VAL == 1)
+    assert(CPY_VAL == 1)
 end
 
 print "Testing format strings."


### PR DESCRIPTION
This also supports constexpr syntax for 0.6.0 due to using simpleexp.