### PR TITLE
Provide code snippet for luaK_semerror

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -164,12 +164,10 @@ static const char *txtToken (LexState *ls, int token) {
 [[noreturn]] static void lexerror (LexState *ls, const char *msg, int token) {
   const bool is_expected_token_error = (strcmp(msg, "syntax error") != 0);
   msg = luaG_addinfo(ls->L, msg, ls->source, ls->getLineNumber());
-  if (token)
-  {
-    Pluto::ErrorMessage err{ ls, HRED "syntax error: " BWHT};
-    err.addMsg(msg);
-    if (is_expected_token_error && ls->t.IsReserved())
-    {
+  Pluto::ErrorMessage err{ ls, HRED "syntax error: " BWHT };
+  err.addMsg(msg);
+  if (token) {
+    if (is_expected_token_error && ls->t.IsReserved()) {
       std::string str = txtToken(ls, token);
       err.addMsg(", but found ")
          .addMsg(str);
@@ -178,14 +176,18 @@ static const char *txtToken (LexState *ls, int token) {
          .addGenericHere(str)
          .finalize();
     }
-    else
-    {
+    else {
       err.addMsg(" near ")
          .addMsg(txtToken(ls, token))
          .addSrcLine(ls->getLineNumber())
          .addGenericHere()
          .finalize();
     }
+  }
+  else {
+    err.addSrcLine(ls->getLineNumber())
+       .addGenericHere()
+       .finalize();
   }
   luaD_throw(ls->L, LUA_ERRSYNTAX);
 }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3025,6 +3025,7 @@ static void localstat (LexState *ls) {
   int nexps;
   expdesc e;
   int line = ls->getLineNumber(); /* in case we need to emit a warning */
+  size_t starting_tidx = ls->tidx; /* code snippets on tuple assignments can have inaccurate line readings because the parser skips lines until it can close the statement */
   do {
     vidx = new_localvar(ls, str_checkname(ls, true), line);
     hint = gettypehint(ls);
@@ -3033,8 +3034,10 @@ static void localstat (LexState *ls) {
     var->vd.kind = kind;
     var->vd.hint = hint;
     if (kind == RDKTOCLOSE) {  /* to-be-closed? */
-      if (toclose != -1)  /* one already present? */
+      if (toclose != -1) { /* one already present? */
+        luaX_setpos(ls, starting_tidx);
         luaK_semerror(ls, "multiple to-be-closed variables in local list");
+      }
       toclose = fs->nactvar + nvars;
     }
     nvars++;


### PR DESCRIPTION
Works, but we again have the issue of the line number being wrong.
```Lua
local a <close>, b <close>
-- hi
```
Now produces:
```
syntax error: basic.pluto:2: multiple to-be-closed variables in local list
    2 | -- hi
      | ^^^^^ here
```
Whereas before it would produce this:
```
basic.pluto:2: multiple to-be-closed variables in local list
```