### PR TITLE
Add enum reflection

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -231,6 +231,14 @@ enum ParserContext {
   PARCTX_BODY,
 };
 
+struct EnumDesc {
+  struct Enumerator {
+    TString* name;
+    lua_Integer value;
+  };
+  std::vector<Enumerator> enumerators;
+};
+
 struct LexState {
   int current;  /* current character (charint) */
   std::vector<std::string> lines;  /* A vector of all the lines processed by the lexer. */
@@ -249,6 +257,7 @@ struct LexState {
   TString *envn;  /* environment variable name */
   WarningConfig warning;  /* Configuration class for compile-time warnings. */
   std::stack<ParserContext> parser_context_stck{};
+  std::vector<EnumDesc> enums{};
 
   LexState()
     : lines { std::string {} }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1900,7 +1900,7 @@ static void const_expr (LexState *ls, expdesc *v) {
 }
 
 
-static void newtable(LexState *ls, expdesc *v, const std::function<bool(expdesc*)>& gen) {
+static void newtable (LexState *ls, expdesc *v, const std::function<bool(expdesc*)>& gen) {
   FuncState* fs = ls->fs;
   int pc = luaK_codeABC(fs, OP_NEWTABLE, 0, 0, 0);
   ConsControl cc;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1937,6 +1937,18 @@ static void primaryexp (LexState *ls, expdesc *v) {
           return true;
         });
       }
+      else if (strcmp(ls->t.seminfo.ts->contents, "names") == 0) {
+        luaX_next(ls);
+        const EnumDesc* ed = &ls->enums.at(v->u.ival);
+        size_t i = 0;
+        newtable(ls, v, [ed, &i](expdesc *e) {
+          if (i == ed->enumerators.size())
+            return false;
+          init_exp(e, VKSTR, 0);
+          e->u.strval = ed->enumerators.at(i++).name;
+          return true;
+        });
+      }
       else {
         throwerr(ls, luaO_fmt(ls->L, "%s is not a member of enums", ls->t.seminfo.ts->contents), "unknown member.");
       }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1950,7 +1950,7 @@ static void primaryexp (LexState *ls, expdesc *v) {
   if (isnametkn(ls)) {
     singlevar(ls, v);
     if (v->k == VENUM) {
-      checknext(ls, '.');
+      checknext(ls, ':');
       check(ls, TK_NAME);
       if (strcmp(ls->t.seminfo.ts->contents, "values") == 0) {
         luaX_next(ls);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -16,6 +16,7 @@
 #include <limits.h>
 #include <string.h>
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -427,7 +428,7 @@ static void process_assign(LexState* ls, Vardesc* var, const TypeDesc& td, int l
 static int reglevel (FuncState *fs, int nvar) {
   while (nvar-- > 0) {
     Vardesc *vd = getlocalvardesc(fs, nvar);  /* get previous variable */
-    if (vd->vd.kind != RDKCTC)  /* is in a register? */
+    if (vd->vd.kind != RDKCTC && vd->vd.kind != RDKENUM)  /* is in a register? */
       return vd->vd.ridx + 1;
   }
   return 0;  /* no variables in registers */
@@ -448,8 +449,8 @@ int luaY_nvarstack (FuncState *fs) {
 */
 static LocVar *localdebuginfo (FuncState *fs, int vidx) {
   Vardesc *vd = getlocalvardesc(fs, vidx);
-  if (vd->vd.kind == RDKCTC)
-    return NULL;  /* no debug info. for constants */
+  if (vd->vd.kind == RDKCTC || vd->vd.kind == RDKENUM)
+    return NULL;  /* no debug info. for constants [Pluto] and named enums */
   else {
     int idx = vd->vd.pidx;
     lua_assert(idx < fs->ndebugvars);
@@ -632,6 +633,10 @@ static int searchvar (FuncState *fs, TString *n, expdesc *var) {
     if (eqstr(n, vd->vd.name)) {  /* found? */
       if (vd->vd.kind == RDKCTC)  /* compile-time constant? */
         init_exp(var, VCONST, fs->firstlocal + i);
+      else if (vd->vd.kind == RDKENUM) {
+        init_exp(var, VENUM, 0);
+        var->u.ival = ivalue(&vd->k);
+      }
       else  /* real variable */
         init_var(fs, var, i);
       return var->k;
@@ -1895,10 +1900,47 @@ static void const_expr (LexState *ls, expdesc *v) {
 }
 
 
+static void newtable(LexState *ls, expdesc *v, const std::function<bool(expdesc*)>& gen) {
+  FuncState* fs = ls->fs;
+  int pc = luaK_codeABC(fs, OP_NEWTABLE, 0, 0, 0);
+  ConsControl cc;
+  luaK_code(fs, 0);  /* space for extra arg. */
+  cc.na = cc.nh = cc.tostore = 0;
+  cc.t = v;
+  init_exp(v, VNONRELOC, fs->freereg);  /* table will be at stack top */
+  luaK_reserveregs(fs, 1);
+  while (gen(&cc.v)) {
+    ++cc.tostore;
+    closelistfield(fs, &cc);
+  }
+  lastlistfield(fs, &cc);
+  luaK_settablesize(fs, pc, v->u.info, cc.na, cc.nh);
+}
+
+
 static void primaryexp (LexState *ls, expdesc *v) {
   /* primaryexp -> NAME | '(' expr ')' */
   if (isnametkn(ls)) {
     singlevar(ls, v);
+    if (v->k == VENUM) {
+      checknext(ls, '.');
+      check(ls, TK_NAME);
+      if (strcmp(ls->t.seminfo.ts->contents, "values") == 0) {
+        luaX_next(ls);
+        const EnumDesc* ed = &ls->enums.at(v->u.ival);
+        size_t i = 0;
+        newtable(ls, v, [ed, &i](expdesc *e) {
+          if (i == ed->enumerators.size())
+            return false;
+          init_exp(e, VKINT, 0);
+          e->u.ival = ed->enumerators.at(i++).value;
+          return true;
+        });
+      }
+      else {
+        throwerr(ls, luaO_fmt(ls->L, "%s is not a member of enums", ls->t.seminfo.ts->contents), "unknown member.");
+      }
+    }
     return;
   }
   switch (ls->t.token) {
@@ -2728,8 +2770,14 @@ static void enumstat (LexState *ls) {
 
   luaX_next(ls); /* skip 'enum' */
 
+  EnumDesc* ed = nullptr;
   if (gett(ls) != TK_BEGIN) { /* enum has name? */
-    luaX_next(ls); /* skip name */
+    auto vidx = new_localvar(ls, str_checkname(ls, true), ls->getLineNumber());
+    auto var = getlocalvardesc(ls->fs, vidx);
+    var->vd.kind = RDKENUM;
+    setivalue(&var->k, ls->enums.size());
+    ed = &ls->enums.emplace_back(EnumDesc{});
+    ls->fs->nactvar++;
   }
 
   const auto line_begin = ls->getLineNumber();
@@ -2737,7 +2785,8 @@ static void enumstat (LexState *ls) {
 
   lua_Integer i = 1;
   while (gett(ls) == TK_NAME) {
-    auto vidx = new_localvar(ls, str_checkname(ls, true), ls->getLineNumber());
+    TString* name = str_checkname(ls, true);
+    auto vidx = new_localvar(ls, name, ls->getLineNumber());
     auto var = getlocalvardesc(ls->fs, vidx);
     if (testnext(ls, '=')) {
       expdesc v;
@@ -2755,7 +2804,11 @@ static void enumstat (LexState *ls) {
       i = v.u.ival;
     }
     var->vd.kind = RDKCTC;
-    setivalue(&var->k, i++);
+    setivalue(&var->k, i);
+    if (ed) {
+      ed->enumerators.emplace_back(EnumDesc::Enumerator{ name, i });
+    }
+    i++;
     ls->fs->nactvar++;
     if (gett(ls) != ',') break;
     luaX_next(ls);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1927,6 +1927,7 @@ static void primaryexp (LexState *ls, expdesc *v) {
       check(ls, TK_NAME);
       if (strcmp(ls->t.seminfo.ts->contents, "values") == 0) {
         luaX_next(ls);
+        checknext(ls, '('); checknext(ls, ')');
         const EnumDesc* ed = &ls->enums.at(v->u.ival);
         size_t i = 0;
         newtable(ls, v, [ed, &i](expdesc *e) {
@@ -1939,6 +1940,7 @@ static void primaryexp (LexState *ls, expdesc *v) {
       }
       else if (strcmp(ls->t.seminfo.ts->contents, "names") == 0) {
         luaX_next(ls);
+        checknext(ls, '('); checknext(ls, ')');
         const EnumDesc* ed = &ls->enums.at(v->u.ival);
         size_t i = 0;
         newtable(ls, v, [ed, &i](expdesc *e) {

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -62,7 +62,8 @@ typedef enum {
   VRELOC,  /* expression can put result in any register;
               info = instruction pc */
   VCALL,  /* expression is a function call; info = instruction pc */
-  VVARARG  /* vararg expression; info = instruction pc */
+  VVARARG,  /* vararg expression; info = instruction pc */
+  VENUM
 } expkind;
 
 [[nodiscard]] constexpr bool vkisconst(lu_byte k) noexcept {
@@ -118,6 +119,7 @@ typedef struct expdesc {
 #define RDKTOCLOSE	2   /* to-be-closed */
 #define RDKCTC		3   /* compile-time constant */
 #define RDKCONSTEXP	4   /* [Pluto] enforced compile-time constant */
+#define RDKENUM		5   /* [Pluto] named enum */
 
 struct PrimitiveType {
   /* 4 bits for ValType, and 1 bit for nullable. */


### PR DESCRIPTION
Example code:
```Lua
enum MyEnum begin
    OPTION_1 = 0,
    OPTION_2,
    OPTION_3 = 5,
    OPTION_4
end

for MyEnum:names() as val do
    print(val)
end

for MyEnum:values() as val do
    print(val)
end

for k, v in MyEnum:kvmap() do
    print(k, v)
end

for v, k in MyEnum:vkmap() do
    print(v, k)
end
```
> OPTION_1
OPTION_2
OPTION_3
OPTION_4
0
1
5
6
OPTION_3        5
OPTION_1        0
OPTION_4        6
OPTION_2        1
0       OPTION_1
1       OPTION_2
5       OPTION_3
6       OPTION_4
