### PR TITLE
Fix access violation on lua_close with strings as default parameters

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1427,7 +1427,7 @@ static void parlist (LexState *ls, std::vector<size_t>* fallbacks = nullptr) {
 }
 
 
-static void compoundassign(LexState* ls, expdesc* v, BinOpr op);
+static void compoundassign(LexState *ls, expdesc *v, BinOpr op);
 static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *prop) {
   /* body ->  '(' parlist ')' block END */
   ls->pushContext(PARCTX_BODY);
@@ -1450,7 +1450,7 @@ static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *pr
     if (tidx != 0) {
       enterlevel(ls);
       expdesc lv;
-      Vardesc* vd = getlocalvardesc(ls->fs, fallback_idx);
+      Vardesc *vd = getlocalvardesc(ls->fs, fallback_idx);
       singlevaraux(ls->fs, vd->vd.name, &lv, 1);
       luaX_setpos(ls, tidx - 1);
       compoundassign(ls, &lv, OPR_COAL);
@@ -2304,7 +2304,7 @@ static int getcompoundop (lua_Integer i, BinOpr *op) {
   reserves N registers (where N = local variables on stack)
   preforms binary operation and assignment
 */ 
-static void compoundassign(LexState *ls, expdesc* v, BinOpr op) {
+static void compoundassign(LexState *ls, expdesc *v, BinOpr op) {
   luaX_next(ls);
   int line = ls->getLineNumber();
   FuncState *fs = ls->fs;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1440,6 +1440,7 @@ static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *pr
   }
   std::vector<expdesc> fallbacks{};
   parlist(ls, &fallbacks);
+  checknext(ls, ')');
   int fallback_idx = 0;
   for (auto& fallback : fallbacks) {
     if (fallback.k != VVOID) {
@@ -1453,7 +1454,6 @@ static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *pr
     }
     ++fallback_idx;
   }
-  checknext(ls, ')');
   TypeDesc rethint = gettypehint(ls);
   TypeDesc p = VT_DUNNO;
   statlist(ls, &p, true);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1387,7 +1387,7 @@ static void simpleexp_with_unary_support (LexState *ls, expdesc *v) {
 }
 
 
-static void parlist (LexState *ls, std::vector<expdesc>* fallbacks = nullptr) {
+static void parlist (LexState *ls, std::vector<size_t>* fallbacks = nullptr) {
   /* parlist -> [ {NAME ','} (NAME | '...') ] */
   FuncState *fs = ls->fs;
   Proto *f = fs->f;
@@ -1400,12 +1400,14 @@ static void parlist (LexState *ls, std::vector<expdesc>* fallbacks = nullptr) {
         auto parhint = gettypehint(ls);
         new_localvar(ls, parname, parhint);
         if (fallbacks) {
-          expdesc* parfallback = &fallbacks->emplace_back(expdesc{});
           if (testnext(ls, '=')) {
-            simpleexp_with_unary_support(ls, parfallback);
-            if (!vkisconst(parfallback->k)) {
-              luaX_syntaxerror(ls, "parameter fallback value must be a compile-time constant");
-            }
+            fallbacks->emplace_back(luaX_getpos(ls));
+            do {
+              luaX_next(ls);
+            } while (ls->t.token != ',' && ls->t.token != ')' && ls->t.token != TK_EOS);
+          }
+          else {
+            fallbacks->emplace_back(0);
           }
         }
         nparams++;
@@ -1425,6 +1427,7 @@ static void parlist (LexState *ls, std::vector<expdesc>* fallbacks = nullptr) {
 }
 
 
+static void compoundassign(LexState* ls, expdesc* v, BinOpr op);
 static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *prop) {
   /* body ->  '(' parlist ')' block END */
   ls->pushContext(PARCTX_BODY);
@@ -1438,22 +1441,24 @@ static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *pr
     new_localvarliteral(ls, "self");  /* create 'self' parameter */
     adjustlocalvars(ls, 1);
   }
-  std::vector<expdesc> fallbacks{};
+  std::vector<size_t> fallbacks{};
   parlist(ls, &fallbacks);
   checknext(ls, ')');
+  const auto saved_pos = luaX_getpos(ls);
   int fallback_idx = 0;
-  for (auto& fallback : fallbacks) {
-    if (fallback.k != VVOID) {
-      Vardesc *vd = getlocalvardesc(ls->fs, fallback_idx);
+  for (const auto& tidx : fallbacks) {
+    if (tidx != 0) {
+      enterlevel(ls);
       expdesc lv;
+      Vardesc* vd = getlocalvardesc(ls->fs, fallback_idx);
       singlevaraux(ls->fs, vd->vd.name, &lv, 1);
-      expdesc lcond = lv;
-      luaK_goifnil(ls->fs, &lcond);
-      luaK_storevar(ls->fs, &lv, &fallback);
-      luaK_patchtohere(ls->fs, lcond.t);
+      luaX_setpos(ls, tidx - 1);
+      compoundassign(ls, &lv, OPR_COAL);
+      leavelevel(ls);
     }
     ++fallback_idx;
   }
+  luaX_setpos(ls, saved_pos);
   TypeDesc rethint = gettypehint(ls);
   TypeDesc p = VT_DUNNO;
   statlist(ls, &p, true);

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -671,6 +671,15 @@ do
     assert(c == -2)
     assert(d == +3)
     assert(e == "Hello")
+
+    local function tf(t = { 1, 2, 3 })
+        return t
+    end
+    local t = tf()
+    assert(#t == 3)
+    assert(t[1] == 1)
+    assert(t[2] == 2)
+    assert(t[3] == 3)
 end
 
 print "Testing walrus operator."

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -662,14 +662,15 @@ end
 print "Testing default arguments."
 do
     local CONST_VAL <const> = 69
-    local function f(a = 1, b = CONST_VAL, c = -2, d = +3)
-        return a, b, c, d
+    local function f(a = 1, b = CONST_VAL, c = -2, d = +3, e = "Hello")
+        return a, b, c, d, e
     end
-    local a, b, c, d = f()
+    local a, b, c, d, e = f()
     assert(a == 1)
     assert(b == 69)
     assert(c == -2)
     assert(d == +3)
+    assert(e == "Hello")
 end
 
 print "Testing walrus operator."


### PR DESCRIPTION
Note: Will also have to update docs, because now non-constant values are acceptable.