### PR TITLE
Add support for building with C linkage

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -15,7 +15,7 @@ jobs:
           path: |
             src/pluto
             src/plutoc
-            src/libpluto.dll
+            src/libpluto.so
             src/libpluto.a
       - run: src/pluto tests/basic.pluto
   ubuntu-20-04:
@@ -29,7 +29,7 @@ jobs:
           path: |
             src/pluto
             src/plutoc
-            src/libpluto.dll
+            src/libpluto.so
             src/libpluto.a
       - run: src/pluto tests/basic.pluto
   debian-10:
@@ -47,7 +47,7 @@ jobs:
           path: |
             src/pluto
             src/plutoc
-            src/libpluto.dll
+            src/libpluto.so
             src/libpluto.a
       - run: src/pluto tests/basic.pluto
   macos:
@@ -61,7 +61,7 @@ jobs:
           path: |
             src/pluto
             src/plutoc
-            src/libpluto.dll
+            src/libpluto.so
             src/libpluto.a
       - run: src/pluto tests/basic.pluto
   windows:
@@ -71,7 +71,6 @@ jobs:
       - run: php scripts/compile.php clang
       - run: php scripts/link_pluto.php clang
       - run: php scripts/link_plutoc.php clang
-      - run: php scripts/link_shared.php clang
       - run: php scripts/link_static.php
       - uses: actions/upload-artifact@v3
         with:
@@ -79,6 +78,5 @@ jobs:
           path: |
             src/pluto.exe
             src/plutoc.exe
-            src/libpluto.dll
             src/libpluto.a
       - run: src/pluto.exe tests/basic.pluto

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -80,3 +80,15 @@ jobs:
             src/plutoc.exe
             src/libpluto.a
       - run: src/pluto.exe tests/basic.pluto
+  windows-dll:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: php scripts/make_dll_c.php clang
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Windows DLL
+          path: |
+            src/pluto.dll
+            src/pluto.lib
+            src/pluto.exp

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /src/*.dll
 /src/*.a
 /src/*.lib
+/src/*.exp
 /tbytecode.script
 /luac.out
 /tests/quick.lua

--- a/scripts/link_shared.php
+++ b/scripts/link_shared.php
@@ -2,7 +2,7 @@
 require __DIR__."/common.php";
 check_compiler();
 
-$cmd = $compiler." -shared -o src/libpluto.dll";
+$cmd = $compiler." -shared -o src/libpluto.so";
 
 for_each_obj(function($file)
 {

--- a/scripts/make_dll_c++.php
+++ b/scripts/make_dll_c++.php
@@ -1,0 +1,21 @@
+<?php
+require __DIR__."/common.php";
+check_compiler();
+
+for_each_obj(function($file)
+{
+	echo "$file\n";
+	global $compiler;
+	passthru($compiler." -o int/{$file}.o -c src/{$file}.cpp -D LUA_BUILD_AS_DLL -D PLUTO_C_LINKAGE=false");
+});
+
+$cmd = $compiler." -shared -o src/pluto++.dll";
+for_each_obj(function($file)
+{
+	if($file != "lua" && $file != "luac")
+	{
+		global $cmd;
+		$cmd .= " int/{$file}.o";
+	}
+});
+passthru($cmd);

--- a/scripts/make_dll_c.php
+++ b/scripts/make_dll_c.php
@@ -1,0 +1,21 @@
+<?php
+require __DIR__."/common.php";
+check_compiler();
+
+for_each_obj(function($file)
+{
+	echo "$file\n";
+	global $compiler;
+	passthru($compiler." -o int/{$file}.o -c src/{$file}.cpp -D LUA_BUILD_AS_DLL -D PLUTO_C_LINKAGE=true -Wno-return-type -Wno-invalid-noreturn");
+});
+
+$cmd = $compiler." -shared -o src/pluto.dll";
+for_each_obj(function($file)
+{
+	if($file != "lua" && $file != "luac")
+	{
+		global $cmd;
+		$cmd .= " int/{$file}.o";
+	}
+});
+passthru($cmd);

--- a/src/dynamic.sun
+++ b/src/dynamic.sun
@@ -3,3 +3,6 @@ cpp 17
 -lua.cpp
 -luac.cpp
 dynamic
+if windows
+	arg -DLUA_BUILD_AS_DLL
+endif

--- a/src/lapi.cpp
+++ b/src/lapi.cpp
@@ -557,7 +557,7 @@ LUA_API const char *lua_pushstring (lua_State *L, const char *s) {
   return s;
 }
 
-LUA_API const char* lua_pushstring(lua_State* L, const std::string& str) {
+PLUTO_API const char* pluto_pushstring(lua_State* L, const std::string& str) {
   return lua_pushstring(L, str.c_str());
 }
 
@@ -1288,7 +1288,7 @@ LUA_API int lua_gc (lua_State *L, int what, ...) {
 */
 
 
-LUA_API void lua_error (lua_State *L) {
+LUA_API_NORETURN void lua_error (lua_State *L) {
   TValue *errobj;
   lua_lock(L);
   errobj = s2v(L->top - 1);

--- a/src/lauxlib.cpp
+++ b/src/lauxlib.cpp
@@ -173,7 +173,7 @@ LUALIB_API void luaL_traceback (lua_State *L, lua_State *L1,
 ** =======================================================
 */
 
-LUALIB_API void luaL_argerror (lua_State *L, int arg, const char *extramsg) {
+LUALIB_API_NORETURN void luaL_argerror (lua_State *L, int arg, const char *extramsg) {
   lua_Debug ar;
   if (!lua_getstack(L, 0, &ar))  /* no stack frame? */
     luaL_error(L, "bad argument #%d (%s)", arg, extramsg);
@@ -191,7 +191,7 @@ LUALIB_API void luaL_argerror (lua_State *L, int arg, const char *extramsg) {
 }
 
 
-LUALIB_API void luaL_typeerror (lua_State *L, int arg, const char *tname) {
+LUALIB_API_NORETURN void luaL_typeerror (lua_State *L, int arg, const char *tname) {
   const char *msg;
   const char *typearg;  /* name for the type of the actual argument */
   if (luaL_getmetafield(L, arg, "__name") == LUA_TSTRING)
@@ -232,7 +232,7 @@ LUALIB_API void luaL_where (lua_State *L, int level) {
 ** not need reserved stack space when called. (At worst, it generates
 ** an error with "stack overflow" instead of the given message.)
 */
-LUALIB_API void luaL_error (lua_State *L, const char *fmt, ...) {
+LUALIB_API_NORETURN void luaL_error (lua_State *L, const char *fmt, ...) {
   va_list argp;
   va_start(argp, fmt);
   luaL_where(L, 1);

--- a/src/lauxlib.h
+++ b/src/lauxlib.h
@@ -50,8 +50,8 @@ LUALIB_API void (luaL_checkversion_) (lua_State *L, lua_Number ver, size_t sz);
 LUALIB_API int (luaL_getmetafield) (lua_State *L, int obj, const char *e);
 LUALIB_API int (luaL_callmeta) (lua_State *L, int obj, const char *e);
 LUALIB_API const char *(luaL_tolstring) (lua_State *L, int idx, size_t *len);
-[[noreturn]] LUALIB_API void (luaL_argerror) (lua_State *L, int arg, const char *extramsg);
-[[noreturn]] LUALIB_API void (luaL_typeerror) (lua_State *L, int arg, const char *tname);
+LUALIB_API_NORETURN void (luaL_argerror) (lua_State *L, int arg, const char *extramsg);
+LUALIB_API_NORETURN void (luaL_typeerror) (lua_State *L, int arg, const char *tname);
 LUALIB_API const char *(luaL_checklstring) (lua_State *L, int arg,
                                                           size_t *l);
 LUALIB_API const char *(luaL_optlstring) (lua_State *L, int arg,
@@ -73,7 +73,7 @@ LUALIB_API void *(luaL_testudata) (lua_State *L, int ud, const char *tname);
 LUALIB_API void *(luaL_checkudata) (lua_State *L, int ud, const char *tname);
 
 LUALIB_API void (luaL_where) (lua_State *L, int lvl);
-[[noreturn]] LUALIB_API void (luaL_error) (lua_State *L, const char *fmt, ...);
+LUALIB_API_NORETURN void (luaL_error) (lua_State *L, const char *fmt, ...);
 
 LUALIB_API int (luaL_checkoption) (lua_State *L, int arg, const char *def,
                                    const char *const lst[]);
@@ -90,8 +90,8 @@ LUALIB_API int (luaL_ref) (lua_State *L, int t);
 LUALIB_API void (luaL_unref) (lua_State *L, int t, int ref);
 
 #ifdef _WIN32
-LUALIB_API std::wstring luaL_utf8_to_utf16(const char *utf8, size_t utf8_len);
-LUALIB_API std::string luaL_utf16_to_utf8(const wchar_t *utf16, size_t utf16_len);
+PLUTOLIB_API std::wstring luaL_utf8_to_utf16(const char *utf8, size_t utf8_len);
+PLUTOLIB_API std::string luaL_utf16_to_utf8(const wchar_t *utf16, size_t utf16_len);
 #endif
 
 LUALIB_API FILE* (luaL_fopen) (const char *filename, size_t filename_len,

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -125,6 +125,9 @@ static int luaB_tonumber (lua_State *L) {
     lua_concat(L, 2);
   }
   lua_error(L);
+#ifdef PLUTO_C_LINKAGE
+  return 0;
+#endif
 }
 
 

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -125,7 +125,7 @@ static int luaB_tonumber (lua_State *L) {
     lua_concat(L, 2);
   }
   lua_error(L);
-#ifdef PLUTO_C_LINKAGE
+#if PLUTO_C_LINKAGE
   return 0;
 #endif
 }

--- a/src/lua.h
+++ b/src/lua.h
@@ -235,7 +235,7 @@ LUA_API void        (lua_pushnumber) (lua_State *L, lua_Number n);
 LUA_API void        (lua_pushinteger) (lua_State *L, lua_Integer n);
 LUA_API const char *(lua_pushlstring) (lua_State *L, const char *s, size_t len);
 LUA_API const char *(lua_pushstring) (lua_State *L, const char *s);
-LUA_API const char *(lua_pushstring) (lua_State* L, const std::string& str);
+PLUTO_API const char *(pluto_pushstring) (lua_State* L, const std::string& str);
 LUA_API const char *(lua_pushvfstring) (lua_State *L, const char *fmt,
                                                       va_list argp);
 LUA_API const char *(lua_pushfstring) (lua_State *L, const char *fmt, ...);
@@ -340,7 +340,7 @@ LUA_API int (lua_gc) (lua_State *L, int what, ...);
 ** miscellaneous functions
 */
 
-[[noreturn]] LUA_API void   (lua_error) (lua_State *L);
+LUA_API_NORETURN void   (lua_error) (lua_State *L);
 
 LUA_API int   (lua_next) (lua_State *L, int idx);
 

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -289,7 +289,7 @@
 
 #if PLUTO_C_LINKAGE
   #define LUA_API			extern "C" PLUTO_API
-  // Note that the lack of [[noreturn]] will cause warnings.
+  // Note that the lack of [[noreturn]] will cause warnings (-Wno-return-type -Wno-invalid-noreturn).
   #define LUA_API_NORETURN	LUA_API
 #else
   #define LUA_API			PLUTO_API

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -268,26 +268,37 @@
 ** the libraries, you may want to use the following definition (define
 ** LUA_BUILD_AS_DLL to get it).
 */
-#if defined(LUA_BUILD_AS_DLL)	/* { */
+#if defined(LUA_BUILD_AS_DLL)
+  #if defined(LUA_CORE) || defined(LUA_LIB)
+    #define PLUTO_DLLSPEC __declspec(dllexport)
+  #else
+    #define PLUTO_DLLSPEC __declspec(dllimport)
+  #endif
+#else
+  #define PLUTO_DLLSPEC
+#endif
 
-#if defined(LUA_CORE) || defined(LUA_LIB)	/* { */
-#define LUA_API __declspec(dllexport)
-#else						/* }{ */
-#define LUA_API __declspec(dllimport)
-#endif						/* } */
+// Additions by Pluto that are not compatible with `extern "C"` use PLUTO_API instead of LUA_API.
+#define PLUTO_API	PLUTO_DLLSPEC
 
-#else				/* }{ */
-
-#define LUA_API		extern
-
-#endif				/* } */
-
+#ifdef PLUTO_C_LINKAGE
+  #define LUA_API			extern "C" PLUTO_API
+  // Note that the lack of [[noreturn]] will cause warnings.
+  #define LUA_API_NORETURN	LUA_API
+#else
+  #define LUA_API			PLUTO_API
+  #define LUA_API_NORETURN	[[noreturn]] LUA_API
+#endif
 
 /*
 ** More often than not the libs go together with the core.
 */
 #define LUALIB_API	LUA_API
 #define LUAMOD_API	LUA_API
+
+#define LUALIB_API_NORETURN	LUA_API_NORETURN
+
+#define PLUTOLIB_API	PLUTO_API
 
 
 /*

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -269,19 +269,25 @@
 ** LUA_BUILD_AS_DLL to get it).
 */
 #if defined(LUA_BUILD_AS_DLL)
+  #ifndef PLUTO_C_LINKAGE
+    #define PLUTO_C_LINKAGE true
+  #endif
   #if defined(LUA_CORE) || defined(LUA_LIB)
     #define PLUTO_DLLSPEC __declspec(dllexport)
   #else
     #define PLUTO_DLLSPEC __declspec(dllimport)
   #endif
 #else
+  #ifndef PLUTO_C_LINKAGE
+    #define PLUTO_C_LINKAGE false
+  #endif
   #define PLUTO_DLLSPEC
 #endif
 
 // Additions by Pluto that are not compatible with `extern "C"` use PLUTO_API instead of LUA_API.
 #define PLUTO_API	PLUTO_DLLSPEC
 
-#ifdef PLUTO_C_LINKAGE
+#if PLUTO_C_LINKAGE
   #define LUA_API			extern "C" PLUTO_API
   // Note that the lack of [[noreturn]] will cause warnings.
   #define LUA_API_NORETURN	LUA_API


### PR DESCRIPTION
Also fixes the fact that the GH actions-produced pluto.dll has no exports so is practically useless. A bit of a mess with special-casing a lot of stuff, but this should "just work," specifically using pluto.dll as a drop-in replacement for lua.dll.