### PR TITLE
Add auto-complete suggestions for tooling

### DIFF
--- a/Pluto.vcxproj
+++ b/Pluto.vcxproj
@@ -235,6 +235,7 @@
     <ClInclude Include="src\lprefix.h" />
     <ClInclude Include="src\lstate.h" />
     <ClInclude Include="src\lstring.h" />
+    <ClInclude Include="src\lsuggestions.hpp" />
     <ClInclude Include="src\ltable.h" />
     <ClInclude Include="src\ltm.h" />
     <ClInclude Include="src\lua.h" />

--- a/Pluto.vcxproj.filters
+++ b/Pluto.vcxproj.filters
@@ -196,6 +196,7 @@
     <ClInclude Include="src\vendor\Soup\Reader.hpp">
       <Filter>vendor\Soup</Filter>
     </ClInclude>
+    <ClInclude Include="src\lsuggestions.hpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="vendor">

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -106,25 +106,33 @@ void luaX_init (lua_State *L) {
 
 
 const char *luaX_token2str (LexState *ls, int token) {
-  return luaO_pushfstring(ls->L, "'%s'", luaX_token2str_noq(ls, token));
+  const char *ret = luaO_pushfstring(ls->L, "'%s'", luaX_token2str_noq(ls, token));
+  ls->L->top--;
+  return ret;
 }
 
 
 /* Converts a token into a string, same as luaX_token2str (but it doesn't quote the token). */
 const char *luaX_token2str_noq (LexState *ls, int token) {
+  const char *ret;
   if (token < FIRST_RESERVED) {  /* single-byte symbols? */
-    if (lisprint(token))
-      return luaO_pushfstring(ls->L, "%c", token);
-    else  /* control character */
-      return luaO_pushfstring(ls->L, "'<\\%d>'", token);
+    if (lisprint(token)) {
+      ret = luaO_pushfstring(ls->L, "%c", token);
+      ls->L->top--;
+    } else { /* control character */
+      ret = luaO_pushfstring(ls->L, "'<\\%d>'", token);
+      ls->L->top--;
+    }
   }
   else {
     const char *s = luaX_tokens[token - FIRST_RESERVED];
-    if (token < TK_EOS)  /* fixed format (symbols and reserved words)? */
-      return luaO_pushfstring(ls->L, "%s", s);
-    else  /* names, strings, and numerals */
+    if (token < TK_EOS) { /* fixed format (symbols and reserved words)? */
+        ret = luaO_pushfstring(ls->L, "%s", s);
+        ls->L->top--;
+    } else  /* names, strings, and numerals */
       return s;
   }
+  return ret;
 }
 
 

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -59,7 +59,7 @@ static const char *const luaX_tokens [] = {
 #ifndef PLUTO_COMPATIBLE_ENUM
     "enum",
 #endif
-    "pluto_suggest",
+    "pluto_suggest_0", "pluto_suggest_1",
     "return", "then", "true", "until", "while",
     "//", "..", "...", "==", ">=", "<=", "~=",
     "<<", ">>", "::", "<eof>",
@@ -953,10 +953,14 @@ const Token& luaX_lookbehind (LexState *ls) {
 
 
 void luaX_checkspecial (LexState *ls) {
-  if (ls->t.token == TK_SUGGEST) {
-    luaX_next(ls);
-    const char* str = luaX_token2str_noq(ls, ls->t.token);
-    size_t len = strlen(str);
+  if (ls->t.token == TK_SUGGEST_0 || ls->t.token == TK_SUGGEST_1) {
+    const char* str = "";
+    size_t len = 0;
+    if (ls->t.token != TK_SUGGEST_0) {
+      luaX_next(ls);
+      str = luaX_token2str_noq(ls, ls->t.token);
+      len = strlen(str);
+    }
     luaX_next(ls);
 
     std::vector<std::pair<const char*, const char*>> suggestions;

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -106,19 +106,7 @@ void luaX_init (lua_State *L) {
 
 
 const char *luaX_token2str (LexState *ls, int token) {
-  if (token < FIRST_RESERVED) {  /* single-byte symbols? */
-    if (lisprint(token))
-      return luaO_pushfstring(ls->L, "'%c'", token);
-    else  /* control character */
-      return luaO_pushfstring(ls->L, "'<\\%d>'", token);
-  }
-  else {
-    const char *s = luaX_tokens[token - FIRST_RESERVED];
-    if (token < TK_EOS)  /* fixed format (symbols and reserved words)? */
-      return luaO_pushfstring(ls->L, "'%s'", s);
-    else  /* names, strings, and numerals */
-      return s;
-  }
+  return luaO_pushfstring(ls->L, "'%s'", luaX_token2str_noq(ls, token));
 }
 
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -53,6 +53,7 @@ enum RESERVED {
 #ifndef PLUTO_COMPATIBLE_ENUM
   TK_ENUM,
 #endif
+  TK_SUGGEST, // New special keywords.
   TK_RETURN, TK_THEN, TK_TRUE, TK_UNTIL, TK_WHILE,
   /* other terminal symbols */
   TK_IDIV, TK_CONCAT,
@@ -387,3 +388,4 @@ LUAI_FUNC const Token& luaX_lookbehind(LexState *ls);
 LUAI_FUNC const char *luaX_token2str (LexState *ls, int token);
 LUAI_FUNC const char *luaX_token2str_noq (LexState *ls, int token);
 LUAI_FUNC const char *luaX_reserved2str (int token);
+LUAI_FUNC void luaX_checkspecial (LexState *ls);

--- a/src/llex.h
+++ b/src/llex.h
@@ -366,6 +366,10 @@ struct LexState {
     const auto& lastattr = line > 1 ? this->getLineString(line - 1) : linebuff;
     return lastattr.find("@pluto_warnings: disable-next") == std::string::npos && getWarningConfig().Get(warning_type);
   }
+
+  [[nodiscard]] bool shouldSuggest() const noexcept {
+    return t.token == TK_SUGGEST_0 || t.token == TK_SUGGEST_1;
+  }
 };
 
 #if defined(_MSC_VER) && _MSC_VER && !__INTEL_COMPILER

--- a/src/llex.h
+++ b/src/llex.h
@@ -53,7 +53,7 @@ enum RESERVED {
 #ifndef PLUTO_COMPATIBLE_ENUM
   TK_ENUM,
 #endif
-  TK_SUGGEST, // New special keywords.
+  TK_SUGGEST_0, TK_SUGGEST_1, // New special keywords.
   TK_RETURN, TK_THEN, TK_TRUE, TK_UNTIL, TK_WHILE,
   /* other terminal symbols */
   TK_IDIV, TK_CONCAT,

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1984,7 +1984,7 @@ static void const_expr (LexState *ls, expdesc *v) {
       return;
     }
     default: {
-      const char* token = luaX_token2str(ls, ls->t.token);
+      const char *token = luaX_token2str(ls, ls->t.token);
       throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
     }
   }
@@ -2119,7 +2119,7 @@ static void enumexp (LexState *ls, expdesc *v, TString *varname) {
       return;
     }
     default: {
-      const char* token = luaX_token2str(ls, ls->t.token);
+      const char *token = luaX_token2str(ls, ls->t.token);
       throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
     }
   }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -237,6 +237,7 @@ static int testnext (LexState *ls, int c) {
 ** Check that next token is 'c'.
 */
 static void check (LexState *ls, int c) {
+  luaX_checkspecial(ls);
   if (ls->t.token != c) {
     error_expected(ls, c);
   }
@@ -2498,6 +2499,7 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeDesc *prop = nul
 
 
 static void expr (LexState *ls, expdesc *v, TypeDesc *prop, bool no_colon) {
+  luaX_checkspecial(ls);
   subexpr(ls, v, 0, prop, no_colon);
   if (testnext(ls, '?')) { /* ternary expression? */
     int escape = NO_JUMP;
@@ -3540,6 +3542,7 @@ static void retstat (LexState *ls, TypeDesc *prop) {
 
 
 static void statement (LexState *ls, TypeDesc *prop) {
+  luaX_checkspecial(ls);
   int line = ls->getLineNumber();
   if (ls->laststat.IsEscapingToken() ||
      (ls->laststat.Is(TK_GOTO) && !ls->findWithinLine(line, luaX_lookbehind(ls).seminfo.ts->toCpp()))) /* Don't warn if this statement is the goto's label. */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3547,7 +3547,7 @@ static void statement (LexState *ls, TypeDesc *prop) {
     throw_warn(ls,
       "unreachable code",
         luaO_fmt(ls->L, "this code comes after an escaping %s statement.", luaX_token2str(ls, ls->laststat.token)), UNREACHABLE_CODE);
-    ls->L->top -= 2;
+    ls->L->top--;
   }
   ls->laststat.token = ls->t.token;
   enterlevel(ls);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2113,9 +2113,15 @@ static void enumexp (LexState *ls, expdesc *v, TString *varname) {
       return;
     }
     case '.': {
-      luaX_next(ls);
-      check(ls, TK_NAME);
       const EnumDesc* ed = &ls->enums.at((size_t)v->u.ival);
+      luaX_next(ls);
+      if (ls->shouldSuggest()) {
+        SuggestionsState ss(ls);
+        for (const auto& e : ed->enumerators) {
+          ss.push("eprop", e.name->contents);
+        }
+      }
+      check(ls, TK_NAME);
       for (const auto& e : ed->enumerators) {
         if (eqstr(e.name->contents, ls->t.seminfo.ts->contents)) {
           init_exp(v, VKINT, 0);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2118,7 +2118,7 @@ static void enumexp (LexState *ls, expdesc *v, TString *varname) {
       if (ls->shouldSuggest()) {
         SuggestionsState ss(ls);
         for (const auto& e : ed->enumerators) {
-          ss.push("eprop", e.name->contents);
+          ss.push("eprop", e.name->contents, std::to_string(e.value));
         }
       }
       check(ls, TK_NAME);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -34,6 +34,7 @@
 #include "lparser.h"
 #include "lstate.h"
 #include "lstring.h"
+#include "lsuggestions.hpp"
 #include "ltable.h"
 #include "lauxlib.h"
 
@@ -2040,6 +2041,13 @@ static void enumexp (LexState *ls, expdesc *v, TString *varname) {
   switch (ls->t.token) {
     case ':': {
       luaX_next(ls);
+      if (ls->shouldSuggest()) {
+        SuggestionsState ss(ls);
+        ss.push("efunc", "values");
+        ss.push("efunc", "names");
+        ss.push("efunc", "kvmap");
+        ss.push("efunc", "vkmap");
+      }
       check(ls, TK_NAME);
       if (strcmp(ls->t.seminfo.ts->contents, "values") == 0) {
         luaX_next(ls);

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -12,12 +12,6 @@
 
 
 /*
-** Shorthand for converting a token into a non-quoted string.
-*/
-#define t2s(lex, token) (luaX_token2str_noq(lex, token))
-
-
-/*
 ** Expression and variable descriptor.
 ** Code generation for variables and expressions can be delayed to allow
 ** optimizations; An 'expdesc' structure describes a potentially-delayed

--- a/src/lsuggestions.hpp
+++ b/src/lsuggestions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -9,6 +10,7 @@ struct SuggestionsState {
   struct Suggestion {
     const char* type;
     const char* name;
+    std::string extra;
   };
 
   LexState* const ls;
@@ -28,8 +30,8 @@ struct SuggestionsState {
     luaX_next(ls); /* skip pluto_suggest_0 or filter */
   }
 
-  void push(const char* type, const char* name) {
-    suggestions.emplace_back(Suggestion{ type, name });
+  void push(const char* type, const char* name, std::string extra = {}) {
+    suggestions.emplace_back(Suggestion{ type, name, std::move(extra) });
   }
 
   ~SuggestionsState() {
@@ -48,6 +50,10 @@ struct SuggestionsState {
         msg.append(suggestion.type);
         msg.push_back(',');
         msg.append(suggestion.name);
+        if (!suggestion.extra.empty()) {
+          msg.push_back(',');
+          msg.append(suggestion.extra);
+        }
         msg.push_back(';');
       }
       msg.pop_back();

--- a/src/lsuggestions.hpp
+++ b/src/lsuggestions.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "llex.h"
+
+struct SuggestionsState {
+  LexState* const ls;
+
+  const char* str = "";
+  size_t len = 0;
+
+  std::vector<std::pair<const char*, const char*>> suggestions;
+
+  SuggestionsState(LexState* ls)
+    : ls(ls) {
+    if (ls->t.token != TK_SUGGEST_0) {
+      luaX_next(ls); /* skip pluto_suggest_x */
+      str = luaX_token2str_noq(ls, ls->t.token);
+      len = strlen(str);
+    }
+    luaX_next(ls); /* skip pluto_suggest_0 or filter */
+  }
+
+  void push(const char* type, const char* name) {
+    suggestions.emplace_back(type, name);
+  }
+
+  ~SuggestionsState() {
+    /* filter suggestions */
+    for (auto i = suggestions.begin(); i != suggestions.end(); ) {
+      if (strncmp(i->second, str, len) == 0)
+        ++i;
+      else
+        i = suggestions.erase(i);
+    }
+
+    /* emit suggestions if we have any */
+    if (!suggestions.empty()) {
+      std::string msg = "suggest: ";
+      for (const auto& suggestion : suggestions) {
+        msg.append(suggestion.first);
+        msg.push_back(',');
+        msg.append(suggestion.second);
+        msg.push_back(';');
+      }
+      msg.pop_back();
+      lua_warning(ls->L, msg.c_str(), 0);
+    }
+  }
+};

--- a/src/lsuggestions.hpp
+++ b/src/lsuggestions.hpp
@@ -6,12 +6,17 @@
 #include "llex.h"
 
 struct SuggestionsState {
+  struct Suggestion {
+    const char* type;
+    const char* name;
+  };
+
   LexState* const ls;
 
   const char* str = "";
   size_t len = 0;
 
-  std::vector<std::pair<const char*, const char*>> suggestions;
+  std::vector<Suggestion> suggestions;
 
   SuggestionsState(LexState* ls)
     : ls(ls) {
@@ -24,13 +29,13 @@ struct SuggestionsState {
   }
 
   void push(const char* type, const char* name) {
-    suggestions.emplace_back(type, name);
+    suggestions.emplace_back(Suggestion{ type, name });
   }
 
   ~SuggestionsState() {
     /* filter suggestions */
     for (auto i = suggestions.begin(); i != suggestions.end(); ) {
-      if (strncmp(i->second, str, len) == 0)
+      if (strncmp(i->name, str, len) == 0)
         ++i;
       else
         i = suggestions.erase(i);
@@ -40,9 +45,9 @@ struct SuggestionsState {
     if (!suggestions.empty()) {
       std::string msg = "suggest: ";
       for (const auto& suggestion : suggestions) {
-        msg.append(suggestion.first);
+        msg.append(suggestion.type);
         msg.push_back(',');
-        msg.append(suggestion.second);
+        msg.append(suggestion.name);
         msg.push_back(';');
       }
       msg.pop_back();


### PR DESCRIPTION
This adds "pluto_suggest_0" and "pluto_suggest_1" keywords. These keywords are not meant to be used any users of the language, but rather placed by tooling which would invoke "plutoc -p" so it knows what could syntactically come next. Currently, Pluto can suggest:
- local variable names
- enum's enumerators (`enum.enumator` syntax)
- enum methods (`enum:method` syntax)
