### PR TITLE
Add 'void' type hint

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1080,13 +1080,13 @@ static int block_follow (LexState *ls, int withuntil) {
 static void propagate_return_type(TypeDesc*& prop, TypeDesc&& ret) {
   if (prop->getType() != VT_DUNNO) { /* had previous return path(s)? */
     if (vtIsNull(prop->getType())) {
-      if (!ret.isNull()) {
+      if (vtCanBeNullable(ret.getType())) {
         ret.setNullable();
         *prop = ret;
       }
     }
     else if (vtIsNull(ret.getType())) {
-      if (!prop->isNull())
+      if (vtCanBeNullable(prop->getType()))
       prop->setNullable();
     }
     else if (!prop->isCompatibleWith(ret)) {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3656,7 +3656,6 @@ static void retstat (LexState *ls, TypeDesc *prop) {
     || ls->t.token == TK_CASE || ls->t.token == TK_DEFAULT
   ) {
     nret = 0;  /* return no values */
-    if (prop) *prop = VT_NIL;
   }
   else {
     nret = explist(ls, &e, prop);  /* optional return values */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1079,13 +1079,13 @@ static int block_follow (LexState *ls, int withuntil) {
 
 static void propagate_return_type(TypeDesc*& prop, TypeDesc&& ret) {
   if (prop->getType() != VT_DUNNO) { /* had previous return path(s)? */
-    if (prop->isNull()) {
+    if (vtIsNull(prop->getType())) {
       if (!ret.isNull()) {
         ret.setNullable();
         *prop = ret;
       }
     }
-    else if (ret.isNull()) {
+    else if (vtIsNull(ret.getType())) {
       if (!prop->isNull())
       prop->setNullable();
     }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1072,7 +1072,7 @@ static int block_follow (LexState *ls, int withuntil) {
 }
 
 
-static void propagate_return_type(TypeDesc *prop, TypeDesc&& ret) {
+static void propagate_return_type(TypeDesc*& prop, TypeDesc&& ret) {
   if (prop->getType() != VT_DUNNO) { /* had previous return path(s)? */
     if (prop->getType() == VT_NIL) {
       ret.setNullable();

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1099,7 +1099,7 @@ static void propagate_return_type(TypeDesc*& prop, TypeDesc&& ret) {
   }
 }
 
-static void statlist (LexState *ls, TypeDesc *prop = nullptr) {
+static void statlist (LexState *ls, TypeDesc *prop = nullptr, bool no_ret_implies_void = false) {
   /* statlist -> { stat [';'] } */
   bool ret = false;
   while (!block_follow(ls, 1)) {
@@ -1113,7 +1113,8 @@ static void statlist (LexState *ls, TypeDesc *prop = nullptr) {
     if (ret) break;
   }
   if (prop && /* do we need to propagate the return type? */
-      !ret) { /* had no return statement? */
+      !ret && /* had no return statement? */
+      no_ret_implies_void) { /* does that imply a void return? */
     propagate_return_type(prop, VT_VOID); /* propagate */
   }
 }
@@ -1598,7 +1599,7 @@ static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *pr
   }
   TypeDesc rethint = gettypehint(ls, true);
   TypeDesc p = VT_DUNNO;
-  statlist(ls, &p);
+  statlist(ls, &p, true);
   if (rethint.getType() != VT_DUNNO && /* has type hint for return type? */
       p.getType() != VT_DUNNO && /* return type is known? */
       !rethint.isCompatibleWith(p)) { /* incompatible? */

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -136,6 +136,10 @@ struct PrimitiveType {
     return (ValType)(data & 0b1111);
   }
 
+  [[nodiscard]] bool isNull() const noexcept {
+    return getType() == VT_NIL || getType() == VT_VOID;
+  }
+
   [[nodiscard]] bool isNullable() const noexcept {
     return (data >> 4) & 1;
   }
@@ -149,8 +153,7 @@ struct PrimitiveType {
     const auto b_t = b.getType();
     return (a_t == b_t)
         ? (isNullable() || !b.isNullable()) /* if same type, b can't be nullable if a isn't nullable */
-        : ((b_t == VT_NIL && isNullable()) /* if different type, b might still be compatible if a is nullable and b is nil */
-          || (b_t == VT_VOID && isNullable()) /* if different type, b might still be compatible if a is nullable and b is void */
+        : ((isNull() && isNullable()) /* if different type, b might still be compatible if a is nullable and b is null (void or nil) */
           || (a_t == VT_NUMBER && (b_t == VT_INT || b_t == VT_FLT)) /* if different type, b might still be compatible if a is number and b is int or float */
           )
         ;
@@ -205,6 +208,10 @@ struct TypeDesc
 
   [[nodiscard]] ValType getType() const noexcept {
     return primitive.getType();
+  }
+
+  [[nodiscard]] bool isNull() const noexcept {
+    return primitive.isNull();
   }
 
   [[nodiscard]] bool isNullable() const noexcept {

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -71,8 +71,8 @@ typedef enum {
 enum ValType : lu_byte {
   VT_DUNNO = 0,
   VT_VOID,
-  VT_MIXED,
   VT_NIL,
+  VT_MIXED,
   VT_NUMBER,
   VT_INT,
   VT_FLT,
@@ -83,6 +83,10 @@ enum ValType : lu_byte {
 
   NUL_VAL_TYPES
 };
+
+[[nodiscard]] inline bool vtIsNull(ValType vt) {
+  return vt == VT_VOID || vt == VT_NIL;
+}
 
 typedef struct expdesc {
   expkind k;
@@ -136,10 +140,6 @@ struct PrimitiveType {
     return (ValType)(data & 0b1111);
   }
 
-  [[nodiscard]] bool isNull() const noexcept {
-    return getType() == VT_NIL || getType() == VT_VOID;
-  }
-
   [[nodiscard]] bool isNullable() const noexcept {
     return (data >> 4) & 1;
   }
@@ -153,7 +153,7 @@ struct PrimitiveType {
     const auto b_t = b.getType();
     return (a_t == b_t)
         ? (isNullable() || !b.isNullable()) /* if same type, b can't be nullable if a isn't nullable */
-        : ((isNull() && isNullable()) /* if different type, b might still be compatible if a is nullable and b is null (void or nil) */
+        : ((vtIsNull(b_t) && isNullable()) /* if different type, b might still be compatible if a is nullable and b is null (void or nil) */
           || (a_t == VT_NUMBER && (b_t == VT_INT || b_t == VT_FLT)) /* if different type, b might still be compatible if a is number and b is int or float */
           )
         ;
@@ -208,10 +208,6 @@ struct TypeDesc
 
   [[nodiscard]] ValType getType() const noexcept {
     return primitive.getType();
-  }
-
-  [[nodiscard]] bool isNull() const noexcept {
-    return primitive.isNull();
   }
 
   [[nodiscard]] bool isNullable() const noexcept {

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -70,6 +70,7 @@ typedef enum {
 /* types of values, for type hinting and propagation */
 enum ValType : lu_byte {
   VT_DUNNO = 0,
+  VT_VOID,
   VT_MIXED,
   VT_NIL,
   VT_NUMBER,
@@ -149,6 +150,7 @@ struct PrimitiveType {
     return (a_t == b_t)
         ? (isNullable() || !b.isNullable()) /* if same type, b can't be nullable if a isn't nullable */
         : ((b_t == VT_NIL && isNullable()) /* if different type, b might still be compatible if a is nullable and b is nil */
+          || (b_t == VT_VOID && isNullable()) /* if different type, b might still be compatible if a is nullable and b is void */
           || (a_t == VT_NUMBER && (b_t == VT_INT || b_t == VT_FLT)) /* if different type, b might still be compatible if a is number and b is int or float */
           )
         ;
@@ -161,6 +163,7 @@ struct PrimitiveType {
     switch (getType())
     {
     case VT_DUNNO: str.append("dunno"); break;
+    case VT_VOID: str.append("void"); break;
     case VT_MIXED: str.append("mixed"); break;
     case VT_NIL: str.append("nil"); break;
     case VT_NUMBER: str.append("number"); break;

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -171,8 +171,8 @@ struct PrimitiveType {
     {
     case VT_DUNNO: str.append("dunno"); break;
     case VT_VOID: str.append("void"); break;
-    case VT_MIXED: str.append("mixed"); break;
     case VT_NIL: str.append("nil"); break;
+    case VT_MIXED: str.append("mixed"); break;
     case VT_NUMBER: str.append("number"); break;
     case VT_INT: str.append("int"); break;
     case VT_FLT: str.append("float"); break;

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -88,6 +88,10 @@ enum ValType : lu_byte {
   return vt == VT_VOID || vt == VT_NIL;
 }
 
+[[nodiscard]] inline bool vtCanBeNullable(ValType vt) {
+  return !vtIsNull(vt) && vt != VT_MIXED;
+}
+
 typedef struct expdesc {
   expkind k;
   union {


### PR DESCRIPTION
Treating void as a new type so this also raises a warning:
```Lua
local function f(): void
    return nil
end
```
> function was hinted to return void but actually returns nil