### PR TITLE
Add 'pluto_use *' & 'pluto_use <version>'

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -173,6 +173,7 @@ enum WarningType : int
   WT_UNREACHABLE_CODE,
   WT_EXCESSIVE_ARGUMENTS,
   WT_DEPRECATED,
+  WT_BAD_PRACTICE,
 
   NUM_WARNING_TYPES
 };
@@ -185,6 +186,7 @@ inline const char* const luaX_warnNames[] = {
   "unreachable-code",
   "excessive-arguments",
   "deprecated",
+  "bad-practice",
 };
 
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3929,16 +3929,18 @@ static void retstat (LexState *ls, TypeDesc *prop) {
 
 
 static int checkkeyword (LexState *ls) {
-  if (ls->t.token == TK_NAME)
-    for (int i = FIRST_NON_COMPAT; i != FIRST_SPECIAL; ++i)
-      if (strcmp(luaX_reserved2str(i), ls->t.seminfo.ts->contents) == 0) {
-        luaX_next(ls);
-        return i;
-      }
-  if (!ls->t.IsNonCompatible()) {
-    if (ls->t.IsCompatible())
-      luaX_syntaxerror(ls, "expected non-compatible keyword");
-    luaX_syntaxerror(ls, "expected keyword");
+  if (ls->t.token != '*') {
+    if (ls->t.token == TK_NAME)
+      for (int i = FIRST_NON_COMPAT; i != FIRST_SPECIAL; ++i)
+        if (strcmp(luaX_reserved2str(i), ls->t.seminfo.ts->contents) == 0) {
+          luaX_next(ls);
+          return i;
+        }
+    if (!ls->t.IsNonCompatible()) {
+      if (ls->t.IsCompatible())
+        luaX_syntaxerror(ls, "expected non-compatible keyword");
+      luaX_syntaxerror(ls, "expected keyword");
+    }
   }
   int token = ls->t.token;
   luaX_next(ls);
@@ -3990,7 +3992,12 @@ static void usestat (LexState *ls) {
         enable = false;
       else checknext(ls, TK_TRUE);
     }
-    if (is_enabled != enable) {
+    if (token == '*') {
+      for (int i = FIRST_NON_COMPAT; i != FIRST_SPECIAL; ++i) {
+        togglekeyword(ls, i, enable);
+      }
+    }
+    else if (is_enabled != enable) {
       togglekeyword(ls, token, enable);
     }
   } while (testnext(ls, ','));

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3980,6 +3980,7 @@ static void togglekeyword (LexState *ls, int token, bool enable) {
 }
 
 static void usestat (LexState *ls) {
+  auto line = ls->getLineNumber();
   luaX_next(ls); /* skip 'pluto_use' */
   do {
     /* check affected tokens */
@@ -4020,9 +4021,9 @@ static void usestat (LexState *ls) {
       else checknext(ls, TK_TRUE);
     }
 
-    /* disallow stupid stuff */
+    /* catch stupid stuff */
     if (is_all && enable)
-      throwerr(ls, "'pluto_use *' is only valid as 'pluto_use * = false'", "did you mean 'pluto_use \"0.6.0\"'?");
+      throw_warn(ls, "'pluto_use *' is a bad idea because future Pluto versions may add keywords that will break your script", "consider using 'pluto_use \"0.6.0\"' instead", line, WT_BAD_PRACTICE);
     if (is_version && !enable)
       throwerr(ls, "'pluto_use <version>' is not valid for disabling tokens", "did you mean 'pluto_use * = false'?");
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3954,7 +3954,6 @@ static void disablekeyword (LexState *ls, int token) {
       i->token = TK_NAME;
 }
 
-
 static void enablekeyword (LexState *ls, int token) {
   const char* str = luaX_reserved2str(token);
   auto i = ls->tokens.begin() + ls->tidx;
@@ -3973,6 +3972,13 @@ static void enablekeyword (LexState *ls, int token) {
         i->token = token;
 }
 
+static void togglekeyword (LexState *ls, int token, bool enable) {
+  if (enable)
+    enablekeyword(ls, token);
+  else
+    disablekeyword(ls, token);
+}
+
 static void usestat (LexState *ls) {
   luaX_next(ls); /* skip 'pluto_use' */
   do {
@@ -3985,10 +3991,7 @@ static void usestat (LexState *ls) {
       else checknext(ls, TK_TRUE);
     }
     if (is_enabled != enable) {
-      if (enable)
-        enablekeyword(ls, token);
-      else
-        disablekeyword(ls, token);
+      togglekeyword(ls, token, enable);
     }
   } while (testnext(ls, ','));
 


### PR DESCRIPTION
Existing behaviour:
- `pluto_use class` — disable compatibility mode for "class"
- `pluto_use class = false` — enable compatibility mode for "class"

Added behaviour:
- `pluto_use *` — disable compatibility mode for all tokens but raises new warning type (bad-practice)
- `pluto_use * = false` — full compatibility mode, forcing the script to be portable
- `pluto_use <version>` — enable compatibility mode for all tokens added after `<version>` and disable compatibility mode for all tokens added in `<version>` and before
- `pluto_use <version> = false` — syntax error
