### PR TITLE
Support ++ statement for table properties

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2744,10 +2744,13 @@ static BinOpr getbinopr (int op) {
 }
 
 
-static void prefixplusplus (LexState *ls, expdesc *v) {
+static void prefixplusplus (LexState *ls, expdesc *v, bool as_statement) {
   int line = ls->getLineNumber();
   luaX_next(ls); /* skip second '+' */
-  singlevar(ls, v); /* variable name */
+  if (as_statement)
+    suffixedexp(ls, v);
+  else
+    singlevar(ls, v); /* variable name */
   FuncState *fs = ls->fs;
   expdesc e = *v, v2;
   if (v->k != VLOCAL) {  /* complex lvalue, use a temporary register. linear perf incr. with complexity of lvalue */
@@ -2817,7 +2820,7 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeDesc *prop = nul
     int line = ls->getLineNumber();
     luaX_next(ls); /* skip '+' */
     if (ls->t.token == '+') { /* '++' ? */
-      prefixplusplus(ls, v);
+      prefixplusplus(ls, v, false);
     }
     else {
       /* support pseudo-unary '+' by implying '0 + subexpr' */
@@ -4268,7 +4271,7 @@ static void statement (LexState *ls, TypeDesc *prop) {
       luaX_next(ls);
       check(ls, '+');
       expdesc v;
-      prefixplusplus(ls, &v);
+      prefixplusplus(ls, &v, true);
       break;
     }
     default: {  /* stat -> func | assignment */

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -855,6 +855,10 @@ do
     local a = 1
     ++a
     assert(a == 2)
+
+    local t = { a = 1 }
+    ++t.a
+    assert(t.a == 2)
 end
 
 print "Testing non-ascii variable names."


### PR DESCRIPTION
I unfortunately had to restrict this to the ++ statement because the expression can't use extra registers without bricking the function call.