### PR TITLE
Fix in expression with nested tables

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2691,6 +2691,7 @@ static void inexpr (LexState *ls, expdesc *v) {
   expdesc v2;
   checknext(ls, TK_IN);
   expr(ls, &v2);
+  luaK_dischargevars(ls->fs, &v2);
   luaK_exp2nextreg(ls->fs, v);
   lua_assert(v->k == VNONRELOC);
   int base = v->u.info;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2690,7 +2690,7 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, TypeDesc *prop) {
 static void inexpr (LexState *ls, expdesc *v) {
   expdesc v2;
   checknext(ls, TK_IN);
-  expr(ls, &v2);
+  simpleexp(ls, &v2);
   luaK_dischargevars(ls->fs, &v2);
   luaK_exp2nextreg(ls->fs, v);
   lua_assert(v->k == VNONRELOC);

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -269,6 +269,18 @@ print "Testing new 'in' expressions."
 if ("hel" in "hello") != true then error() end
 if ("abc" in "hello") != false then error() end
 do
+    local t = {
+        apple = true,
+        [69] = true,
+    }
+    assert("apple" in t)
+    assert("banana" in t == false)
+    assert(42 in t == false)
+    assert(69 in t)
+    assert(true in t == false)
+    assert(false in t == false)
+end
+do
     -- table must be global for this failure case
     t = {
         subt = {}

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -268,6 +268,17 @@ end
 print "Testing new 'in' expressions."
 if ("hel" in "hello") != true then error() end
 if ("abc" in "hello") != false then error() end
+do
+    -- table must be global for this failure case
+    t = {
+        subt = {}
+    }
+    local function proxy(b)
+        assert(b == false)
+    end
+    proxy(42 in t.subt)
+    t = nil
+end
 
 print "Testing break N syntax."
 do


### PR DESCRIPTION
Also made the consumption of right-hand operand less greedy, so e.g. `== false` is not considered as a part of it.