### PR TITLE
Allow empty properties & type hints for class

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1283,7 +1283,7 @@ static void recfield (LexState *ls, ConsControl *cc) {
   fs->freereg = reg;  /* free registers */
 }
 
-static void prenamedfield(LexState* ls, ConsControl* cc, const char* name) {
+static void prenamedfield (LexState *ls, ConsControl *cc, const char *name) {
   FuncState* fs = ls->fs;
   int reg = ls->fs->freereg;
   expdesc tab, key, val;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1518,7 +1518,6 @@ static void classexpr (LexState *ls, expdesc *t) {
   init_exp(&cc.v, VVOID, 0);  /* no value (yet) */
   while (ls->t.token != TK_END) {
     lua_assert(cc.v.k == VVOID || cc.tostore > 0);
-    if (ls->t.token == '}') break;
     closelistfield(fs, &cc);
     field(ls, &cc);
     (testnext(ls, ',') || testnext(ls, ';'));

--- a/tests/basic.pluto
+++ b/tests/basic.pluto
@@ -1054,6 +1054,12 @@ do
     c.num = 42
     assert(c.num == 42)
 end
+do
+    local class ClassParsingTest
+        property_no_value
+        property_type_hint: string
+    end
+end
 
 print "Testing named varargs."
 do


### PR DESCRIPTION
Re #293. Only a parsing change right now, but we may start emitting type mismatch warnings at some point in the future.