### PR TITLE
Allow expsuffix after new

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2683,7 +2683,7 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, TypeDesc *prop) {
     case TK_PNEW: {
       if (prop) *prop = VT_TABLE;
       newexpr(ls, v);
-      return;
+      break;
     }
 #ifndef PLUTO_COMPATIBLE_CLASS
     case TK_CLASS:


### PR DESCRIPTION
This sorta fixes #299/#300, as in, the following is now valid syntax:
```Lua
print(new Human("John").name)
```
However, this is still invalid, because 'new' is only an expression, not a statement:
```Lua
new Human("John"):sayHello()
```