### PR TITLE
Improve type hinting and propagation to support more alternatives than just nilable or not

### DIFF
--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -774,7 +774,7 @@ void luaK_dischargevars (FuncState *fs, expdesc *e) {
       break;
     }
     case VLOCAL: {  /* already in a register */
-      e->code_primitive = getlocalvardesc(fs, e->u.var.vidx)->vd.prop.getType();
+      e->code_primitive = getlocalvardesc(fs, e->u.var.vidx)->vd.prop.toPrimitive();
       e->u.info = e->u.var.ridx;
       e->k = VNONRELOC;  /* becomes a non-relocatable value */
       break;

--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -774,7 +774,7 @@ void luaK_dischargevars (FuncState *fs, expdesc *e) {
       break;
     }
     case VLOCAL: {  /* already in a register */
-      e->code_primitive = getlocalvardesc(fs, e->u.var.vidx)->vd.prop.toPrimitive();
+      e->code_primitive = getlocalvardesc(fs, e->u.var.vidx)->vd.prop->toPrimitive();
       e->u.info = e->u.var.ridx;
       e->k = VNONRELOC;  /* becomes a non-relocatable value */
       break;

--- a/src/llex.h
+++ b/src/llex.h
@@ -311,6 +311,7 @@ struct LexState {
   std::stack<TString*> parent_classes{};
   std::vector<EnumDesc> enums{};
   std::vector<TString*> export_symbols{};
+  std::vector<void*> parse_time_allocations{};
 
   LexState()
     : lines{ std::string{} }, warnconfs{ WarningConfig(0) }
@@ -318,6 +319,12 @@ struct LexState {
     laststat = Token {};
     laststat.token = TK_EOS;
     parser_context_stck.push(PARCTX_NONE); /* ensure there is at least 1 item on the parser context stack */
+  }
+
+  ~LexState() {
+    for (auto& a : parse_time_allocations) {
+      free(a);
+    }
   }
 
   [[nodiscard]] bool hasDoneLexerPass() const noexcept {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2635,9 +2635,14 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, TypeHint *prop) {
     }
     case TK_FUNCTION: {
       luaX_next(ls);
-      TypeDesc funcdesc;
-      body(ls, v, 0, ls->getLineNumber(), &funcdesc);
-      prop->emplaceTypeDesc(std::move(funcdesc));
+      if (prop) {
+        TypeDesc funcdesc;
+        body(ls, v, 0, ls->getLineNumber(), &funcdesc);
+        prop->emplaceTypeDesc(std::move(funcdesc));
+      }
+      else {
+        body(ls, v, 0, ls->getLineNumber());
+      }
       return;
     }
     case '|': {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3948,7 +3948,7 @@ static void retstat (LexState *ls, TypeHint *prop) {
     || ls->t.token == TK_CASE || ls->t.token == TK_DEFAULT
   ) {
     nret = 0;  /* return no values */
-    if (prop) *prop = VT_VOID;
+    if (prop) prop->emplaceTypeDesc(VT_VOID);
   }
   else {
     nret = explist(ls, &e, prop);  /* optional return values */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1135,10 +1135,12 @@ static bool statlist (LexState *ls, TypeHint *prop = nullptr, bool no_ret_implie
     }
     if (ret) break;
   }
-  if (prop && /* do we need to propagate the return type? */
-      !ret && /* had no return statement? */
-      no_ret_implies_void) { /* does that imply a void return? */
-    prop->emplaceTypeDesc(VT_VOID); /* propagate */
+  if (prop) { /* do we need to propagate the return type? */
+    if (!ret && /* had no return statement? */
+        no_ret_implies_void) { /* does that imply a void return? */
+      prop->emplaceTypeDesc(VT_VOID); /* propagate */
+    }
+    prop->fixTypes();
   }
   return ret;
 }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1138,7 +1138,7 @@ static bool statlist (LexState *ls, TypeHint *prop = nullptr, bool no_ret_implie
   if (prop && /* do we need to propagate the return type? */
       !ret && /* had no return statement? */
       no_ret_implies_void) { /* does that imply a void return? */
-      prop->emplaceTypeDesc(VT_VOID); /* propagate */
+    prop->emplaceTypeDesc(VT_VOID); /* propagate */
   }
   return ret;
 }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1499,7 +1499,8 @@ static void applyextends (LexState *ls, expdesc *v, TString *parent, int line) {
   FuncState *fs = ls->fs;
 
   expdesc f;
-  singlevar(ls, &f, luaS_newliteral(ls->L, "Pluto_operator_extends"));
+  singlevaraux(fs, luaS_newliteral(ls->L, "Pluto_operator_extends"), &f, 1);
+  lua_assert(f.k != VVOID);
   luaK_exp2nextreg(fs, &f);
 
   expdesc args = *v;

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -250,6 +250,18 @@ struct TypeHint {
     return contains(VT_NIL);
   }
 
+  void fixTypes() {
+    if (descs[1].type != VT_DUNNO) { /* contains more than 1 type? */
+      /* convert 'void' to 'nil' */
+      for (auto& desc : descs) {
+        if (desc.type == VT_VOID) {
+          desc.type = VT_NIL;
+          break;
+        }
+      }
+    }
+  }
+
   [[nodiscard]] std::string toString() const {
     std::string str{};
     if (isNullable())

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -285,8 +285,8 @@ typedef union Vardesc {
   struct {
     TValuefields;  /* constant value (if it is a compile-time constant) */
     lu_byte kind;
-    TypeHint hint;
-    TypeHint prop; /* type propagation */
+    TypeHint* hint;
+    TypeHint* prop; /* type propagation */
     lu_byte ridx;  /* register holding the variable */
     short pidx;  /* index of the variable in the Proto's 'locvars' array */
     TString *name;  /* variable name */

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -95,6 +95,7 @@ enum ValType : lu_byte {
     case VT_STR: return "string";
     case VT_TABLE: return "table";
     case VT_FUNC: return "function";
+    default:;
   }
   return "ERROR";
 }

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -226,7 +226,8 @@ struct TypeHint {
   }
 
   [[nodiscard]] bool isCompatibleWith(const TypeDesc& td) const noexcept {
-    return contains(td.type);
+    return contains(td.type)
+        || ((td.type == VT_INT || td.type == VT_FLT) && contains(VT_NUMBER));
   }
 
   [[nodiscard]] bool isCompatibleWith(const TypeHint& b) const noexcept {

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -190,6 +190,8 @@ struct TypeHint {
     emplaceTypeDesc(vt);
   }
 
+  void operator=(ValType) = delete;
+
   void clear() noexcept {
     for (auto& desc : descs) {
       desc.type = VT_DUNNO;


### PR DESCRIPTION
```Lua
local function a(a: int|string): string|int
    return {}
end
a({})
```
> basic.pluto:1: warning: function was hinted to return string|int but actually returns table [type-mismatch]
basic.pluto:4: warning: Function's a parameter was type-hinted as int|string but provided with table [type-mismatch]
    4 | a({})
      | ^^^^^ here: argument type mismatch