### PR TITLE
Improve string lexing

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -741,6 +741,11 @@ static int llex (LexState *ls, SemInfo *seminfo, bool for_interpolated_string) {
         if (!check_next1(ls, '"') && !check_next1(ls, '\''))
           return '$';
         ls->appendLineBuff(del);
+        {
+          Token& t = ls->tokens.emplace_back(Token{});
+          t.token = '(';
+          t.line = (int)ls->lines.size();
+        }
         bool need_concat = false;
         while (ls->current != del) {
           switch (ls->current) {
@@ -808,6 +813,11 @@ static int llex (LexState *ls, SemInfo *seminfo, bool for_interpolated_string) {
         }
         next(ls);  /* skip delimiter */
         ls->appendLineBuff(del);
+        {
+          Token& t = ls->tokens.emplace_back(Token{});
+          t.token = ')';
+          t.line = (int)ls->lines.size();
+        }
         break;
       }
       case '.': {  /* '.', '..', '...', or number */


### PR DESCRIPTION
I've decided to simply wrap it with '(' and ')' to avoid the error, but if we wanted it to error, we could maybe special-case the error message so it's less confusing.