### PR TITLE
Improve unreachable code warning

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -345,22 +345,6 @@ struct LexState {
     return tidx == (size_t)-1 ? 1 : tokens.at(tidx).line;
   }
 
-
-  /// Find a substring within the current line buffer.
-  /// There is an overload that allows a line number as the first argument to search a specific line.
-  [[nodiscard]] bool findWithinLine(const std::string& substr, int offset = 0) noexcept
-  {
-    const std::string& str = getLineBuff();
-    return str.find(substr, offset) != std::string::npos;
-  }
-
-  /// Find a substring within the respective line.
-  /// There is an overload that allows you to omit the 'line' argument and default to the current line buffer.
-  [[nodiscard]] bool findWithinLine(int line, const std::string& substr, int offset = 0) const noexcept {
-    const std::string& str = getLineString(line);
-    return str.find(substr, offset) != std::string::npos;
-  }
-
   [[nodiscard]] int getLineNumberOfLastNonEmptyLine() const noexcept {
     for (int line = getLineNumber(); line != 0; --line) {
       if (!getLineString(line).empty()) {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4233,7 +4233,7 @@ static void statement (LexState *ls, TypeHint *prop) {
   int line = ls->getLineNumber();
   if (ls->t.token != ';') {
     if (ls->laststat.IsEscapingToken()
-      || (ls->laststat.Is(TK_GOTO) && !ls->findWithinLine(line, luaX_lookbehind(ls).seminfo.ts->toCpp()))) /* Don't warn if this statement is the goto's label. */
+      || (ls->laststat.Is(TK_GOTO) && ls->t.token != TK_DBCOLON)) /* Don't warn if this statement is a goto label. */
     {
       throw_warn(ls,
         "unreachable code",

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4231,17 +4231,17 @@ static void statement (LexState *ls, TypeHint *prop) {
     return;
   }
   int line = ls->getLineNumber();
-  if ((ls->laststat.IsEscapingToken()
-    || (ls->laststat.Is(TK_GOTO) && !ls->findWithinLine(line, luaX_lookbehind(ls).seminfo.ts->toCpp()))) /* Don't warn if this statement is the goto's label. */
-    && ls->t.token != ';') /* Don't warn if this is only a semicolon */
-  {
-    throw_warn(ls,
-      "unreachable code",
-        luaO_fmt(ls->L, "this code comes after an escaping %s statement.", luaX_token2str(ls, ls->laststat.token)), WT_UNREACHABLE_CODE);
-    ls->L->top.p--;
-  }
-  if (ls->t.token != ';')
+  if (ls->t.token != ';') {
+    if (ls->laststat.IsEscapingToken()
+      || (ls->laststat.Is(TK_GOTO) && !ls->findWithinLine(line, luaX_lookbehind(ls).seminfo.ts->toCpp()))) /* Don't warn if this statement is the goto's label. */
+    {
+      throw_warn(ls,
+        "unreachable code",
+          luaO_fmt(ls->L, "this code comes after an escaping %s statement.", luaX_token2str(ls, ls->laststat.token)), WT_UNREACHABLE_CODE);
+      ls->L->top.p--;
+    }
     ls->laststat.token = ls->t.token;
+  }
   enterlevel(ls);
   switch (ls->t.token) {
     case ';': {  /* stat -> ';' (empty statement) */


### PR DESCRIPTION
This solves 2 problems:
- luaX_lookbehind may land on a semicolon due to laststat not being updated by them; accessing seminfo of a semicolon is undefined behaviour afaik
- The line following a goto containing the label name e.g. in a string would suppress the warning unexpectedly