### PR TITLE
Add dumpvar & exportvar

### DIFF
--- a/src/lapi.cpp
+++ b/src/lapi.cpp
@@ -58,7 +58,7 @@ const char lua_ident[] =
 ** Convert an acceptable index to a pointer to its respective value.
 ** Non-valid indices return the special nil value 'G(L)->nilvalue'.
 */
-static TValue *index2value (lua_State *L, int idx) {
+TValue *index2value (lua_State *L, int idx) {
   CallInfo *ci = L->ci;
   if (idx > 0) {
     StkId o = ci->func.p + idx;

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -554,11 +554,17 @@ static int luaB_newuserdata (lua_State *L) {
 
 
 TValue *index2value (lua_State *L, int idx);
+void addquoted (luaL_Buffer *b, const char *s, size_t len);
 
 static void luaB_dump_impl (lua_State *L, int indents, Table *recursion_marker) {
   if (lua_type(L, -1) != LUA_TTABLE) {
     if (lua_type(L, -1) == LUA_TSTRING) {
-      luaO_pushfstring(L, "\"%s\"", lua_tostring(L, -1));
+      size_t l;
+      const char *s = lua_tolstring(L, -1, &l);
+      luaL_Buffer b;
+      luaL_buffinit(L, &b);
+      addquoted(&b, s, l);
+      luaL_pushresult(&b);
     }
     else {
       luaL_tolstring(L, -1, NULL);

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -556,7 +556,7 @@ static int luaB_newuserdata (lua_State *L) {
 TValue *index2value (lua_State *L, int idx);
 void addquoted (luaL_Buffer *b, const char *s, size_t len);
 
-static void luaB_dump_impl (lua_State *L, int indents, Table *recursion_marker) {
+static void luaB_dumpvar_impl (lua_State *L, int indents, Table *recursion_marker) {
   if (lua_type(L, -1) != LUA_TTABLE) {
     if (lua_type(L, -1) == LUA_TSTRING) {
       size_t l;
@@ -587,13 +587,13 @@ static void luaB_dump_impl (lua_State *L, int indents, Table *recursion_marker) 
     dump.append(indents, '\t');
     dump.push_back('[');
     lua_pushvalue(L, -2);
-    luaB_dump_impl(L, indents + 1, recursion_marker);
+    luaB_dumpvar_impl(L, indents + 1, recursion_marker);
     dump.append(lua_tostring(L, -1));
     lua_pop(L, 2);
     dump.append("] = ");
 
     lua_pushvalue(L, -1);
-    luaB_dump_impl(L, indents + 1, recursion_marker);
+    luaB_dumpvar_impl(L, indents + 1, recursion_marker);
     dump.append(lua_tostring(L, -1));
     lua_pop(L, 2);
     dump.append(",\n");
@@ -605,16 +605,16 @@ static void luaB_dump_impl (lua_State *L, int indents, Table *recursion_marker) 
   pluto_pushstring(L, dump);
 }
 
-static int luaB_dump (lua_State *L) {
+static int luaB_dumpvar (lua_State *L) {
   luaL_checkany(L, 1);
   lua_pushvalue(L, 1);
-  luaB_dump_impl(L, 1, hvalue(index2value(L, -1)));
+  luaB_dumpvar_impl(L, 1, hvalue(index2value(L, -1)));
   return 1;
 }
 
 
 static const luaL_Reg base_funcs[] = {
-  {"dump", luaB_dump},
+  {"dumpvar", luaB_dumpvar},
   {"newuserdata", luaB_newuserdata},
   {"assert", luaB_assert},
   {"collectgarbage", luaB_collectgarbage},

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -557,7 +557,12 @@ TValue *index2value (lua_State *L, int idx);
 
 static void luaB_dump_impl (lua_State *L, int indents, Table *recursion_marker) {
   if (lua_type(L, -1) != LUA_TTABLE) {
-    luaL_tolstring(L, -1, NULL);
+    if (lua_type(L, -1) == LUA_TSTRING) {
+      luaO_pushfstring(L, "\"%s\"", lua_tostring(L, -1));
+    }
+    else {
+      luaL_tolstring(L, -1, NULL);
+    }
     return;
   }
   if (indents != 1 && hvalue(index2value(L, -1)) == recursion_marker) {
@@ -575,8 +580,10 @@ static void luaB_dump_impl (lua_State *L, int indents, Table *recursion_marker) 
 
     dump.append(indents, '\t');
     dump.push_back('[');
-    dump.append(luaL_tolstring(L, -2, NULL));
-    lua_pop(L, 1);
+    lua_pushvalue(L, -2);
+    luaB_dump_impl(L, indents + 1, recursion_marker);
+    dump.append(lua_tostring(L, -1));
+    lua_pop(L, 2);
     dump.append("] = ");
 
     lua_pushvalue(L, -1);

--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -1146,7 +1146,7 @@ static int lua_number2strx (lua_State *L, char *buff, int sz,
 #define MAX_FORMAT	32
 
 
-static void addquoted (luaL_Buffer *b, const char *s, size_t len) {
+void addquoted (luaL_Buffer *b, const char *s, size_t len) {
   luaL_addchar(b, '"');
   while (len--) {
     if (*s == '"' || *s == '\\' || *s == '\n') {

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -1205,39 +1205,7 @@ LUAI_FUNC int luaB_ipairsaux (lua_State *L);
 {
   std::ostringstream str { };
 
-  switch (ttype(t))
-  {
-    case LUA_TNIL:
-      str << "nil";
-      break;
-    case LUA_TBOOLEAN: 
-      str << "boolean";
-      break;
-    case LUA_TLIGHTUSERDATA: 
-      str << "lightuserdata";
-      break;
-    case LUA_TNUMBER:
-      str << "number";
-      break;
-    case LUA_TSTRING:
-      str << "string";
-      break;
-    case LUA_TTABLE:
-      str << "table";
-      break;
-    case LUA_TFUNCTION:
-      str << "function";
-      break;
-    case LUA_TUSERDATA:
-      str << "userdata";
-      break;
-    case LUA_TTHREAD:
-      str << "thread";
-      break;
-    default:
-      str << "unknown";
-  }
-  
+  str << ttypename(ttype(t));
   str << "-";
   str << (void*)t;
 


### PR DESCRIPTION
The original goal was table.dump (#337), but I ended up being a bit inspired by PHP's var_dump and var_export.

```Lua
local t = {
	[1] = "a",
	[2] = "b",
	["a"] = 1,
	["b"] = 2,
	["t"] = {
		["deez"] = "nuts"
	}
}
t["r"] = t
print(dumpvar(t))
```

Possible output:
```
{
        [1] = "a",
        [2] = "b",
        ["a"] = 1,
        ["b"] = 2,
        ["r"] = *RECURSION*,
        ["t"] = {
                ["deez"] = "nuts",
        },
}
```
---
TODO:
- [x] Quote strings
- [x] Add `exportvar` that guarantees valid Lua code, so errors on recursion