### PR TITLE
Add initial type propagation for global variables

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -11,6 +11,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "lobject.h"
@@ -321,6 +322,7 @@ struct LexState {
   std::vector<EnumDesc> enums{};
   std::vector<TString*> export_symbols{};
   std::vector<void*> parse_time_allocations{};
+  std::unordered_map<const TString*, void*> global_props{};
 
   LexState()
     : lines{ std::string{} }, warnconfs{ WarningConfig(0) }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -476,6 +476,16 @@ static void process_assign(LexState* ls, Vardesc* var, const TypeHint& t, int li
 }
 
 
+static TypeHint& get_global_prop(LexState* ls, const TString* name) {
+  if (auto e = ls->global_props.find(name); e != ls->global_props.end()) {
+    return *reinterpret_cast<TypeHint*>(e->second);
+  }
+  auto th = new_typehint(ls);
+  ls->global_props.emplace(name, th);
+  return *th;
+}
+
+
 /*
 ** Convert 'nvar', a compiler index level, to its corresponding
 ** register. For that, search for the highest variable below that level
@@ -2499,6 +2509,12 @@ static void suffixedexp (LexState *ls, expdesc *v, int flags = 0, TypeHint *prop
   /* suffixedexp ->
        primaryexp { '.' NAME | '[' exp ']' | ':' NAME funcargs | funcargs } */
   primaryexp(ls, v);
+  if (prop) {
+    if (v->k == VINDEXUP) {
+      TValue *key = &ls->fs->f->k[v->u.ind.idx];
+      prop->merge(get_global_prop(ls, tsvalue(key)));
+    }
+  }
   expsuffix(ls, v, flags, prop);
 }
 
@@ -3164,6 +3180,11 @@ static void restassign (LexState *ls, struct LHS_assign *lh, int nvars) {
         adjust_assign(ls, nvars, nexps, &e);
       else {
         luaK_setoneret(ls->fs, &e);  /* close last expression */
+        if (lh->v.k == VINDEXUP) {
+          TValue *key = &ls->fs->f->k[lh->v.u.ind.idx];
+          lua_assert(ttype(key) == LUA_TSTRING);
+          get_global_prop(ls, tsvalue(key)).merge(prop);
+        }
         if (lh->v.k == VLOCAL) { /* assigning to a local variable? */
           exp_propagate(ls, e, prop);
           process_assign(ls, getlocalvardesc(ls->fs, lh->v.u.var.vidx), prop, line);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -388,6 +388,11 @@ static int registerlocalvar (LexState *ls, FuncState *fs, TString *varname) {
       luaX_newstring(ls, "" v, (sizeof(v)/sizeof(char)) - 1));
 
 
+static TypeHint* new_typehint (LexState *ls) {
+  return ::new (ls->parse_time_allocations.emplace_back(malloc(sizeof(TypeHint)))) TypeHint();
+}
+
+
 [[nodiscard]] static TypeHint gettypehint (LexState *ls, bool funcret = false) noexcept {
   /* TYPEHINT -> [':' TYPEDESC { '|' TYPEDESC } ] */
   TypeHint th;
@@ -507,11 +512,6 @@ static LocVar *localdebuginfo (FuncState *fs, int vidx) {
     lua_assert(idx < fs->ndebugvars);
     return &fs->f->locvars[idx];
   }
-}
-
-
-static TypeHint* new_typehint (LexState *ls) {
-  return ::new (ls->parse_time_allocations.emplace_back(malloc(sizeof(TypeHint)))) TypeHint();
 }
 
 


### PR DESCRIPTION
Can now raise a warning for this code:
```Lua
a = 69
local b: string = a
print(b)
```