### PR TITLE
Fail faster when parsing non-compound assignment

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3027,7 +3027,7 @@ static void check_conflict (LexState *ls, struct LHS_assign *lh, expdesc *v) {
   reserves N registers (where N = local variables on stack)
   preforms binary operation and assignment
 */ 
-static void compoundassign(LexState *ls, expdesc *v, BinOpr op) {
+static void compoundassign (LexState *ls, expdesc *v, BinOpr op) {
   luaX_next(ls);
   int line = ls->getLineNumber();
   FuncState *fs = ls->fs;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3078,8 +3078,9 @@ static void restassign (LexState *ls, struct LHS_assign *lh, int nvars) {
   }
   else {  /* restassign -> '=' explist */
     check(ls, '=');
-    BinOpr op = getbinopr((int)ls->t.seminfo.i);  /* binary operation from lexer state */
-    if (op != OPR_NOBINOPR) {  /* is there a saved binop? */
+    if ((int)ls->t.seminfo.i != 0) {  /* is there a saved binop? */
+      BinOpr op = getbinopr((int)ls->t.seminfo.i);  /* binary operation from lexer state */
+      lua_assert(op != OPR_NOBINOPR);
       check_condition(ls, nvars == 1, "unsupported tuple assignment");
       compoundassign(ls, &lh->v, op);  /* perform binop & assignment */
       return;  /* avoid default */


### PR DESCRIPTION
No need to call `getbinopr` to determine if we're on a compound assign token