### PR TITLE
Changes to OP_IN

### DIFF
--- a/src/lvm.h
+++ b/src/lvm.h
@@ -134,3 +134,4 @@ LUAI_FUNC lua_Integer luaV_mod (lua_State *L, lua_Integer x, lua_Integer y);
 LUAI_FUNC lua_Number luaV_modf (lua_State *L, lua_Number x, lua_Number y);
 LUAI_FUNC lua_Integer luaV_shiftl (lua_Integer x, lua_Integer y);
 LUAI_FUNC void luaV_objlen (lua_State *L, StkId ra, const TValue *rb);
+LUAI_FUNC bool luaV_searchelement(lua_State* L, const Table* t, const TValue* element);

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -282,21 +282,29 @@ if ("hel" in "hello") != true then error() end
 if ("abc" in "hello") != false then error() end
 do
     local t = {
-        apple = true,
-        [69] = true,
+        nil,
+        key = "KEY",
+        nil,
+        "ARRAY"
     }
-    assert("apple" in t)
-    assert("banana" in t == false)
-    assert(42 in t == false)
-    assert(69 in t)
-    assert(true in t == false)
-    assert(false in t == false)
+    assert(nil in t)
+    assert("KEY" in t)
+    assert("ARRAY" in t)
+    assert(("NOTHING" in t) == false)
 end
 do
     -- table must be global for this failure case
     t = {
-        subt = {}
+        subt = {
+            nil,
+            key = "KEY",
+            nil,
+            "ARRAY"
+        }
     }
+    assert(nil in t.subt)
+    assert("KEY" in t.subt)
+    assert("ARRAY" in t.subt)
     local function proxy(b)
         assert(b == false)
     end
@@ -305,9 +313,39 @@ do
 end
 do
     -- temporary table
-    assert("apple" in { apple = true })
+    assert("apple" in { 1, nil, "aaaa", "apple" })
     assert(not "banana" in { apple = true })
     assert(type("apple" in { apple = true }) == "boolean")
+end
+do -- check stack corruption
+    local t = {
+        nil,
+        key = "KEY",
+        nil,
+        "ARRAY"
+    }
+
+    local a = "KEY"
+    assert(a in t)
+    assert(a == "KEY")
+    local b = || -> "Hello World"
+    local c = "ARRAY"
+    local d = nil
+    assert(c in t)
+    assert(d in t)
+    local e = "NOTHING"
+    assert(not e in t)
+    assert(a == "KEY")
+    assert(b() == "Hello World")
+    assert(c == "ARRAY")
+    assert(d == nil)
+    assert(e == "NOTHING")
+end
+do 
+    local t = {key="value"}
+    assert(("key" in t) == false)
+    t[1] = "world"
+    assert((1 in t) == false)
 end
 
 print "Testing break N syntax."


### PR DESCRIPTION
This feature is a complete mess. Somewhere across the line it became an equivalent to searching for a key which, for obvious reasons, is a totally useless operation. The documentation largely describes this feature as doing what it does now _after_ this fix so it's not really a breaking change. 

Sticking it with 0.8.0 since this stuff (1) needs extended testing; and (2) blurs the line between feature/behavior change and bugfix since this has at least been implied to of been proper behavior.

New behavior:
1. When in table: checks for an element. Both an element inside of an array and an element that belongs to a key. This is useful. `table.contains` exists but this is an elegant short-hand. It's also 3x faster than table.contains for obvious reasons.
2. Same for strings: checks for substring.