### PR TITLE
Add "not in" syntax to compliment 'in' boolean inversion

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3004,7 +3004,7 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, TypeHint *prop) {
 }
 
 
-static void inexpr (LexState *ls, expdesc *v) {
+static void inexpr (LexState *ls, expdesc *v, bool invert = false) {
   expdesc v2;
   checknext(ls, TK_IN);
   luaK_exp2nextreg(ls->fs, v);
@@ -3013,7 +3013,7 @@ static void inexpr (LexState *ls, expdesc *v) {
   simpleexp(ls, &v2);
   luaK_dischargevars(ls->fs, &v2);
   luaK_exp2nextreg(ls->fs, &v2);
-  luaK_codeABC(ls->fs, OP_IN, v->u.info, v2.u.info, 0);
+  luaK_codeABC(ls->fs, OP_IN, v->u.info, v2.u.info, invert ? 1 : 0);
   ls->fs->freereg = base + 1;
 }
 
@@ -3150,8 +3150,12 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop = nul
   }
   else {
     simpleexp(ls, v, flags, prop);
-    if (ls->t.token == TK_IN) {
-      inexpr(ls, v);
+    const bool inverted_in = ls->t.token == TK_NOT && luaX_lookahead(ls) == TK_IN;
+    if (ls->t.token == TK_IN || inverted_in) {
+      if (inverted_in) {
+        testnext(ls, TK_NOT);
+      }
+      inexpr(ls, v, inverted_in);
       if (prop) prop->emplaceTypeDesc(VT_BOOL);
     }
   }

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -2632,25 +2632,30 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         StkId ra = RA(i);
         TValue *a = s2v(ra);
         TValue *b = vRB(i);
+        bool result = false;
 #ifdef PLUTO_VMDUMP
         std::string old = stringify_tvalue(a);  /* RA will be changed below. */
 #endif
         if (ttisstring(a) && ttisstring(b)) {
           if (strstr(getstr(tsvalue(b)), getstr(tsvalue(a))) != nullptr) {
-            setbtvalue(s2v(ra));
-          } else {
-            setbfvalue(s2v(ra));
+            result = true;
           }
         } else {
           if (!ttistable(b)) {
             luaG_runerror(L, "expected second 'in' operand to be table, got %s", ttypename(ttype(b)));
           } else {
             if (luaV_searchelement(L, hvalue(b), a)) {
-              setbtvalue(s2v(ra));
-            } else {
-              setbfvalue(s2v(ra));
+              result = true;
             }
           }
+        }
+        if (GETARG_C(i) == 1) { /* R(C) = invert bool */
+          result = !result;
+        }
+        if (result) {
+          setbtvalue(s2v(ra));
+        } else {
+          setbfvalue(s2v(ra));
         }
         vmDumpInit();
         vmDumpAddA();

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -291,6 +291,7 @@ do
     assert("KEY" in t)
     assert("ARRAY" in t)
     assert(("NOTHING" in t) == false)
+    assert("NOTHING" not in t)
 end
 do
     -- table must be global for this failure case
@@ -309,6 +310,7 @@ do
         assert(b == false)
     end
     proxy(42 in t.subt)
+    assert("NOTHING" not in t.subt)
     t = nil
 end
 do
@@ -316,6 +318,7 @@ do
     assert("apple" in { 1, nil, "aaaa", "apple" })
     assert(not "banana" in { apple = true })
     assert(type("apple" in { apple = true }) == "boolean")
+    assert("banana" not in { apple = true })
 end
 do -- check stack corruption
     local t = {
@@ -340,6 +343,7 @@ do -- check stack corruption
     assert(c == "ARRAY")
     assert(d == nil)
     assert(e == "NOTHING")
+    assert(e not in t)
 end
 do 
     local t = {key="value"}


### PR DESCRIPTION
Very simple stuff. Looks cleaner than `not a in b` and especially `(a in b) == false`