### PR TITLE
Make '{' a valid escape sequence (for string interpolation)

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -486,7 +486,7 @@ static void process_string_escape (LexState *ls) {
     case 'u': utf8esc(ls);  return;  /* no save */
     case '\n': case '\r':
       inclinenumber(ls); c = '\n'; goto only_save;
-    case '\\': case '\"': case '\'':
+    case '\\': case '\"': case '\'': case '{':
       c = ls->current; goto read_save;
     case EOZ: return;  /* no save, will raise an error next loop */
     case 'z': {  /* zap following span of spaces */

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1091,6 +1091,12 @@ do
     assert($"{person:printInformation()}" == "My name is John & my age is 25.")
 end
 assert($"{true ? 'true' : 'false'} is the value" == "true is the value")
+do -- escaping
+    local a = "world"
+    assert($"hello {a}, \{}" == "hello world, {}")
+    assert($"hello {a}, {1 == 1}, \{1 == 1}" == "hello world, true, {1 == 1}")
+    assert($"hello {a}, {1 == 1}, \\{1 == 1}" == "hello world, true, \\true")
+end
 
 print "Testing ++ operator."
 do


### PR DESCRIPTION
Resolves #390 