### PR TITLE
Improve handling of injected code in lundump & ldebug

### DIFF
--- a/src/ldebug.cpp
+++ b/src/ldebug.cpp
@@ -291,7 +291,16 @@ static void funcinfo (lua_Debug *ar, Closure *cl) {
     }
     ar->linedefined = p->linedefined;
     ar->lastlinedefined = p->lastlinedefined;
-    ar->what = (ar->linedefined == 0) ? "main" : "Lua";
+    if (ar->linedefined == 'plin') {
+      ar->source = "=[Pluto-injected code]";
+      ar->srclen = LL("=[Pluto-injected code]");
+      ar->linedefined = -1;
+      ar->lastlinedefined = -1;
+      ar->what = "Pluto-injected code";
+    }
+    else {
+      ar->what = (ar->linedefined == 0) ? "main" : "Lua";
+    }
   }
   luaO_chunkid(ar->short_src, ar->source, ar->srclen);
 }
@@ -353,6 +362,8 @@ static int auxgetinfo (lua_State *L, const char *what, lua_Debug *ar,
       }
       case 'l': {
         ar->currentline = (ci && isLua(ci)) ? getcurrentline(ci) : -1;
+        if (ar->currentline == 'plin')
+          ar->currentline = -1;
         break;
       }
       case 'u': {

--- a/src/llex.h
+++ b/src/llex.h
@@ -94,7 +94,8 @@ struct Token {
 
   Token() = default;
 
-  static constexpr int LINE_INJECTED = -1886153070; /* -'plin' */
+  // Can't be negative to avoid issues with precompiled code.
+  static constexpr int LINE_INJECTED = 'plin';
 
   Token(int token)
     : token(token), line(LINE_INJECTED)


### PR DESCRIPTION
Fixes #393 and additionally improves tracebacks that include injected code — before:

```
pluto: test.pluto:1886153070: 'new' used on non-table value
stack traceback:
        [C]: in function 'error'
        test.pluto:1886153070: in local 'Pluto_operator_new'
        test.pluto:1: in main chunk
        [C]: in ?
```

After:

```
pluto: 'new' used on non-table value
stack traceback:
        [C]: in function 'error'
        [Pluto-injected code]: in local 'Pluto_operator_new'
        test.pluto:1: in main chunk
        [C]: in ?
```