### PR TITLE
Improve table.contains

### DIFF
--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -456,18 +456,20 @@ static int tisfrozen (lua_State *L) {
 static int tcontains (lua_State *L) {
   luaL_checktype(L, 1, LUA_TTABLE);
   luaL_checkany(L, 2);
+  const bool only_array = !lua_istrue(L, 3);
 
   lua_pushvalue(L, 1);
   lua_pushnil(L);
   while (lua_next(L, -2)) {
     lua_pushvalue(L, -2);
     if (lua_compare(L, 2, -2, LUA_OPEQ)) {
-      lua_pushinteger(L, lua_tointeger(L, -1));
-      return 1;
+      const bool is_int = lua_isinteger(L, -1);
+      if ((only_array && is_int) || (!only_array && !is_int)) {
+        lua_pushvalue(L, -1);
+        return 1;
+      }
     }
-    else {
-      lua_pop(L, 2);
-    }
+    lua_pop(L, 2); /* Pop result of lua_compare */
   }
   
   lua_pop(L, 1);

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -831,7 +831,7 @@ else
     print("Soup is not linked, skipping relevant tests.")
 end
 do
-    local t = {}
+    local t = { key = "value" }
     table.insert(t, 0)
     table.insert(t, "Hello")
     table.insert(t, true)
@@ -841,6 +841,11 @@ do
     assert(table.contains(t, false) == nil)
     assert(table.contains(t, 0) == 1)
     assert(table.contains(t, 1) == nil)
+    assert(t:contains("value") == nil)
+    assert(t:contains("value", true) == "key")
+    t[4] = 3
+    assert(t:contains(3) == 4)
+    assert(t:contains(3, true) == nil)
     assert(string.isascii("hello world") == true)
     assert(string.isascii("hello.world") == true)
     assert(string.isascii("hello1world") == true)


### PR DESCRIPTION
Function strictly for integer indexes OR keys. This complements the reimplementation of `in` where now users have a specific way to search integer, non-integer, and mixed tables without making their own.

As a side effect of this behavior change, table.contains will return `nil` when a key of the undesired type has the desired value. Right now, it returns `0` for keys which is a bug.