### PR TITLE
Add PLUTO_NO_FILESYSTEM for content moderation

### DIFF
--- a/src/linit.cpp
+++ b/src/linit.cpp
@@ -44,7 +44,9 @@ static const luaL_Reg loadedlibs[] = {
   {LUA_LOADLIBNAME, luaopen_package},
   {LUA_COLIBNAME, luaopen_coroutine},
   {LUA_TABLIBNAME, luaopen_table},
+#ifndef PLUTO_NO_FILESYSTEM
   {LUA_IOLIBNAME, luaopen_io},
+#endif
   {LUA_OSLIBNAME, luaopen_os},
   {LUA_STRLIBNAME, luaopen_string},
   {LUA_MATHLIBNAME, luaopen_math},

--- a/src/loslib.cpp
+++ b/src/loslib.cpp
@@ -144,6 +144,9 @@
 
 
 static int os_execute (lua_State *L) {
+#ifdef PLUTO_NO_OS_EXECUTE
+  return 0;
+#else
   const char *cmd = luaL_optstring(L, 1, NULL);
   int stat;
   errno = 0;
@@ -154,6 +157,7 @@ static int os_execute (lua_State *L) {
     lua_pushboolean(L, stat);  /* true if there is a shell */
     return 1;
   }
+#endif
 }
 
 
@@ -438,11 +442,15 @@ static const luaL_Reg syslib[] = {
   {"clock",       os_clock},
   {"date",        os_date},
   {"difftime",    os_difftime},
+#ifndef PLUTO_NO_OS_EXECUTE
   {"execute",     os_execute},
+#endif
   {"exit",        os_exit},
   {"getenv",      os_getenv},
+#ifndef PLUTO_NO_FILESYSTEM
   {"remove",      l_os_remove},
   {"rename",      l_os_rename},
+#endif
   {"setlocale",   os_setlocale},
   {"time",        os_time},
   {"tmpname",     os_tmpname},

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -987,6 +987,23 @@
 // This will affect require and package.loadlib.
 //#define PLUTO_LOADCLIB_HOOK ContmodOnLoadCLib
 
+// If defined, Pluto will prevent loading the entire io library & os.remove, and os.rename to prevent filesystem access.
+// Pluto will compile any filesystem-related functions to do nothing more than "return 0;"
+//   This is done largely to ensure package.loadlib gets nothing from loading their symbols
+//   There has been exploits in the past that have managed to load these lua_CFunction objects provided they're in memory. This shouldn't even be considered a worry with Pluto, since they are literally compiled to do nothing instead of only getting excluded from luaL_openlibs.
+// 
+// It's highly suggested in most cases to define PLUTO_NO_OS_EXECUTE below too, since os.execute can be used for file-system access. 
+// 
+// It's suggested you implement PLUTO_LOADCLIB_HOOK, etc, for even more powerful coverage. Package.loadlib can still load other Pluto/Lua libraries and use their lua_CFunction objects.
+//#define PLUTO_NO_FILESYSTEM
+#ifdef PLUTO_NO_FILESYSTEM
+#define FS_FUNCTION return 0;
+#else
+#define FS_FUNCTION
+#endif
+
+//#define PLUTO_NO_OS_EXECUTE
+
 /*
 ** {====================================================================
 ** Pluto configuration: Performance


### PR DESCRIPTION
The only potentially controversial part of this commit is the FS_FUNCTION macro. This was done because of exploits like [this](https://gist.github.com/corsix/6575486) in the past. Of course, they're old, but I have no idea if they're patched or if similar undiscovered exploits could be deployed in the future. This particular exploit would not be possible because we eliminate `io.open`. In any case, it's a "better safe than sorry" type of thing. File-system functions both cannot be accessed through traditional means and cannot be used even if they are somehow accessed.

Theoretically, any `lua_CFunction` can be called from Lua.

Resolves #288 