### PR TITLE
New Warning Type, Improve Existing Coverage

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -184,6 +184,8 @@ enum WarningType : int
   WT_DEPRECATED,
   WT_BAD_PRACTICE,
   WT_POSSIBLE_TYPO,
+  WT_NON_PORTABLE_CODE,
+  WT_NON_PORTABLE_BYTECODE,
 
   NUM_WARNING_TYPES
 };
@@ -198,18 +200,33 @@ inline const char* const luaX_warnNames[] = {
   "deprecated",
   "bad-practice",
   "possible-typo",
+  "non-portable-code",
+  "non-portable-bytecode",
 };
 
 
-struct WarningConfig
+class WarningConfig
 {
+public:
   const size_t begins_at;
   bool toggles[NUM_WARNING_TYPES];
 
-  WarningConfig(size_t begins_at) noexcept
-    : begins_at(begins_at)
-  {
-    setAllTo(true);
+private:
+  [[nodiscard]] static bool getDefaultState(WarningType type) noexcept {
+    switch (type) {
+    case WT_NON_PORTABLE_CODE:
+    case WT_NON_PORTABLE_BYTECODE:
+      return false;
+    default:
+      return true;
+    }
+  }
+
+public:
+  WarningConfig(size_t begins_at) noexcept : begins_at(begins_at) {
+    for (int id = 0; id != NUM_WARNING_TYPES; ++id) {
+      toggles[id] = getDefaultState((WarningType)id);
+    }
   }
 
   void copyFrom(const WarningConfig& b) noexcept

--- a/src/llex.h
+++ b/src/llex.h
@@ -101,67 +101,54 @@ struct Token {
 
   Token(int token)
     : token(token), line(LINE_INJECTED)
-  {
-  }
+  {}
 
   Token(int token, TString* ts)
     : token(token), seminfo(ts), line(LINE_INJECTED)
-  {
-  }
+  {}
 
-  [[nodiscard]] bool Is(int t) const noexcept
-  {
+  [[nodiscard]] bool Is(int t) const noexcept {
     return token == t;
   }
 
-  [[nodiscard]] bool IsReserved() const noexcept
-  {
+  [[nodiscard]] bool IsReserved() const noexcept {
     return token >= FIRST_RESERVED && token <= LAST_RESERVED;
   }
 
-  /// Does this token escape control flow? I.e, a TK_BREAK or TK_CONTINUE?
-  [[nodiscard]] bool IsEscapingToken() const noexcept
-  {
+  [[nodiscard]] bool IsEscapingToken() const noexcept {
     return token == TK_BREAK || token == TK_CONTINUE;
   }
 
-  [[nodiscard]] bool IsReservedNonValue() const noexcept
-  {
+  [[nodiscard]] bool IsReservedNonValue() const noexcept {
     return IsReserved() && token != TK_TRUE && token != TK_FALSE && token != TK_NIL
       && token != TK_PPARENT
       && token != TK_PARENT
       ;
   }
 
-  [[nodiscard]] bool IsNarrow() const noexcept
-  {
+  [[nodiscard]] bool IsNarrow() const noexcept {
     return token == TK_IN
       || (token >= TK_CASE && token < FIRST_COMPAT)
       ;
   }
 
-  [[nodiscard]] bool IsCompatible() const noexcept
-  {
+  [[nodiscard]] bool IsCompatible() const noexcept {
       return (token >= FIRST_COMPAT && token < FIRST_NON_COMPAT);
   }
 
-  [[nodiscard]] bool IsNonCompatible() const noexcept
-  {
+  [[nodiscard]] bool IsNonCompatible() const noexcept {
       return (token >= FIRST_NON_COMPAT && token < FIRST_SPECIAL);
   }
 
-  [[nodiscard]] bool IsOptional() const noexcept
-  {
+  [[nodiscard]] bool IsOptional() const noexcept {
       return (token >= FIRST_OPTIONAL && token < FIRST_SPECIAL);
   }
 
-  [[nodiscard]] bool IsSpecial() const noexcept
-  {
+  [[nodiscard]] bool IsSpecial() const noexcept {
       return (token >= FIRST_SPECIAL && token < TK_RETURN);
   }
 
-  [[nodiscard]] bool IsOverridable() const noexcept
-  {
+  [[nodiscard]] bool IsOverridable() const noexcept {
       return token == TK_PARENT || token == TK_PPARENT;
   }
 };
@@ -173,8 +160,7 @@ struct Token {
 */
 
 
-enum WarningType : int
-{
+enum WarningType : int {
   ALL_WARNINGS = 0,
 
   WT_VAR_SHADOW,
@@ -229,33 +215,26 @@ public:
     }
   }
 
-  void copyFrom(const WarningConfig& b) noexcept
-  {
+  void copyFrom(const WarningConfig& b) noexcept {
     memcpy(toggles, b.toggles, sizeof(toggles));
   }
 
-  [[nodiscard]] bool Get(WarningType type) const noexcept
-  {
+  [[nodiscard]] bool get(WarningType type) const noexcept {
     return toggles[type];
   }
   
-  [[nodiscard]] bool& Get(WarningType type) noexcept
-  {
+  [[nodiscard]] bool& get(WarningType type) noexcept {
     return toggles[type];
   }
 
-  void setAllTo(bool newState) noexcept
-  {
-    for (int id = 0; id != NUM_WARNING_TYPES; ++id)
-    {
+  void setAllTo(bool newState) noexcept {
+    for (int id = 0; id != NUM_WARNING_TYPES; ++id) {
       toggles[id] = newState;
     }
   }
 
-  void processComment(const std::string& line) noexcept
-  {
-    for (int id = 0; id != NUM_WARNING_TYPES; ++id)
-    {
+  void processComment(const std::string& line) noexcept {
+    for (int id = 0; id != NUM_WARNING_TYPES; ++id) {
       std::string enable  = "enable-";
       std::string disable = "disable-";
 
@@ -264,25 +243,21 @@ public:
       enable += name;
       disable += name;
 
-      if (line.find(enable) != std::string::npos)
-      {
+      if (line.find(enable) != std::string::npos) {
         if (name != "all")
-          Get((WarningType)id) = true;
+          get((WarningType)id) = true;
         else
           setAllTo(true);
-      }
-      else if (line.find(disable) != std::string::npos)
-      {
+      } else if (line.find(disable) != std::string::npos) {
         if (name != "all")
-          Get((WarningType)id) = false;
+          get((WarningType)id) = false;
         else
           setAllTo(false);
       }
     }
   }
 
-  [[nodiscard]] static const char* getWarningName(const WarningType w)
-  {
+  [[nodiscard]] static const char* getWarningName(const WarningType w) {
     lua_assert((size_t)w >= 0 && (size_t)w < NUM_WARNING_TYPES);
     return luaX_warnNames[(size_t)w];
   }
@@ -337,9 +312,7 @@ struct LexState {
   std::vector<void*> parse_time_allocations{};
   std::unordered_map<const TString*, void*> global_props{};
 
-  LexState()
-    : lines{ std::string{} }, warnconfs{ WarningConfig(0) }
-  {
+  LexState() : lines{ std::string{} }, warnconfs{ WarningConfig(0) } {
     laststat = Token {};
     laststat.token = TK_EOS;
     parser_context_stck.push(PARCTX_NONE); /* ensure there is at least 1 item on the parser context stack */
@@ -443,7 +416,7 @@ struct LexState {
   [[nodiscard]] bool shouldEmitWarning(int line, WarningType warning_type) const {
     const auto& linebuff = this->getLineString(line);
     const auto& lastattr = line > 1 ? this->getLineString(line - 1) : linebuff;
-    return lastattr.find("@pluto_warnings: disable-next") == std::string::npos && getWarningConfig().Get(warning_type);
+    return lastattr.find("@pluto_warnings: disable-next") == std::string::npos && getWarningConfig().get(warning_type);
   }
 
   [[nodiscard]] bool shouldSuggest() const noexcept {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -174,6 +174,33 @@ static void throw_warn(LexState* ls, const char* err, WarningType warningType) {
 
 
 /*
+** Responsible for the following:
+**   - Non-portable keyword usage. (class, switch, etc)
+**   - Non-portable bytecode generation. (nil-coalesce, "in" expressions)
+**  
+** Missing coverage:
+**   - Implicit pairs for-loops. If I knew how to check this at compile-time, the feature would be Lua-bytecode compatible.
+**   - String indexing.
+** 
+** Worth considering:
+**   - Non-portable standard library usage. Some of our functions are so 'expected' to exist that people forget Lua doesn't have them.
+**   - We could alternatively inject Lua-versions of our standard library into files intended to be portable, but this might be a lot of work for little.
+*/
+static void portability_warn (LexState *ls, WarningType wt) {
+  if (ls->t.IsNonCompatible()) {
+    throw_warn(ls, "non-portable keyword usage", luaO_fmt(ls->L, "try using 'pluto_%s' instead to ensure keyword portability.", luaX_token2str_noq(ls, ls->t.token)), wt);
+    ls->L->top.p--;
+    return;
+  }
+
+  if (ls->t.token == TK_COAL || ls->t.seminfo.i == TK_COAL || ls->t.token == TK_IN) {
+    throw_warn(ls, "non-portable operator usage", "this operator generates bytecode which is incompatible with Lua.", wt);
+    return;
+  }
+}
+
+
+/*
 ** This function will throw an exception and terminate the program.
 */
 [[noreturn]] static void error_expected (LexState *ls, int token) {
@@ -1593,6 +1620,9 @@ static void classstat (LexState *ls) {
 
 
 static void localclass (LexState *ls) {
+  luaX_prev(ls);
+  portability_warn(ls, WT_NON_PORTABLE_CODE);
+  luaX_next(ls);
   auto line = ls->getLineNumber();
   TString *name = str_checkname(ls, 0);
   TString *parent = checkextends(ls);
@@ -2912,6 +2942,7 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, TypeHint *prop) {
       return;
     }
   }
+  portability_warn(ls, WT_NON_PORTABLE_CODE);
   switch (ls->t.token) {
     case TK_FLT: {
       if (prop) prop->emplaceTypeDesc(VT_FLT);
@@ -3160,6 +3191,7 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop = nul
       if (inverted_in) {
         testnext(ls, TK_NOT);
       }
+      portability_warn(ls, WT_NON_PORTABLE_BYTECODE);
       inexpr(ls, v, inverted_in);
       if (prop) prop->emplaceTypeDesc(VT_BOOL);
     }
@@ -3169,6 +3201,7 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop = nul
     return OPR_NOBINOPR;
   }
   /* expand while operators have priorities higher than 'limit' */
+  portability_warn(ls, WT_NON_PORTABLE_BYTECODE);
   op = getbinopr(ls->t.token);
   while (op != OPR_NOBINOPR && priority[op].left > limit) {
     expdesc v2;
@@ -3339,6 +3372,7 @@ static void restassign (LexState *ls, struct LHS_assign *lh, int nvars) {
   }
   else {  /* restassign -> '=' explist */
     check(ls, '=');
+    portability_warn(ls, WT_NON_PORTABLE_BYTECODE);
     if ((int)ls->t.seminfo.i != 0) {  /* is there a saved binop? */
       BinOpr op = getbinopr((int)ls->t.seminfo.i);  /* binary operation from lexer state */
       lua_assert(op != OPR_NOBINOPR);
@@ -4449,6 +4483,7 @@ static void statement (LexState *ls, TypeHint *prop) {
     ls->laststat.token = ls->t.token;
   }
   enterlevel(ls);
+  portability_warn(ls, WT_NON_PORTABLE_CODE);
   switch (ls->t.token) {
     case ';': {  /* stat -> ';' (empty statement) */
       luaX_next(ls);  /* skip ';' */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -558,23 +558,16 @@ static LocVar *localdebuginfo (FuncState *fs, int vidx) {
 
 
 /*
-** Arbitrary selection. Based on probability to be used as an identifier.
-** For example:
-**   - 'dumpvar' is vulnerable to 'string.dump' results.
-**   - 'type' is vulnerable to anything that needs to allocate the type of anything.
-**   - 'next' is obvious. Probably one of the most probable victims. 
-**   - 'arg' is an absurdly common variable name but also the command-line interface.
+** Arbitrary selection. Based on probability to cause a confusing error (i.e, something that can be more deep than 'attempt to call a string value')
+** For example, shadowing 'arg' with a function makes an obvious error. But, shadowing with string or table can cause confusing bugs because they can both be indexed and won't raise an error.
 */
 inline const char* const common_global_names[] = {
 #ifdef PLUTO_EXTENDED_COMMON_GLOBAL_NAMES
   PLUTO_EXTENDED_COMMON_GLOBAL_NAMES,
 #endif
   "table",
-  "dumpvar",
-  "arg",
   "string",
-  "type",
-  "next"
+  "arg"
 };
 
 

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -830,6 +830,11 @@
 // If defined, Pluto won't imbue tables with a metatable by default.
 //#define PLUTO_NO_DEFAULT_TABLE_METATABLE
 
+// Extend the known common globals for variable shadow warnings.
+// It should look like this: #define PLUTO_EXTENDED_COMMON_GLOBAL_NAMES "global", "anotherglobal", "and_another_global"
+// This cannot remain empty. Commas are only required to separate names. No trailing comma is required.
+//#define PLUTO_EXTENDED_COMMON_GLOBAL_NAMES
+
 /*
 ** {====================================================================
 ** Pluto configuration: Compatibility


### PR DESCRIPTION
- `checkforshadowing` didn't check upvalues and parameter names. Considered pushing to main but this wasn't really a bug and it would create a merge conflict. This is a pretty big coverage improvement.

- Adds `non-portable-code` & `non-portable-bytecode` warning type (disabled by default) for whenever a keyword or operator is not guaranteed to work on other Pluto versions or when produced bytecode is not compatible with Lua. Lacks coverage for string indexing & for-in loops without pairs since this is probably impossible to properly check during compilation.

- Some globals are now included in `checkforshadowing`.

Closes #381 and scraps PR 248