### PR TITLE
Add version_compare

### DIFF
--- a/Pluto.vcxproj
+++ b/Pluto.vcxproj
@@ -487,8 +487,10 @@
     <ClCompile Include="src\vendor\Soup\JsonObject.cpp" />
     <ClCompile Include="src\vendor\Soup\JsonString.cpp" />
     <ClCompile Include="src\vendor\Soup\Optional.hpp" />
+    <ClCompile Include="src\vendor\Soup\spaceship.cpp" />
     <ClCompile Include="src\vendor\Soup\unicode.cpp" />
     <ClCompile Include="src\vendor\Soup\urlenc.cpp" />
+    <ClCompile Include="src\vendor\Soup\version_compare.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\lerrormessage.hpp" />
@@ -547,12 +549,14 @@
     <ClInclude Include="src\vendor\Soup\JsonObject.hpp" />
     <ClInclude Include="src\vendor\Soup\JsonString.hpp" />
     <ClInclude Include="src\vendor\Soup\Reader.hpp" />
+    <ClInclude Include="src\vendor\Soup\spaceship.hpp" />
     <ClInclude Include="src\vendor\Soup\string.hpp" />
     <ClInclude Include="src\vendor\Soup\TreeNode.hpp" />
     <ClInclude Include="src\vendor\Soup\type_traits.hpp" />
     <ClInclude Include="src\vendor\Soup\unicode.hpp" />
     <ClInclude Include="src\vendor\Soup\UniquePtr.hpp" />
     <ClInclude Include="src\vendor\Soup\urlenc.hpp" />
+    <ClInclude Include="src\vendor\Soup\version_compare.hpp" />
     <ClInclude Include="src\vendor\Soup\Writer.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -23,6 +23,10 @@
 #include "lobject.h"
 #include "lstate.h"
 
+#ifdef PLUTO_USE_SOUP
+#include "vendor/Soup/version_compare.hpp"
+#endif
+
 
 static int luaB_print (lua_State *L) {
 #ifdef PLUTO_VMDUMP
@@ -706,7 +710,18 @@ static int luaB_exportvar (lua_State *L) {
 }
 
 
+#ifdef PLUTO_USE_SOUP
+static int luaB_version_compare (lua_State *L) {
+  lua_pushinteger(L, SOUP_STRONG_ORDERING_TO_INT(soup::version_compare(luaL_checkstring(L, 1), luaL_checkstring(L, 2))));
+  return 1;
+}
+#endif
+
+
 static const luaL_Reg base_funcs[] = {
+#ifdef PLUTO_USE_SOUP
+  {"version_compare", luaB_version_compare},
+#endif
   {"exportvar", luaB_exportvar},
   {"dumpvar", luaB_dumpvar},
   {"newuserdata", luaB_newuserdata},

--- a/src/vendor/Soup/spaceship.cpp
+++ b/src/vendor/Soup/spaceship.cpp
@@ -1,0 +1,10 @@
+#include "spaceship.hpp"
+
+#if !SOUP_SPACESHIP_USE_STD
+namespace soup
+{
+	const strong_ordering strong_ordering::less = -1;
+	const strong_ordering strong_ordering::equal = 0;
+	const strong_ordering strong_ordering::greater = 1;
+}
+#endif

--- a/src/vendor/Soup/spaceship.hpp
+++ b/src/vendor/Soup/spaceship.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "base.hpp"
+
+#define SOUP_SPACESHIP_USE_STD SOUP_CPP20
+
+#if SOUP_SPACESHIP_USE_STD
+#include <compare>
+#endif
+
+namespace soup
+{
+#if SOUP_SPACESHIP_USE_STD
+	using strong_ordering = ::std::strong_ordering;
+
+	#define SOUP_SPACESHIP(a, b) ((a) <=> (b))
+
+	[[nodiscard]] inline int SOUP_STRONG_ORDERING_TO_INT(strong_ordering so)
+	{
+		if (so != 0)
+		{
+			return so < 0 ? -1 : 1;
+		}
+		return 0;
+	}
+#else
+	class strong_ordering
+	{
+	private:
+		int value;
+
+	public:
+		static const strong_ordering less;
+		static const strong_ordering equal;
+		static const strong_ordering greater;
+
+		constexpr strong_ordering(int value) noexcept
+			: value(value)
+		{
+		}
+
+		constexpr operator int() const noexcept
+		{
+			return value;
+		}
+	};
+
+	template <typename T>
+	[[nodiscard]] inline strong_ordering SOUP_SPACESHIP(const T& a, const T& b)
+	{
+		if (a == b)
+		{
+			return strong_ordering::equal;
+		}
+		if (a < b)
+		{
+			return strong_ordering::less;
+		}
+		return strong_ordering::greater;
+	}
+
+	#define SOUP_STRONG_ORDERING_TO_INT(so) ((so).operator int())
+#endif
+}

--- a/src/vendor/Soup/version_compare.cpp
+++ b/src/vendor/Soup/version_compare.cpp
@@ -1,0 +1,47 @@
+#include "version_compare.hpp"
+
+#include "string.hpp"
+
+namespace soup
+{
+	strong_ordering version_compare(std::string in_a, std::string in_b)
+	{
+		std::vector<long> a{};
+		std::vector<long> b{};
+
+		string::replaceAll(in_a, "-", ".");
+		string::replaceAll(in_b, "-", ".");
+
+		for (const auto& s : string::explode(in_a, '.'))
+		{
+			a.emplace_back(string::toInt<long>(s, -1));
+		}
+		for (const auto& s : string::explode(in_b, '.'))
+		{
+			b.emplace_back(string::toInt<long>(s, -1));
+		}
+
+		if (a.size() != b.size())
+		{
+			if (a.size() > b.size())
+			{
+				b.insert(b.end(), a.size() - b.size(), 0);
+			}
+			else
+			{
+				a.insert(a.end(), b.size() - a.size(), 0);
+			}
+		}
+
+		for (size_t i = 0; i != a.size(); ++i)
+		{
+			auto c = SOUP_SPACESHIP(a[i], b[i]);
+			if (c != 0)
+			{
+				return c;
+			}
+		}
+
+		return strong_ordering::equal;
+	}
+}

--- a/src/vendor/Soup/version_compare.hpp
+++ b/src/vendor/Soup/version_compare.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+#include "spaceship.hpp"
+
+namespace soup
+{
+	[[nodiscard]] strong_ordering version_compare(std::string in_a, std::string in_b);
+}

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1002,6 +1002,14 @@ do
     menu = table.map(menu, |item| -> item.id == betterDoener.id ? betterDoener : item)
     assert(menu[2].name == "Better Doener")
 end
+if _PSOUP then
+    assert(version_compare("0.1.0", "0.1.0") == 0)
+    assert(version_compare("0.1.0", "0.2.0") ~= 0)
+    assert(version_compare("0.2.0", "0.1.0") > 0)
+    assert(version_compare("0.2.0", "0.1.0") >= 0)
+    assert(version_compare("0.1.0", "0.2.0") < 0)
+    assert(version_compare("0.1.0", "0.1.0") <= 0)
+end
 
 print "Testing default table metatable."
 do


### PR DESCRIPTION
I also made this nice abstraction for it, but not sure if it's too useful:
```Lua
class VersionStruct
    function __construct(value)
        self.value = value
    end

    function __tostring()
        return self.value
    end

    function __eq(b)
        return version_compare(self.value, tostring(b)) == 0
    end

    function __lt(b)
        return version_compare(self.value, tostring(b)) < 0
    end

    function __le(b)
        return version_compare(self.value, tostring(b)) <= 0
    end
end

function version(str)
    return new VersionStruct(str)
end

assert(version "0.1.0" == version "0.1.0")
assert(version "0.1.0" ~= version "0.2.0")
assert(version "0.2.0" > version "0.1.0")
assert(version "0.2.0" >= version "0.1.0")
assert(version "0.1.0" < version "0.2.0")
assert(version "0.1.0" <= version "0.1.0")
```