### PR TITLE
"Assertion" Standard Library

### DIFF
--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -778,12 +778,6 @@ LUAMOD_API int luaopen_base (lua_State *L) {
   lua_pushboolean(L, false);
 #endif
   lua_setfield(L, -2, "_PSOUP");
-#ifndef PLUTO_NO_DEFAULT_TABLE_METATABLE
-  G(L)->ready_for_table_mt = false;
-#endif
-#ifndef PLUTO_NO_DEFAULT_TABLE_METATABLE
-  G(L)->ready_for_table_mt = true;
-#endif
   return 1;
 }
 

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -778,42 +778,9 @@ LUAMOD_API int luaopen_base (lua_State *L) {
   lua_pushboolean(L, false);
 #endif
   lua_setfield(L, -2, "_PSOUP");
-  const auto startup_code = R"EOC(
-pluto_class Exception
-    __name = "Exception"
-
-    function __construct(public what)
-        local caller
-        local i = 2
-        while true do
-            caller = debug.getinfo(i)
-            if caller == nil then
-                error("Exception instances must be created with 'pluto_new'", 0)
-            end
-            ++i
-            if caller.name == "Pluto_operator_new" then
-                caller = debug.getinfo(i)
-                break
-            end
-        end
-        self.where = $"{caller.short_src}:{caller.currentline}"
-        error(self, 0)
-    end
-
-    function __tostring()
-        return $"{self.where}: {tostring(self.what)}"
-    end
-end
-
-function instanceof(a, b)
-  return a instanceof b
-end
-)EOC";
-  luaL_loadbuffer(L, startup_code, strlen(startup_code), "Pluto Supplemental Standard Library");
 #ifndef PLUTO_NO_DEFAULT_TABLE_METATABLE
   G(L)->ready_for_table_mt = false;
 #endif
-  lua_pcall(L, 0, 0, 0);
 #ifndef PLUTO_NO_DEFAULT_TABLE_METATABLE
   G(L)->ready_for_table_mt = true;
 #endif

--- a/src/linit.cpp
+++ b/src/linit.cpp
@@ -102,6 +102,294 @@ end
 function instanceof(a, b)
   return a instanceof b
 end
+
+package.preload["assert"] = function()
+  local module = {}
+
+  local function deepCompare(t1, t2)
+    if t1 == t2 then
+      return true
+    end
+
+    if #t1 ~= #t2 then
+      return false
+    end
+
+    if next(t1) == nil and next(t2) ~= nil then
+      return false
+    end
+
+    for k, v1 in t1 do
+      local v2 = t2[k]
+        
+      if type(v1) == "table" and type(v2) == "table" and v1 ~= v2 then
+        if not deepCompare(v1, v2) then
+          return false
+        end
+      elseif v1 ~= v2 then
+        return false
+      end
+    end
+
+    return true
+  end
+
+  local class AssertionError
+    function __construct(assertion_name: string, public intended_value, public received_value)
+      self.assertion_name = "assert." .. assertion_name
+      self.should_dump = true
+      self.write_intended = true
+      self.write_recieved = true
+
+      self.intended_name = "Intended Value"
+      self.received_name = "Received Value"
+
+      return self
+    end
+
+    function raise()
+      local message = self:getFileInformation() .. " -> Assertion Error: " .. self:getExtraInformation()
+
+      if self.write_intended then
+        message ..= "\n\t"
+        message ..= self.intended_name .. ": " .. self:dumpValue(self.intended_value, self.hardcoded ? false : self.should_dump)
+      end
+
+      if self.write_recieved then
+        message ..= "\n\t"
+        message ..= self.received_name .. ": " .. self:dumpValue(self.received_value, self.should_dump)
+      end
+
+      if self.operator_comparison then
+        local n1 = self:dumpValue(self.intended_value)
+        local n2 = self:dumpValue(self.received_value)
+        local op = self.operator_comparison_operator
+
+        message ..= "\n\t"
+        message ..= $"Expression: ({n1} {op} {n2}) == false"
+      end
+
+      if self.simple then
+        message ..= "\n\t"
+        message ..= self.simple_message
+      end
+
+      message ..= "\n" -- Before traceback.
+
+      error(message, 0)
+    end
+
+    function dumpValue(value, should_dump: bool = self.should_dump): string
+      if type(value) == "function" or should_dump == false then
+        return tostring(value)
+      end
+
+      local dump = dumpvar(value) -- dumpvar will still serialize subfunctions, need to fix that.
+
+      if type(value) == "table" then
+        if dump:len() < 80 then
+          dump = dump:replace("\n", " "):replace("\t", "")
+        else
+          dump = "\n" .. dump:truncate(300, true)
+        end
+      end
+
+      return dump
+    end
+
+    function getFileInformation(): string
+      local caller
+
+      for i = 2, 255 do
+        caller = debug.getinfo(i)
+        if caller and not tostring(caller.short_src):contains("[") then
+          break
+        end
+      end
+
+      local short_src = caller?.short_src ?? "unk"
+      local currentline = caller?.currentline ?? "0"
+
+      return $"{short_src}:{currentline}"
+    end
+
+    function getExtraInformation(): string
+      return $"({self.assertion_name})"
+    end
+
+    function setDontDump() -- Applies to both the intended and received values.
+      self.should_dump = false
+
+      return self
+    end
+
+    function setHardcoded() -- Prevents 'Intended Value' from being dumped.
+      self.hardcoded = true
+
+      return self
+    end
+
+    function setOperatorComparison(operator: string) -- Expression: N operator N (replaces intended/received)
+      self.operator_comparison = true
+      self.operator_comparison_operator = operator
+      self.write_intended = false
+      self.write_recieved = false
+
+      return self
+    end
+
+    function setSimple(message: string)
+      self.write_recieved = false
+      self.write_intended = false
+      self.simple = true
+      self.simple_message = message
+
+      return self
+    end
+
+    function setNameOverride(intended: string, received: string)
+      if intended then
+        self.intended_name = intended
+      end
+
+      if received then
+        self.received_name = received
+      end
+
+      return self
+    end
+  end
+
+  function module.isnil(value)
+    if value ~= nil then
+      return new AssertionError("isnil", "nil", value):setHardcoded():raise()
+    end
+  end
+
+  function module.istrue(value)
+    if value ~= true then
+      return new AssertionError("istrue", "true", value):setHardcoded():raise()
+    end
+  end
+
+  function module.isfalse(value)
+    if value ~= false then
+      return new AssertionError("isfalse", "false", value):setHardcoded():raise()
+    end
+  end
+
+  function module.falsy(value)
+    if value then -- It's truthy
+      return new AssertionError("falsy", "nil or false", value):setHardcoded():raise()
+    end
+  end
+
+  function module.truthy(value)
+    if not value then
+      return new AssertionError("falsy", "not nil or false", value):setHardcoded():raise()
+    end
+  end
+
+   function module.notnil(value)
+    if value == nil then
+      return new AssertionError("notnil", "not nil", value):setHardcoded():raise()
+    end
+  end
+
+  function module.equal(value1, value2)
+    if type(value1) == "table" and type(value2) == "table" then
+      if not deepCompare(value1, value2) then
+        return new AssertionError("equal", value1, value2):raise()
+      end
+    else
+      if value1 ~= value2 then
+        return new AssertionError("equal", value1, value2):raise()
+      end
+    end
+  end
+
+  function module.nequal(value1, value2)
+    if type(value1) == "table" and type(value2) == "table" then
+      if deepCompare(value1, value2) then
+        return new AssertionError("nequal", value1, value2):raise()
+      end
+    else
+      if value1 == value2 then
+        return new AssertionError("nequal", value1, value2):raise()
+      end
+    end
+  end
+
+  function module.lessthan(value1, value2)
+    if not (value1 < value2) then
+      return new AssertionError("lessthan", value1, value2):setOperatorComparison("<"):raise()
+    end
+  end
+
+  function module.lessthaneq(value1, value2)
+    if not (value1 <= value2) then
+      return new AssertionError("lessthaneq", value1, value2):setOperatorComparison("<="):raise()
+    end
+  end
+
+  function module.greaterthan(value1, value2)
+    if not (value1 > value2) then
+      return new AssertionError("greaterthan", value1, value2):setOperatorComparison(">"):raise()
+    end
+  end
+
+  function module.greaterthaneq(value1, value2)
+    if not (value1 >= value2) then
+      return new AssertionError("greaterthaneq", value1, value2):setOperatorComparison(">="):raise()
+    end
+  end
+
+  function module.noerror(callback, ...)
+    local status, err = pcall(callback, ...)
+    if status == false then
+      return new AssertionError("noerror", nil, nil):setSimple("An error was raised: " .. tostring(err)):raise()
+    end
+  end
+
+  function module.haserror(callback, ...)
+    local status, err = pcall(callback, ...)
+    if status == true then
+      return new AssertionError("haserror", nil, nil):setSimple("Expected an error, but there was none."):raise()
+    end
+  end
+
+  function module.containserror(substring, callback, ...)
+    local status, err = pcall(callback, ...)
+    if status == true then
+      return new AssertionError("containserror", nil, nil):setSimple("Expected an error, but there was none."):raise()
+    elseif not tostring(err):contains(substring) then
+      return new AssertionError("containserror", substring, tostring(err)):setDontDump():setNameOverride("Absent String", "Error Message"):raise()
+    end
+  end
+
+  function module.type(desired_type, ...)
+    local t = {...}
+    for i = 1, #t do
+      local v = t[i]
+      if type(v) ~= desired_type then
+        return new AssertionError($"type, argument #{i}", desired_type, v):setHardcoded():setNameOverride("Intended Type"):raise()
+      end
+    end
+  end
+
+  setmetatable(module, {
+    __call = function (self, cond, err_msg = "assertion failed!")
+      err_msg = " " .. err_msg
+      if not cond then
+        return new AssertionError("assert", nil, nil):setSimple(err_msg):raise()
+      end
+    end
+  })
+
+  module.AssertionError = AssertionError
+
+  return module
+end
 )EOC";
   luaL_loadbuffer(L, startup_code, strlen(startup_code), "Pluto Standard Library");
   lua_call(L, 0, 0);

--- a/src/lstate.cpp
+++ b/src/lstate.cpp
@@ -239,7 +239,6 @@ static void f_luaopen (lua_State *L, void *ud) {
   g->gcstp = 0;  /* allow gc */
   setnilvalue(&g->nilvalue);  /* now state is complete */
 #ifndef PLUTO_NO_DEFAULT_TABLE_METATABLE
-  g->ready_for_table_mt = true;
   setnilvalue(&g->table_mt);
 #endif
   luai_userstateopen(L);

--- a/src/lstate.h
+++ b/src/lstate.h
@@ -312,7 +312,6 @@ typedef struct global_State {
   std::time_t deadline;
 #endif
 #ifndef PLUTO_NO_DEFAULT_TABLE_METATABLE
-  bool ready_for_table_mt;
   TValue table_mt;
 #endif
 } global_State;

--- a/src/ltable.cpp
+++ b/src/ltable.cpp
@@ -643,8 +643,6 @@ Table *luaH_new (lua_State *L) {
 
 #ifndef PLUTO_NO_DEFAULT_TABLE_METATABLE
 void luaH_initmetatable (lua_State *L, Table *t) {
-  if (!G(L)->ready_for_table_mt)
-    return;
   L->ci->top.p++;
   lua_pushnil(L); /* space on the stack where the metatable will go */
   if (ttisnil(&G(L)->table_mt)) {

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -58,6 +58,93 @@ do
     f(1)
 end
 
+print "Testing assertion library"
+do
+    local assert = require("assert")
+
+    local function noerror(callback, ...)
+        local status, msg = pcall(callback, ...)
+        assert(status == true)
+    end
+    local function haserror(callback, ...)
+        local status, msg = pcall(callback, ...)
+        assert(status == false)
+    end
+    local function containserror(sub, callback, ...)
+        local status, msg = pcall(callback, ...)
+        assert((status == false) and msg:contains(sub))
+    end
+
+    noerror(assert.isnil, nil)
+    haserror(assert.isnil, 1)
+    containserror("Intended Value: nil", assert.isnil, 1)
+    noerror(assert.istrue, true)
+    haserror(assert.istrue, 1)
+    containserror("true", assert.istrue, 1)
+    noerror(assert.isfalse, false)
+    haserror(assert.isfalse, 1)
+    containserror("false", assert.isfalse, 1)
+    noerror(assert.falsy, nil)
+    haserror(assert.falsy, { 1, 2, 3 })
+    containserror("nil or false", assert.falsy, 99)
+    noerror(assert.truthy, {})
+    haserror(assert.truthy, false)
+    containserror("not nil or false", assert.truthy, nil)
+    noerror(assert.notnil, false)
+    haserror(assert.notnil, nil)
+    containserror("not nil", assert.notnil, nil)
+    local fn = || -> 0
+    local t1 = {
+        1, 2, 3, 4, 5, 6, 7, 9, 0,
+        k = {
+            tabbb = {
+                anothertab = {
+                    1, 2, 3, 4, another_tab = {
+                        ["a"] = fn
+                    }
+                }
+            }
+        }
+    }
+    local t2 = {
+        1, 2, 3, 4, 5, 6, 7, 9, 0,
+        k = {
+            tabbb = {
+                anothertab = {
+                    1, 2, 3, 4, another_tab = {
+                        ["a"] = fn
+                    }
+                }
+            }
+        }
+    }
+    assert.equal(t1, t2)
+    noerror(assert.equal, t1, t2)
+    noerror(assert.equal, t1, t1)
+    haserror(assert.equal, t1, { 1, 2, 3, 4 })
+    haserror(assert.nequal, t1, t2)
+    noerror(assert.nequal, t1, { 1, 2, 3, k = 5 })
+    noerror(assert.nequal, 1, 2)
+    noerror(assert.lessthan, 1, 2)
+    containserror("<", assert.lessthan, 2, 2)
+    noerror(assert.lessthaneq, 2, 2)
+    containserror("<=", assert.lessthaneq, 3, 2)
+    containserror("Expression", assert.lessthaneq, 3, 2)
+    noerror(assert.greaterthan, 2, 1)
+    containserror(">", assert.greaterthan, 1, 2)
+    noerror(assert.greaterthaneq, 2, 2)
+    containserror(">=", assert.greaterthaneq, 2, 3)
+    noerror(assert.noerror, tostring, 5)
+    containserror("An error was raised:", assert.noerror, error, 5)
+    noerror(assert.haserror, error, "hello world")
+    containserror("Expected", assert.haserror, tostring, "hello")
+    noerror(assert.containserror, "hello world", error, "hello world")
+    containserror("Expected", assert.containserror, "hello world", tostring, "hello world")
+    containserror("Absent", assert.containserror, "hello world", error, "abc")
+    assert.equal({}, {})
+    assert.nequal({}, { 1 })
+end
+
 print "Testing compound assignment."
 do
     local a, b = 1, 2


### PR DESCRIPTION
Adds the following assertions:
- `isnil`
- `istrue`
- `isfalse`
- `falsy`
- `truthy`
- `notnil`
- `equal`
  - Supports tables.
- `nequal`
  - Supports tables.
- `lessthan`
- `lessthaneq`
- `greaterthan`
- `greaterthaneq`
- `noerror`
- `haserror`
- `containserror`
  - Checks for a substring inside of an error message. 
- `type`
  - Supports vararg. 

The main purpose of the library is descriptive errors which allow one execution pass to make the issue obvious.
```
pluto: test.pluto:2 -> Assertion Error: (assert.equal)
        Intended Value: string(5) "*****"
        Received Value: string(4) "****"

pluto: test.pluto:2 -> Assertion Error: (assert.equal)
        Intended Value: { [1] = string(2) "my", [2] = string(5) "split", [3] = string(6) "string", }
        Received Value: { [1] = string(2) "my", [2] = string(5) "split", [3] = string(5) "thing", }

pluto: test.pluto:2 -> Assertion Error: (assert.containserror)
        Absent String: length
        Error Message: argument 'count' for string.duplicate must be larger than zero

pluto: test.pluto:2 -> Assertion Error: (assert.type, argument #5)
        Intended Type: number
        Received Value: string(5) "hello"
```

Name shadowing is not a worry because `__call` redirects to a custom reimplementation of `_G.assert`
```lua
local assert = require("assert")
assert(false, "uh oh")
```
```
pluto: test.pluto:2 -> Assertion Error: (assert.assert)
         uh oh
```
To-Do:
- [x] `deepCompare` always fails when the first table is empty.
  - The cause is obvious, only `t1` gets iterated. Considering adding a `table.compare` first. 
- [ ] A test suite that allows us to easily observe the error messages of every assert.

Resolving the file:line of the original assertion call is a little awkward since we pick the first source file we find. We always have the correct information in the traceback, problem is figuring out which file it may be.