### PR TITLE
Make operator implementations <const>

### DIFF
--- a/operators.pluto
+++ b/operators.pluto
@@ -1,6 +1,6 @@
 -- lparser.cpp's builtinoperators
 
-local function Pluto_operator_new(mt, ...)
+local Pluto_operator_new <const> = function(mt, ...)
   if type(mt) ~= "table" then
     error "'new' used on non-table value"
   end
@@ -15,7 +15,7 @@ local function Pluto_operator_new(mt, ...)
   return t
 end
 
-local function Pluto_operator_extends(c, p)
+local Pluto_operator_extends <const> = function(c, p)
   for {
     -- luaT_eventname
     "__gc", "__mode", "__len", "__eq",
@@ -36,7 +36,7 @@ local function Pluto_operator_extends(c, p)
   c.__parent = p
 end
 
-local function Pluto_operator_instanceof(t, mt)
+local Pluto_operator_instanceof <const> = function(t, mt)
   t = getmetatable(t)
   while t do
     if t == mt then
@@ -47,6 +47,6 @@ local function Pluto_operator_instanceof(t, mt)
   return false
 end
 
-local function Pluto_operator_spaceship(a, b)
+local Pluto_operator_spaceship <const> = function(a, b)
   return a ~= b ? a < b ? -1 : +1 : 0
 end

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4812,10 +4812,16 @@ static void builtinoperators (LexState *ls) {
     ls->tokens = {}; /* avoid use of moved warning */
 
     if (ls->uses_new) {
-      // local function Pluto_operator_new(mt, ...)
+      // local Pluto_operator_new <const> = function(mt, ...)
       ls->tokens.emplace_back(Token(TK_LOCAL));
-      ls->tokens.emplace_back(Token(TK_FUNCTION));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "Pluto_operator_new")));
+#ifndef PLUTO_LET_ME_MESS_AROUND
+      ls->tokens.emplace_back(Token('<'));
+      ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "const")));
+      ls->tokens.emplace_back(Token('>'));
+#endif
+      ls->tokens.emplace_back(Token('='));
+      ls->tokens.emplace_back(Token(TK_FUNCTION));
       ls->tokens.emplace_back(Token('('));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "mt")));
       ls->tokens.emplace_back(Token(','));
@@ -4902,10 +4908,16 @@ static void builtinoperators (LexState *ls) {
       ls->tokens.emplace_back(Token(TK_END));
     }
     if (ls->uses_extends) {
-      // local function Pluto_operator_extends(c, p)
+      // local Pluto_operator_extends <const> = function(c, p)
       ls->tokens.emplace_back(Token(TK_LOCAL));
-      ls->tokens.emplace_back(Token(TK_FUNCTION));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "Pluto_operator_extends")));
+#ifndef PLUTO_LET_ME_MESS_AROUND
+      ls->tokens.emplace_back(Token('<'));
+      ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "const")));
+      ls->tokens.emplace_back(Token('>'));
+#endif
+      ls->tokens.emplace_back(Token('='));
+      ls->tokens.emplace_back(Token(TK_FUNCTION));
       ls->tokens.emplace_back(Token('('));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "c")));
       ls->tokens.emplace_back(Token(','));
@@ -5021,10 +5033,16 @@ static void builtinoperators (LexState *ls) {
       ls->tokens.emplace_back(Token(TK_END));
     }
     if (ls->uses_instanceof) {
-      // local function Pluto_operator_instanceof(t, mt)
+      // local Pluto_operator_instanceof <const> = function(t, mt)
       ls->tokens.emplace_back(Token(TK_LOCAL));
-      ls->tokens.emplace_back(Token(TK_FUNCTION));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "Pluto_operator_instanceof")));
+#ifndef PLUTO_LET_ME_MESS_AROUND
+      ls->tokens.emplace_back(Token('<'));
+      ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "const")));
+      ls->tokens.emplace_back(Token('>'));
+#endif
+      ls->tokens.emplace_back(Token('='));
+      ls->tokens.emplace_back(Token(TK_FUNCTION));
       ls->tokens.emplace_back(Token('('));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "t")));
       ls->tokens.emplace_back(Token(','));
@@ -5076,10 +5094,16 @@ static void builtinoperators (LexState *ls) {
       ls->tokens.emplace_back(Token(TK_END));
     }
     if (ls->uses_spaceship) {
-      // local function Pluto_operator_spaceship(a, b)
+      // local Pluto_operator_spaceship <const> = function(a, b)
       ls->tokens.emplace_back(Token(TK_LOCAL));
-      ls->tokens.emplace_back(Token(TK_FUNCTION));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "Pluto_operator_spaceship")));
+#ifndef PLUTO_LET_ME_MESS_AROUND
+      ls->tokens.emplace_back(Token('<'));
+      ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "const")));
+      ls->tokens.emplace_back(Token('>'));
+#endif
+      ls->tokens.emplace_back(Token('='));
+      ls->tokens.emplace_back(Token(TK_FUNCTION));
       ls->tokens.emplace_back(Token('('));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "a")));
       ls->tokens.emplace_back(Token(','));

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -60,6 +60,9 @@
 #define luaO_fmt luaO_pushfstring
 
 
+//#define PLUTO_ALLOW_FUNCTION_INJECTION_REASSIGNMENT
+
+
 std::string TypeDesc::toString() const {
   std::string str = vtToString(type);
   if (type == VT_FUNC &&
@@ -4815,7 +4818,7 @@ static void builtinoperators (LexState *ls) {
       // local Pluto_operator_new <const> = function(mt, ...)
       ls->tokens.emplace_back(Token(TK_LOCAL));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "Pluto_operator_new")));
-#ifndef PLUTO_LET_ME_MESS_AROUND
+#ifndef PLUTO_ALLOW_FUNCTION_INJECTION_REASSIGNMENT
       ls->tokens.emplace_back(Token('<'));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "const")));
       ls->tokens.emplace_back(Token('>'));
@@ -4911,7 +4914,7 @@ static void builtinoperators (LexState *ls) {
       // local Pluto_operator_extends <const> = function(c, p)
       ls->tokens.emplace_back(Token(TK_LOCAL));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "Pluto_operator_extends")));
-#ifndef PLUTO_LET_ME_MESS_AROUND
+#ifndef PLUTO_ALLOW_FUNCTION_INJECTION_REASSIGNMENT
       ls->tokens.emplace_back(Token('<'));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "const")));
       ls->tokens.emplace_back(Token('>'));
@@ -5036,7 +5039,7 @@ static void builtinoperators (LexState *ls) {
       // local Pluto_operator_instanceof <const> = function(t, mt)
       ls->tokens.emplace_back(Token(TK_LOCAL));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "Pluto_operator_instanceof")));
-#ifndef PLUTO_LET_ME_MESS_AROUND
+#ifndef PLUTO_ALLOW_FUNCTION_INJECTION_REASSIGNMENT
       ls->tokens.emplace_back(Token('<'));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "const")));
       ls->tokens.emplace_back(Token('>'));
@@ -5097,7 +5100,7 @@ static void builtinoperators (LexState *ls) {
       // local Pluto_operator_spaceship <const> = function(a, b)
       ls->tokens.emplace_back(Token(TK_LOCAL));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "Pluto_operator_spaceship")));
-#ifndef PLUTO_LET_ME_MESS_AROUND
+#ifndef PLUTO_ALLOW_FUNCTION_INJECTION_REASSIGNMENT
       ls->tokens.emplace_back(Token('<'));
       ls->tokens.emplace_back(Token(TK_NAME, luaX_newliteral(ls, "const")));
       ls->tokens.emplace_back(Token('>'));


### PR DESCRIPTION
Also adds the `PLUTO_LET_ME_MESS_AROUND` macro which removes the `<const>`, but I'm not gonna add it to luaconf and keep it undocumented for now because it's likely only of use to us.