### PR TITLE
Add '!' as a shorthand for 'not'

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -890,8 +890,10 @@ static int llex (LexState *ls, SemInfo *seminfo) {
       }
       case '!': {
         next(ls);
-        if (check_next1(ls, '=')) return TK_NE;  /* '!=' */
-        else return '!';
+        if (check_next1(ls, '='))
+          return TK_NE;  /* '!=' */
+        seminfo->ts = luaX_newliteral(ls, "!");
+        return TK_NOT;
       }
       case '?': {
         next(ls);


### PR DESCRIPTION
Closes #340. I was also gonna add `&&` and `||`, but `|| ->` could be the start of a lambda that doesn't take any parameters, so it was problematic.