### PR TITLE
Improve standard library function names

### DIFF
--- a/src/linit.cpp
+++ b/src/linit.cpp
@@ -495,7 +495,7 @@ package.preload["Vector3"] = function()
       return (self * b):sum()
     end
 
-    function crossProduct(b)
+    function cross_product(b)
       return new Vector3(
         self.y * b.z - self.z * b.y,
         self.z * b.x - self.x * b.z,
@@ -503,19 +503,19 @@ package.preload["Vector3"] = function()
       )
     end
 
-    function toAbs()
+    function to_abs()
       return new Vector3(math.abs(self.x), math.abs(self.y), math.abs(self.z))
     end
 
-    function toNormalised()
+    function to_normalised()
       return self / self:magnitude()
     end
 
-    function toNormalized()
+    function to_normalized()
       return self / self:magnitude()
     end
 
-    function toRotYUp()
+    function to_rot_y_up()
       local yaw = math.deg(math.atan(self.x, self.z)) * -1
       local pitch = math.deg(math.asin(self.y / self:magnitude()))
       return new Vector3(
@@ -525,7 +525,7 @@ package.preload["Vector3"] = function()
       )
     end
 
-    function toRotZUp()
+    function to_rot_z_up()
       local yaw = math.deg(math.atan(self.x, self.y)) * -1
       local pitch = math.deg(math.asin(self.z / self:magnitude()))
       return new Vector3(
@@ -535,17 +535,17 @@ package.preload["Vector3"] = function()
       )
     end
 
-    function lookAtYUp(b)
+    function look_at_y_up(b)
       local dir = (b - self)
       return dir:toRotYUp()
     end
 
-    function lookAtZUp(b)
+    function look_at_z_up(b)
       local dir = (b - self)
       return dir:toRotZUp()
     end
 
-    function toDirYUp()
+    function to_dir_y_up()
       local yaw_radians = math.rad(self.z)
       local pitch_radians = math.rad(self.x) * -1
       return new Vector3(
@@ -555,7 +555,7 @@ package.preload["Vector3"] = function()
       )
     end
 
-    function toDirZUp()
+    function to_dir_z_up()
       local yaw_radians = math.rad(self.z)
       local pitch_radians = math.rad(self.x) * -1
       return new Vector3(

--- a/src/liolib.cpp
+++ b/src/liolib.cpp
@@ -858,7 +858,7 @@ static int exists (lua_State *L)
 }
 
 
-static int copyto (lua_State *L)
+static int io_copy (lua_State *L)
 {
   FS_FUNCTION
   Protect(
@@ -1088,7 +1088,8 @@ static const luaL_Reg iolib[] = {
   {"absolute", absolute},
   {"canonical", canonical},
   {"parent", parent},
-  {"copyto", copyto},
+  {"copyto", io_copy}, /* deprecated */
+  {"copy", io_copy}, /* added in Pluto 0.8.0 */
   {"exists", exists},
   {"filesize", filesize},
   {"isfile", isfile},

--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -2379,8 +2379,10 @@ static const luaL_Reg strlib[] = {
   {"islower", str_islower},
   {"split", str_split},
   {"partition", str_partition},
-  {"endswith", str_endswith},
-  {"startswith", str_startswith},
+  {"endswith", str_endswith}, /* deprecated */
+  {"startswith", str_startswith}, /* deprecated */
+  {"ends_with", str_endswith}, /* added in Pluto 0.8.0 */
+  {"starts_with", str_startswith}, /* added in Pluto 0.8.0 */
   {"byte", str_byte},
   {"char", str_char},
   {"dump", str_dump},


### PR DESCRIPTION
In general, I do like the way functions are named, e.g. `dumpvar` is quite nice compared to the alternatives of `dump_var` or `dumpVar`. I guess `DumpVar` is alright, but would be a huge deviation.

However, a few outliers in the standard library (imo):
- Vector3 method names — our first class with methods, so important to get this right. As much as I find snake_case disgusting for method names, it is consistent with the rest of the standard library, and therefore it balances out.
- string.endswith & string.startswith — Added an underscore to get string.ends_with & string.starts_with, respectively. These will be aliases for now, but in the distant future the old names may be removed.
- io.copyto — This one didn't make huge sense in the way it's called because it's not `a:copyto(b)`, but instead `io.copyto(a, b)`; `io.copy(a, b)` makes a lot more sense, imo. In the same way as the string methods, this is only an alias for now, but eventually the old name may be removed.