### PR TITLE
Add safe navigation for calls

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2290,6 +2290,10 @@ static void safe_navigation(LexState *ls, expdesc *v) {
         luaK_indexed(fs, v, &key);
         break;
       }
+      case '(': {
+        funcargs(ls, v);
+        break;
+      }
       default: {
         luaX_syntaxerror(ls, "unexpected symbol");
       }
@@ -2657,7 +2661,7 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
     switch (ls->t.token) {
       case '?': {  /* safe navigation or ternary */
         auto t = luaX_lookahead(ls);
-        if (t != '[' && t != '.') {
+        if (t != '[' && t != '.' && t != '(') {
           /* it's a ternary but we have to deal with that later */
           return; /* back to primaryexp */
         }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2286,12 +2286,13 @@ static void safe_navigation(LexState *ls, expdesc *v) {
       }       
       case '.': {
         luaX_next(ls);
-        codename(ls, &key);
-        luaK_indexed(fs, v, &key);
-        break;
-      }
-      case '(': {
-        funcargs(ls, v);
+        if (ls->t.token == '(') {
+          funcargs(ls, v);
+        }
+        else {
+          codename(ls, &key);
+          luaK_indexed(fs, v, &key);
+        }
         break;
       }
       default: {
@@ -2661,7 +2662,7 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
     switch (ls->t.token) {
       case '?': {  /* safe navigation or ternary */
         auto t = luaX_lookahead(ls);
-        if (t != '[' && t != '.' && t != '(') {
+        if (t != '[' && t != '.') {
           /* it's a ternary but we have to deal with that later */
           return; /* back to primaryexp */
         }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -368,8 +368,8 @@ do
         return true
     end
 
-    assert(func?() == true)
-    assert(optional_func?() == nil)
+    assert(func?.() == true)
+    assert(optional_func?.() == nil)
 end
 
 print "Testing shorthand ternary."
@@ -382,6 +382,8 @@ do
     assert((a == 4 ? "yes" : "no") == "no")
     assert((3 == a ? "yes" : "no") == "yes")
     assert((4 == a ? "yes" : "no") == "no")
+    local cond = true
+    assert((cond?(69):42) == 69)
 end
 
 print "Testing 'in' expressions."

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -363,6 +363,14 @@ do
     T.K.Z = {}
     assert(T?.K?.Z == T.K.Z)
 end
+do
+    local function func()
+        return true
+    end
+
+    assert(func?() == true)
+    assert(optional_func?() == nil)
+end
 
 print "Testing shorthand ternary."
 do


### PR DESCRIPTION
- [x] `some_func?.()`
- [ ] `inst:method?()`
- [ ] `inst?:method()`
- [ ] `inst?:method?()`