### PR TITLE
Add safe navigation for method calls

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2291,7 +2291,6 @@ static void safe_navigation(LexState *ls, expdesc *v) {
         break;
       }
       case ':': {
-        expdesc key;
         luaX_next(ls);
         codename(ls, &key);
         luaK_self(fs, v, &key);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2290,6 +2290,14 @@ static void safe_navigation(LexState *ls, expdesc *v) {
         luaK_indexed(fs, v, &key);
         break;
       }
+      case ':': {
+        expdesc key;
+        luaX_next(ls);
+        codename(ls, &key);
+        luaK_self(fs, v, &key);
+        funcargs(ls, v);
+        break;
+      }
       default: {
         luaX_syntaxerror(ls, "unexpected symbol");
       }
@@ -2678,7 +2686,7 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
     switch (ls->t.token) {
       case '?': {  /* safe navigation or ternary */
         auto t = luaX_lookahead(ls);
-        if (t != '[' && t != '.') {
+        if (t != '[' && t != '.' && t != ':') {
           /* it's a ternary but we have to deal with that later */
           return; /* back to primaryexp */
         }

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -2209,11 +2209,17 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
           vmbreak;
         }
 #endif // PLUTO_ILP_ENABLE
-        docondjump();
         vmDumpInit();
         vmDumpAddA();
-        vmDumpAdd (GETARG_k(i));
-        vmDumpOut (";");
+        vmDumpAdd(GETARG_k(i));
+        vmDumpAdd(GETARG_sJ(*pc));
+        if (cond) {
+          vmDumpOut("; conditional jump: condition is true");
+        }
+        else {
+          vmDumpOut("; conditional jump: condition is false");
+        }
+        docondjump();
         vmbreak;
       }
       vmcase(OP_TESTSET) {

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -377,6 +377,11 @@ do
     local inst = new Class()
     assert(inst?:method() == true)
     assert(optinst?:method() == nil)
+    assert(inst:method?() == true)
+    assert(inst:optmethod?() == nil)
+    assert(inst?:method?() == true)
+    assert(inst?:optmethod?() == nil)
+    assert(optinst?:method?() == nil)
 end
 
 print "Testing shorthand ternary."

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -365,6 +365,18 @@ do
 
     local t = { [-1] = 1 }
     assert(t?[-1] == 1)
+
+    local class Class
+        val: bool = true
+
+        function method()
+            return self.val
+        end
+    end
+
+    local inst = new Class()
+    assert(inst?:method() == true)
+    assert(optinst?:method() == nil)
 end
 
 print "Testing shorthand ternary."


### PR DESCRIPTION
- [x] `inst:method?()`
- [x] `inst?:method()`
- [x] `inst?:method?()`