### PR TITLE
Remove the capture limit

### DIFF
--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -564,8 +564,10 @@ static const char *start_capture (MatchState *ms, const char *s,
   const char *res;
   int level = ms->level;
   if (level == INT_MAX) luaL_error(ms->L, "too many captures");
-  lua_assert(ms->capture.size() == level);
-  ms->capture.emplace_back(MatchState::Capture{ s, what });
+  if (level >= ms->capture.size())
+    ms->capture.emplace_back();
+  ms->capture[level].init = s;
+  ms->capture[level].len = what;
   ms->level = level+1;
   if ((res=match(ms, s, p)) == NULL)  /* match failed? */
     ms->level--;  /* undo capture */


### PR DESCRIPTION
```Lua
local text = "a ":repeat(100)
local pattern = "(%a+) ":repeat(50)

print("string.find")
print(string.find(text, pattern))

print("string.gmatch")
for w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15, w16, w17, w18, w19, w20, w21, w22, w23, w24, w25, w26, w27, w28, w29, w30, w31, w32, w33, w34, w35, w36, w37, w38, w39, w40, w41, w42, w43, w44, w45, w46, w47, w48, w49, w50
	in string.gmatch(text, pattern) do
    print(w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15, w16, w17, w18, w19, w20, w21, w22, w23, w24, w25, w26, w27, w28, w29, w30, w31, w32, w33, w34, w35, w36, w37, w38, w39, w40, w41, w42, w43, w44, w45, w46, w47, w48, w49, w50)
end
```