### PR TITLE
Provide a slightly more useful message when 'else if' is used instead of 'elseif'

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4009,8 +4009,18 @@ static void ifstat (LexState *ls, int line, TypeHint *prop = nullptr) {
   test_then_block(ls, &escapelist, prop);  /* IF cond THEN block */
   while (ls->t.token == TK_ELSEIF)
     test_then_block(ls, &escapelist, prop);  /* ELSEIF cond THEN block */
-  if (testnext(ls, TK_ELSE))
+  size_t else_if = 0;
+  if (testnext(ls, TK_ELSE)) {
+    if (ls->t.token == TK_IF)
+      else_if = luaX_getpos(ls);
     block(ls);  /* 'else' part */
+  }
+  if (ls->t.token != TK_END && else_if) {
+    auto pos = luaX_getpos(ls);
+    luaX_setpos(ls, else_if);
+    throw_warn(ls, "'else if' is not the same as 'elseif' in Lua/Pluto", "did you mean 'elseif'?", WT_POSSIBLE_TYPO);
+    luaX_setpos(ls, pos);
+  }
   check_match(ls, TK_END, TK_IF, line);
   luaK_patchtohere(fs, escapelist);  /* patch escape list to 'if' end */
 }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4009,18 +4009,14 @@ static void ifstat (LexState *ls, int line, TypeHint *prop = nullptr) {
   test_then_block(ls, &escapelist, prop);  /* IF cond THEN block */
   while (ls->t.token == TK_ELSEIF)
     test_then_block(ls, &escapelist, prop);  /* ELSEIF cond THEN block */
-  size_t else_if = 0;
+  int else_if = 0;
   if (testnext(ls, TK_ELSE)) {
     if (ls->t.token == TK_IF)
-      else_if = luaX_getpos(ls);
+      else_if = ls->getLineNumber();
     block(ls);  /* 'else' part */
   }
-  if (ls->t.token != TK_END && else_if) {
-    auto pos = luaX_getpos(ls);
-    luaX_setpos(ls, else_if);
-    throw_warn(ls, "'else if' is not the same as 'elseif' in Lua/Pluto", "did you mean 'elseif'?", WT_POSSIBLE_TYPO);
-    luaX_setpos(ls, pos);
-  }
+  if (ls->t.token != TK_END && else_if)
+    throw_warn(ls, "'else if' is not the same as 'elseif' in Lua/Pluto", "did you mean 'elseif'?", else_if, WT_POSSIBLE_TYPO);
   check_match(ls, TK_END, TK_IF, line);
   luaK_patchtohere(fs, escapelist);  /* patch escape list to 'if' end */
 }


### PR DESCRIPTION
Example:
```Lua
local a = 1
if a == 1 then
    -- ...
else if a == 2 then
    -- ...
end
```
Now produces:
```
basic.pluto:4: warning: 'else if' is not the same as 'elseif' in Lua/Pluto [possible-typo]
    4 | else if a == 2 then
      | ^^^^^^^^^^^^^^^^^^^ here: did you mean 'elseif'?
C:\Users\Sainan\Desktop\Repos\Pluto\out\pluto x64\pluto.exe: syntax error: basic.pluto:6: missing 'end' to terminate 'if' block on line 2 (near '<eof>')
    6 | end
      | ^^^ here: this was the last statement.
```