### PR TITLE
Add .deb package & CI improvements

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -10,17 +10,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: php scripts/compile.php clang
       - run: php scripts/link_pluto.php clang
-      - run: php scripts/link_plutoc.php clang
-      - run: php scripts/link_shared.php clang
-      - run: php scripts/link_static.php
-      - uses: actions/upload-artifact@v3
-        with:
-          name: "Ubuntu 22.04"
-          path: |
-            src/pluto
-            src/plutoc
-            src/libpluto.so
-            src/libpluto.a
       - run: src/pluto testes/_driver.pluto
   ubuntu-20-04:
     runs-on: ubuntu-20.04
@@ -28,17 +17,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: php scripts/compile.php clang
       - run: php scripts/link_pluto.php clang
-      - run: php scripts/link_plutoc.php clang
-      - run: php scripts/link_shared.php clang
-      - run: php scripts/link_static.php
-      - uses: actions/upload-artifact@v3
-        with:
-          name: "Debian 11, Ubuntu 20.04"
-          path: |
-            src/pluto
-            src/plutoc
-            src/libpluto.so
-            src/libpluto.a
       - run: src/pluto testes/_driver.pluto
   debian-10:
     runs-on: [debian-10]
@@ -51,7 +29,7 @@ jobs:
       - run: php scripts/link_static.php
       - uses: actions/upload-artifact@v3
         with:
-          name: "Debian 10"
+          name: "Debian 10 and above"
           path: |
             src/pluto
             src/plutoc

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -94,7 +94,10 @@ jobs:
             src/pluto.exe
             src/plutoc.exe
             src/libpluto.a
-            plutolang/*.nupkg
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Windows Chocolatey Package
+          path: plutolang/*.nupkg
       - run: src/pluto.exe testes/_driver.pluto
   windows-dll:
     runs-on: windows-latest

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -36,6 +36,11 @@ jobs:
             src/libpluto.so
             src/libpluto.a
       - run: src/pluto testes/_driver.pluto
+      - run: php scripts/bundle_deb.php
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "Debian 10 and above - .deb Package"
+          path: pluto.deb
   macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -86,6 +86,7 @@ jobs:
       - run: php scripts/link_pluto.php clang
       - run: php scripts/link_plutoc.php clang
       - run: php scripts/link_static.php
+      - run: php scripts/bundle_nupkg.php
       - uses: actions/upload-artifact@v3
         with:
           name: Windows
@@ -93,6 +94,7 @@ jobs:
             src/pluto.exe
             src/plutoc.exe
             src/libpluto.a
+            plutolang/*.nupkg
       - run: src/pluto.exe testes/_driver.pluto
   windows-dll:
     runs-on: windows-latest

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -64,7 +64,6 @@ jobs:
       - run: php scripts/link_pluto.php clang
       - run: php scripts/link_plutoc.php clang
       - run: php scripts/link_static.php
-      - run: php scripts/bundle_nupkg.php
       - uses: actions/upload-artifact@v3
         with:
           name: Windows
@@ -72,11 +71,12 @@ jobs:
             src/pluto.exe
             src/plutoc.exe
             src/libpluto.a
+      - run: src/pluto.exe testes/_driver.pluto
+      - run: php scripts/bundle_nupkg.php
       - uses: actions/upload-artifact@v3
         with:
           name: Windows Chocolatey Package
           path: plutolang/*.nupkg
-      - run: src/pluto.exe testes/_driver.pluto
   windows-dll:
     runs-on: windows-latest
     steps:

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,25 @@
+pkgname=pluto
+pkgver=tbd
+pkgrel=1
+arch=('x86_64')
+makedepends=('php')
+source=("pluto-git::git+https://github.com/PlutoLang/Pluto")
+sha256sums=('SKIP')
+
+pkgver () {
+	git rev-parse --short HEAD
+}
+
+build () {
+	cd pluto-git
+	php scripts/compile.php clang
+	php scripts/link_pluto.php clang
+	php scripts/link_plutoc.php clang
+}
+
+package () {
+	cd $srcdir/pluto-git
+	mkdir -p $pkgdir/usr/local/bin
+	cp src/pluto $pkgdir/usr/local/bin/pluto
+	cp src/plutoc $pkgdir/usr/local/bin/plutoc
+}

--- a/scripts/bundle_deb.php
+++ b/scripts/bundle_deb.php
@@ -1,0 +1,30 @@
+<?php
+foreach (file("src/lua.h") as $line)
+{
+	if (substr($line, 0, 29) == '#define PLUTO_VERSION "Pluto ')
+	{
+		$pluto_version = substr(rtrim($line), 29, -1);
+		break;
+	}
+}
+$pluto_version or die("Failed to determine Pluto version");
+
+mkdir("pluto");
+mkdir("pluto/DEBIAN");
+file_put_contents("pluto/DEBIAN/control", <<<EOC
+Package: pluto
+Version: $pluto_version
+Section: custom
+Priority: optional
+Architecture: all
+Essential: no
+Maintainer: Sainan <sainan@calamity.gg>
+Description: A superset of Lua 5.4 — with unique features, optimizations, and improvements.
+
+EOC);
+mkdir("pluto/usr");
+mkdir("pluto/usr/local");
+mkdir("pluto/usr/local/bin");
+copy("src/pluto", "pluto/usr/local/bin/pluto");
+copy("src/plutoc", "pluto/usr/local/bin/plutoc");
+passthru("dpkg-deb --build pluto");

--- a/scripts/bundle_deb.php
+++ b/scripts/bundle_deb.php
@@ -22,9 +22,12 @@ Maintainer: Sainan <sainan@calamity.gg>
 Description: A superset of Lua 5.4 — with unique features, optimizations, and improvements.
 
 EOC);
+chmod("pluto/DEBIAN/control", 0644);
 mkdir("pluto/usr");
 mkdir("pluto/usr/local");
 mkdir("pluto/usr/local/bin");
 copy("src/pluto", "pluto/usr/local/bin/pluto");
 copy("src/plutoc", "pluto/usr/local/bin/plutoc");
+chmod("pluto/usr/local/bin/pluto", 0755);
+chmod("pluto/usr/local/bin/plutoc", 0755);
 passthru("dpkg-deb --build pluto");

--- a/scripts/bundle_nupkg.php
+++ b/scripts/bundle_nupkg.php
@@ -1,0 +1,34 @@
+<?php
+foreach (file("src/lua.h") as $line)
+{
+	if (substr($line, 0, 29) == '#define PLUTO_VERSION "Pluto ')
+	{
+		$pluto_version = substr(rtrim($line), 29, -1);
+		break;
+	}
+}
+$pluto_version or die("Failed to determine Pluto version");
+
+mkdir("plutolang");
+copy("LICENSE", "plutolang/LICENSE.txt");
+copy("src/pluto.exe", "plutolang/pluto.exe");
+copy("src/plutoc.exe", "plutolang/plutoc.exe");
+chdir("plutolang");
+file_put_contents(".chocogen.json", <<<EOC
+{
+    "path": ["pluto.exe", "plutoc.exe", "LICENSE.txt", "VERIFICATION.txt"],
+    "title": "Pluto Language",
+    "description": "A superset of Lua 5.4 — with unique features, optimizations, and improvements.",
+    "authors": "Ryan Starrett, Sainan",
+    "website": "https://pluto-lang.org/",
+    "repository": "https://github.com/PlutoLang/Pluto",
+    "tags": "pluto lua development programming foss cross-platform non-admin",
+    "icon": "https://pluto-lang.org/img/logo.png",
+    "license": "https://github.com/PlutoLang/Pluto/blob/main/LICENSE",
+    "changelog": "https://github.com/PlutoLang/Pluto/releases",
+    "issues": "https://github.com/PlutoLang/Pluto/issues"
+}
+EOC);
+file_put_contents("VERIFICATION.txt", "These are the same files as in the Windows.zip for this release of Pluto: https://github.com/PlutoLang/Pluto/releases");
+file_put_contents("chocogen.php", file_get_contents("https://raw.githubusercontent.com/calamity-inc/chocogen/0b1c843eaa167caf590bd56f46f5a57f6ffc6000/chocogen.php"));
+passthru("php chocogen.php $pluto_version");


### PR DESCRIPTION
- Chocolatey Package/.nupkg now generated directly on Github Actions
- No longer uploading Debian 11/Ubuntu 20 & Ubuntu 22 binaries, as Debian 10 covers them all
- Github Actions now also generates .deb package