### PR TITLE
Add json.null

### DIFF
--- a/src/ljson.cpp
+++ b/src/ljson.cpp
@@ -36,6 +36,13 @@ static const luaL_Reg funcs[] = {
 	{nullptr, nullptr}
 };
 
-PLUTO_NEWLIB(json);
+LUAMOD_API int luaopen_json(lua_State* L)
+{
+	luaL_newlib(L, funcs);
+	lua_pushlightuserdata(L, reinterpret_cast<void*>(static_cast<uintptr_t>('PJNL')));
+	lua_setfield(L, -2, "null");
+	return 1;
+}
+const Pluto::PreloadedLibrary Pluto::preloaded_json{ "json", funcs, &luaopen_json };
 
 #endif

--- a/src/ljson.hpp
+++ b/src/ljson.hpp
@@ -94,6 +94,13 @@ static soup::UniquePtr<soup::JsonNode> checkJson(lua_State* L, int i)
 			return obj;
 		}
 	}
+	else if (type == LUA_TLIGHTUSERDATA)
+	{
+		if (reinterpret_cast<uintptr_t>(lua_touserdata(L, i)) == 'PJNL')
+		{
+			return soup::make_unique<soup::JsonNull>();
+		}
+	}
 	luaL_typeerror(L, i, "JSON-castable type");
 }
 


### PR DESCRIPTION
This allows us to encode a null value:
```Lua
local json = require("pluto:json")
print(json.encode({
    ["null"] = json.null
}))
```

I was gonna add an "explicit_null" flag to json.decode, but I really didn't like the semantics of that. Also doesn't matter much, the main issue was encoding.