### PR TITLE
Summarize issues with table.filter, tweak table.map, add table.reorder

### DIFF
--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -591,6 +591,7 @@ static int treorder (lua_State* L) {
     lua_pop(L, 1); // stack: table, key
   }
 
+  luaH_resizearray(L, hvalue(index2value(L, 1)), (unsigned int)idx);
   lua_settop(L, 1);
   return 1;
 }

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -522,25 +522,23 @@ static int tmap (lua_State *L) {
   lua_newtable(L);
   lua_pushvalue(L, 1);
   lua_pushnil(L);
-  /* stack now: out, in, key */
+  /* stack now: table, key */
   while (lua_next(L, -2)) {
-    /* stack now: out, in, key, value */
+    /* stack now: table, key, value */
     lua_pushvalue(L, 2);
     lua_pushvalue(L, -2);
-    /* stack now: out, in, key, value, function, value */
+    /* stack now: table, key, value, function, value */
     lua_call(L, 1, 1);
-    /* stack now: out, in, key, value, mapped_value */
+    /* stack now: table, key, value, mapped_value */
     lua_pushvalue(L, -3);
     lua_pushvalue(L, -2);
-    /* stack now: out, in, key, value, mapped_value, key, mapped_value */
-    lua_settable(L, -7);
-    /* stack now: out, in, key, value, mapped_value */
+    /* stack now: table, key, value, mapped_value, key, mapped_value */
+    lua_settable(L, -6);
+    /* stack now: table, key, value, mapped_value */
     lua_pop(L, 2);
-    /* stack now: out, in, key */
+    /* stack now: table, key */
   }
-  /* stack now: out, in */
-  lua_pop(L, 1);
-  /* stack now: out */
+  /* stack now: table */
   return 1;
 }
 

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -482,35 +482,34 @@ static int tfilter (lua_State *L) {
   luaL_checktype(L, 1, LUA_TTABLE);
   luaL_checktype(L, 2, LUA_TFUNCTION);
 
-  lua_newtable(L);
-  lua_Integer idx = 1;
   lua_pushvalue(L, 1);
   lua_pushnil(L);
-  /* stack now: out, in, key */
+  /* stack now: table, key */
   while (lua_next(L, -2)) {
-    /* stack now: out, in, key, value */
+    /* stack now: table, key, value */
     lua_pushvalue(L, 2);
     lua_pushvalue(L, -2);
-    /* stack now: out, in, key, value, function, value */
+    /* stack now: table, key, value, function, value */
     lua_call(L, 1, 1);
-    /* stack now: out, in, key, value, bKeep */
+    /* stack now: table, key, value, bKeep */
+
     const bool bKeep = lua_toboolean(L, -1);
     lua_pop(L, 1);
-    /* stack now: out, in, key, value */
-    if (bKeep) {
-      lua_pushinteger(L, idx++);
-      /* stack now: out, in, key, value, idx */
+    /* stack now: table, key, value */
+    if (!bKeep) {
       lua_pushvalue(L, -2);
-      /* stack now: out, in, key, value, idx, value */
-      lua_settable(L, -6);
-      /* stack now: out, in, key, value */
+      /* stack now: table, key, value, key */
+      lua_pushnil(L);
+      /* stack now: table, key, value, key, value */
+      lua_settable(L, -5);
+      /* stack now: table, key, value */
     }
+
     lua_pop(L, 1);
-    /* stack now: out, in, key */
+    /* stack now: table, key */
   }
-  /* stack now: out, in */
-  lua_pop(L, 1);
-  /* stack now: out */
+  
+  lua_settop(L, 1);
   return 1;
 }
 

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -561,9 +561,37 @@ static int treverse (lua_State *L) {
 
 
 TValue *index2value (lua_State *L, int idx);
-static int tlimit(lua_State *L) {
+static int tlimit (lua_State *L) {
   luaL_checktype(L, 1, LUA_TTABLE);
   lua_pushinteger(L, hvalue(index2value(L, 1))->alimit);
+  return 1;
+}
+
+
+static int treorder (lua_State* L) {
+  luaL_checktype(L, 1, LUA_TTABLE);
+
+  lua_pushvalue(L, 1); // stack: table
+  lua_pushnil(L); // stack: table, key
+
+  lua_Integer idx = 1;
+  while (lua_next(L, -2)) { // stack: table, key, value
+    if (lua_isinteger(L, -2)) {
+      if (auto val = lua_tointeger(L, -2); val > idx) {
+        lua_pushinteger(L, val); // stack: table, key, value, key
+        lua_pushnil(L); // stack: table, key, value, key, value
+        lua_settable(L, 1); // stack: table, key, value
+      }
+
+      lua_pushinteger(L, idx++); // stack: table, key, value, key
+      lua_pushvalue(L, -2); // stack; table, key, value, key, value
+      lua_settable(L, 1); // stack; table, key, value
+    }
+
+    lua_pop(L, 1); // stack: table, key
+  }
+
+  lua_settop(L, 1);
   return 1;
 }
 
@@ -572,6 +600,7 @@ static int tlimit(lua_State *L) {
 
 
 static const luaL_Reg tab_funcs[] = {
+  {"reorder", treorder},
   {"limit", tlimit},
   {"reverse", treverse},
   {"map", tmap},

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1151,13 +1151,15 @@ do
     assert("hello world":repeat(2) == "hello worldhello world")
 end
 do
-    local t = { 5, 4, 3, 2, 1 }
+    local t = { 5, 4, 3, 2, 1, even = 8, odd = 9 }
     table.filter(t, |x| -> x % 2 ~= 0)
     assert(t[1] == 5)
     assert(t[2] == nil)
     assert(t[3] == 3)
     assert(t[4] == nil)
     assert(t[5] == 1)
+    assert(t.even == nil)
+    assert(t.odd == 9)
 end
 do
     do

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1160,6 +1160,25 @@ do
     assert(t[5] == 1)
 end
 do
+    do
+        local t = { 1, nil, 2, nil, nil, 3, nil, nil, nil, 4, nil }
+        t:reorder()
+        assert(t[1] == 1)
+        assert(t[2] == 2)
+        assert(t[3] == 3)
+        assert(t[4] == 4)
+        assert(t[5] == nil)
+    end
+
+    do
+        local t = { 1, 2, 3, "hello" }:reorder()
+        assert(t[1] == 1)
+        assert(t[2] == 2)
+        assert(t[3] == 3)
+        assert(t[4] == "hello")
+    end
+end
+do
     local menu = {
         { id = 1, name = "Pizza" },
         { id = 2, name = "Doener" }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1152,11 +1152,12 @@ do
 end
 do
     local t = { 5, 4, 3, 2, 1 }
-    t = table.filter(t, |x| -> x % 2 ~= 0)
+    table.filter(t, |x| -> x % 2 ~= 0)
     assert(t[1] == 5)
-    assert(t[2] == 3)
-    assert(t[3] == 1)
-    assert(#t == 3) -- there should be only 3 items in the array part
+    assert(t[2] == nil)
+    assert(t[3] == 3)
+    assert(t[4] == nil)
+    assert(t[5] == 1)
 end
 do
     local menu = {


### PR DESCRIPTION
Attempts to resolve the dispute of `table.filter` functionality. Now it will only remove keys which are filtered, no longer will it reindex/reorder the table. The function `table.reorder` has been added to allow users to reorder explicitly on demand. Both because it's helpful to complement `table.filter` in continuous arrays, and it's also helpful to have on its own.