### PR TITLE
Improve 'else if' warning coverage

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -356,6 +356,7 @@ struct LexState {
   bool uses_instanceof = false;
   bool uses_spaceship = false;
 
+  int else_if = 0;  /* line on which 'else if' was seen, to raise warning in case of missing 'end' */
   std::vector<WarningConfig> warnconfs;
   std::stack<ParserContext> parser_context_stck{};
   std::stack<ClassData> classes{};

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -343,6 +343,8 @@ static void check_match (LexState *ls, int what, int who, int where) {
       error_expected(ls, what);  /* do not need a complex message */
     else {
       if (what == TK_END) {
+        if (ls->else_if)
+          throw_warn(ls, "'else if' is not the same as 'elseif' in Lua/Pluto", "did you mean 'elseif'?", ls->else_if, WT_POSSIBLE_TYPO);
         std::string msg = "missing 'end' to terminate ";
         msg.append(luaX_token2str(ls, who));
         if (who != TK_BEGIN) {
@@ -4025,14 +4027,11 @@ static void ifstat (LexState *ls, int line, TypeHint *prop = nullptr) {
   test_then_block(ls, &escapelist, prop);  /* IF cond THEN block */
   while (ls->t.token == TK_ELSEIF)
     test_then_block(ls, &escapelist, prop);  /* ELSEIF cond THEN block */
-  int else_if = 0;
   if (testnext(ls, TK_ELSE)) {
     if (ls->t.token == TK_IF)
-      else_if = ls->getLineNumber();
+      ls->else_if = ls->getLineNumber();
     block(ls);  /* 'else' part */
   }
-  if (ls->t.token != TK_END && else_if)
-    throw_warn(ls, "'else if' is not the same as 'elseif' in Lua/Pluto", "did you mean 'elseif'?", else_if, WT_POSSIBLE_TYPO);
   check_match(ls, TK_END, TK_IF, line);
   luaK_patchtohere(fs, escapelist);  /* patch escape list to 'if' end */
 }


### PR DESCRIPTION
Previously, this really only worked in the main block, now it also works in cases like this:
```Lua
local function f(b)
    if b then
    else if b then
    end
end
```