### PR TITLE
Perform concat at compile-time

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -38,6 +38,7 @@
 #include "lsuggestions.hpp"
 #include "ltable.h"
 #include "lauxlib.h"
+#include "lvm.h"
 
 #include "lerrormessage.hpp"
 
@@ -3404,6 +3405,18 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
       if (op == OPR_CONCAT) {
         if (prop)
           prop->emplaceTypeDesc(VT_STR);
+        if (v->k == VKSTR && ls->t.token == TK_STRING) {
+          setsvalue2s(ls->L, ls->L->top.p, v->u.strval);
+          ls->L->top.p++;
+          setsvalue2s(ls->L, ls->L->top.p, ls->t.seminfo.ts);
+          ls->L->top.p++;
+          luaV_concat(ls->L, 2);
+		  ls->L->top.p--;
+          v->u.strval = tsvalue(s2v(ls->L->top.p));
+          luaX_next(ls);
+		  op = getbinopr(ls->t.token);
+          continue;
+        }
       }
       else if (op == OPR_COAL) {
         if (luaK_isalwaysnil(ls, v)) {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3416,11 +3416,11 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
           setsvalue2s(ls->L, ls->L->top.p, ls->t.seminfo.ts);
           ls->L->top.p++;
           luaV_concat(ls->L, 2);
-		  ls->L->top.p--;
+          ls->L->top.p--;
           v->k = VKSTR;
           v->u.strval = tsvalue(s2v(ls->L->top.p));
           luaX_next(ls);
-		  op = getbinopr(ls->t.token);
+          op = getbinopr(ls->t.token);
           continue;
         }
       }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3405,13 +3405,19 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
       if (op == OPR_CONCAT) {
         if (prop)
           prop->emplaceTypeDesc(VT_STR);
-        if (v->k == VKSTR && ls->t.token == TK_STRING) {
-          setsvalue2s(ls->L, ls->L->top.p, v->u.strval);
+        TString *lhs = nullptr;
+        if (v->k == VKSTR)
+          lhs = v->u.strval;
+        else if (v->k == VCONST && ttisstring(&ls->dyd->actvar.arr[v->u.info].k))
+          lhs = tsvalue(&ls->dyd->actvar.arr[v->u.info].k);
+        if (lhs && ls->t.token == TK_STRING) {
+          setsvalue2s(ls->L, ls->L->top.p, lhs);
           ls->L->top.p++;
           setsvalue2s(ls->L, ls->L->top.p, ls->t.seminfo.ts);
           ls->L->top.p++;
           luaV_concat(ls->L, 2);
 		  ls->L->top.p--;
+          v->k = VKSTR;
           v->u.strval = tsvalue(s2v(ls->L->top.p));
           luaX_next(ls);
 		  op = getbinopr(ls->t.token);

--- a/testes/literals.lua
+++ b/testes/literals.lua
@@ -229,7 +229,7 @@ do  -- reuse of long strings
   assert(a1 == getadd(foo2()))
 
   local sd = "0123456789" .. "0123456789012345678901234567890123456789"
-  assert(sd == s1 and getadd(sd) ~= a1)
+  assert(sd == s1) -- [Pluto] removed the check that addresses are not identical, because we do this concat at compile-time.
 end
 
 


### PR DESCRIPTION
Handles
```Lua
print("a" .. "b")
```
And
```Lua
local a <const> = "a"
print(a .. "b")
```
However, optimising for RHS being a const variable might be a bit too much effort to do correctly.