### PR TITLE
Improve non-portable-bytecode warning

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -217,7 +217,7 @@ static void check_for_non_portable_code (LexState *ls) {
 **   - We could alternatively inject Lua-versions of our standard library into files intended to be portable, but this might be a lot of work for little.
 */
 static void check_for_non_portable_bytecode (LexState *ls) {
-  if (ls->t.token == TK_COAL || ls->t.seminfo.i == TK_COAL || ls->t.token == TK_IN || ls->t.token == TK_INSTANCEOF || ls->t.token == TK_SPACESHIP) {
+  if (ls->t.token == TK_COAL || ls->t.seminfo.i == TK_COAL || ls->t.token == TK_IN) {
     throw_warn(ls, "non-portable operator usage", "this operator generates bytecode which is incompatible with Lua.", WT_NON_PORTABLE_BYTECODE);
     return;
   }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4601,6 +4601,10 @@ static void trystat (LexState *ls) {
 
     ls->fs->f->onPlutoOpUsed(0);  /* not bytecode-incompatible, but this will not run on Lua without errors. */
 
+    int return_line = ls->getLineNumber() - 1;
+    if (return_line < line) return_line = line;
+    throw_warn(ls, "non-portable statement usage", "returning from a try block generates bytecode which is incompatible with Lua.", return_line, WT_NON_PORTABLE_BYTECODE);
+
     expdesc tlimit;
     singlevar(ls, &tlimit, luaX_newliteral(ls, "table"));
     luaK_exp2anyregup(ls->fs, &tlimit);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1931,7 +1931,6 @@ static void parlist (LexState *ls, std::vector<std::pair<TString*, TString*>>* p
 }
 
 
-static void compoundassign(LexState *ls, expdesc *v, BinOpr op);
 static void body (LexState *ls, expdesc *e, int ismethod, int line, TypeDesc *funcdesc) {
   /* body ->  '(' parlist ')' block END */
   ls->pushContext(PARCTX_BODY);


### PR DESCRIPTION
- Added coverage for try block with return statement
- Removed warning for 'instanceof' and '<=>'
- Removed warning for `nil ?? ...` because the generated code is compatible