### PR TITLE
Add luaG_addsrcinfo

### DIFF
--- a/src/ldebug.cpp
+++ b/src/ldebug.cpp
@@ -852,7 +852,7 @@ const char *luaG_addinfo (lua_State *L, const char *msg, TString *src,
 
 #ifndef PLUTO_LUA_LINKABLE
 /* Pushes a string that is 'src:line ' prefixed to 'msg', or returns false on failure. */
-bool luaG_addinfo_pluto (lua_State *L, const char *msg) {
+bool luaG_addsrcinfo (lua_State *L, const char *msg) {
   CallInfo *ci = L->ci;
   while (ci && !isLua(ci)) {
     ci = ci->previous;

--- a/src/ldebug.cpp
+++ b/src/ldebug.cpp
@@ -850,6 +850,7 @@ const char *luaG_addinfo (lua_State *L, const char *msg, TString *src,
 }
 
 
+#ifndef PLUTO_LUA_LINKABLE
 /* Pushes a string that is 'src:line ' prefixed to 'msg', or returns false on failure. */
 bool luaG_addinfo_pluto (lua_State *L, const char *msg) {
   CallInfo *ci = L->ci;
@@ -862,6 +863,7 @@ bool luaG_addinfo_pluto (lua_State *L, const char *msg) {
   }
   return false;
 }
+#endif
 
 
 l_noret luaG_errormsg (lua_State *L) {

--- a/src/ldebug.cpp
+++ b/src/ldebug.cpp
@@ -850,6 +850,20 @@ const char *luaG_addinfo (lua_State *L, const char *msg, TString *src,
 }
 
 
+/* Pushes a string that is 'src:line ' prefixed to 'msg', or returns false on failure. */
+bool luaG_addinfo_pluto (lua_State *L, const char *msg) {
+  CallInfo *ci = L->ci;
+  while (ci && !isLua(ci)) {
+    ci = ci->previous;
+  }
+  if (ci) {
+    luaG_addinfo(L, msg, ci_func(ci)->p->source, getcurrentline(ci));
+    return true;
+  }
+  return false;
+}
+
+
 l_noret luaG_errormsg (lua_State *L) {
   if (L->errfunc != 0) {  /* is there an error handling function? */
     StkId errfunc = restorestack(L, L->errfunc);

--- a/src/ldebug.h
+++ b/src/ldebug.h
@@ -54,7 +54,7 @@ LUAI_FUNC l_noret luaG_runerror (lua_State *L, const char *fmt, ...);
 LUAI_FUNC const char *luaG_addinfo (lua_State *L, const char *msg,
                                                   TString *src, int line);
 #ifndef PLUTO_LUA_LINKABLE
-LUAI_FUNC bool luaG_addinfo_pluto (lua_State *L, const char *msg);
+LUAI_FUNC bool luaG_addsrcinfo (lua_State *L, const char *msg);
 #endif
 LUAI_FUNC l_noret luaG_errormsg (lua_State *L);
 LUAI_FUNC int luaG_traceexec (lua_State *L, const Instruction *pc);

--- a/src/ldebug.h
+++ b/src/ldebug.h
@@ -53,6 +53,7 @@ LUAI_FUNC l_noret luaG_ordererror (lua_State *L, const TValue *p1,
 LUAI_FUNC l_noret luaG_runerror (lua_State *L, const char *fmt, ...);
 LUAI_FUNC const char *luaG_addinfo (lua_State *L, const char *msg,
                                                   TString *src, int line);
+LUAI_FUNC bool luaG_addinfo_pluto (lua_State *L, const char *msg);
 LUAI_FUNC l_noret luaG_errormsg (lua_State *L);
 LUAI_FUNC int luaG_traceexec (lua_State *L, const Instruction *pc);
 LUAI_FUNC int luaG_tracecall (lua_State *L);

--- a/src/ldebug.h
+++ b/src/ldebug.h
@@ -53,7 +53,9 @@ LUAI_FUNC l_noret luaG_ordererror (lua_State *L, const TValue *p1,
 LUAI_FUNC l_noret luaG_runerror (lua_State *L, const char *fmt, ...);
 LUAI_FUNC const char *luaG_addinfo (lua_State *L, const char *msg,
                                                   TString *src, int line);
+#ifndef PLUTO_LUA_LINKABLE
 LUAI_FUNC bool luaG_addinfo_pluto (lua_State *L, const char *msg);
+#endif
 LUAI_FUNC l_noret luaG_errormsg (lua_State *L);
 LUAI_FUNC int luaG_traceexec (lua_State *L, const Instruction *pc);
 LUAI_FUNC int luaG_tracecall (lua_State *L);


### PR DESCRIPTION
This allows integrators to provide better warning messages. Usage looks like this:
```C++
std::string message = "Some warning...";
if (luaG_addsrcinfo(L, message.c_str()))
{
    message = lua_tostring(L, -1);
    lua_pop(L, 1);
}
```