### PR TITLE
Remove PLUTO_USE_SOUP

### DIFF
--- a/Pluto.vcxproj
+++ b/Pluto.vcxproj
@@ -222,7 +222,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -242,7 +242,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>LUA_BUILD_AS_DLL;PLUTO_C_LINKAGE=true;PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LUA_BUILD_AS_DLL;PLUTO_C_LINKAGE=true;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -262,7 +262,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -282,7 +282,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>LUA_BUILD_AS_DLL;PLUTO_C_LINKAGE=false;PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LUA_BUILD_AS_DLL;PLUTO_C_LINKAGE=false;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -302,7 +302,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -322,7 +322,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -342,7 +342,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>LUA_BUILD_AS_DLL;PLUTO_C_LINKAGE=true;PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LUA_BUILD_AS_DLL;PLUTO_C_LINKAGE=true;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -362,7 +362,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -382,7 +382,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>LUA_BUILD_AS_DLL;PLUTO_C_LINKAGE=false;PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LUA_BUILD_AS_DLL;PLUTO_C_LINKAGE=false;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -402,7 +402,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>PLUTO_USE_SOUP;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/scripts/common.php
+++ b/scripts/common.php
@@ -24,7 +24,7 @@ function check_compiler()
 	}
 
 	$compiler = resolve_installed_program($argv[1]);
-	$compiler .= " -std=c++17 -DPLUTO_USE_SOUP -O3";
+	$compiler .= " -std=c++17 -O3";
 	if(defined("PHP_WINDOWS_VERSION_MAJOR"))
 	{
 		$compiler .= " -D _CRT_SECURE_NO_WARNINGS";

--- a/src/.sun
+++ b/src/.sun
@@ -3,7 +3,6 @@ static
 cpp 17
 
 require vendor/Soup include_dir=.
-arg -DPLUTO_USE_SOUP
 
 +*.cpp
 -lua.cpp

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@
 PLAT= mingw
 
 CXX= g++ -std=c++17 -O3 -flto
-CXXFLAGS= -Wall -Wextra -DPLUTO_USE_SOUP $(SYSCFLAGS) $(MYCFLAGS)
+CXXFLAGS= -Wall -Wextra $(SYSCFLAGS) $(MYCFLAGS)
 LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
 LIBS= -lm $(SYSLIBS) $(MYLIBS)
 

--- a/src/dynamic.sun
+++ b/src/dynamic.sun
@@ -3,7 +3,6 @@ dynamic
 cpp 17
 
 require vendor/Soup include_dir=.
-arg -DPLUTO_USE_SOUP
 
 +*.cpp
 -lua.cpp

--- a/src/lbase32.cpp
+++ b/src/lbase32.cpp
@@ -3,8 +3,6 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
-#ifdef PLUTO_USE_SOUP
-
 #include "vendor/Soup/base32.hpp"
 
 static int encode(lua_State* L) {
@@ -24,5 +22,3 @@ static const luaL_Reg funcs[] = {
 };
 
 PLUTO_NEWLIB(base32)
-
-#endif

--- a/src/lbase64.cpp
+++ b/src/lbase64.cpp
@@ -3,8 +3,6 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
-#ifdef PLUTO_USE_SOUP
-
 #include <string>
 #include "vendor/Soup/base64.hpp"
 
@@ -49,5 +47,3 @@ static const luaL_Reg funcs[] = {
 };
 
 PLUTO_NEWLIB(base64)
-
-#endif

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -23,9 +23,7 @@
 #include "lobject.h"
 #include "lstate.h"
 
-#ifdef PLUTO_USE_SOUP
 #include "vendor/Soup/version_compare.hpp"
-#endif
 
 
 static int luaB_print (lua_State *L) {
@@ -719,18 +717,14 @@ static int luaB_exportvar (lua_State *L) {
 }
 
 
-#ifdef PLUTO_USE_SOUP
 static int luaB_version_compare (lua_State *L) {
   lua_pushinteger(L, SOUP_STRONG_ORDERING_TO_INT(soup::version_compare(luaL_checkstring(L, 1), luaL_checkstring(L, 2))));
   return 1;
 }
-#endif
 
 
 static const luaL_Reg base_funcs[] = {
-#ifdef PLUTO_USE_SOUP
   {"version_compare", luaB_version_compare},
-#endif
   {"exportvar", luaB_exportvar},
   {"dumpvar", luaB_dumpvar},
   {"newuserdata", luaB_newuserdata},
@@ -780,12 +774,8 @@ LUAMOD_API int luaopen_base (lua_State *L) {
   /* set global _PVERSION */
   lua_pushliteral(L, PLUTO_VERSION);
   lua_setfield(L, -2, "_PVERSION");
-  /* set global _PSOUP */
-#ifdef PLUTO_USE_SOUP
+  /* set global _PSOUP (always true as of 0.8.0) */
   lua_pushboolean(L, true);
-#else
-  lua_pushboolean(L, false);
-#endif
   lua_setfield(L, -2, "_PSOUP");
   return 1;
 }

--- a/src/ljson.cpp
+++ b/src/ljson.cpp
@@ -3,8 +3,6 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
-#ifdef PLUTO_USE_SOUP
-
 #include "ljson.hpp"
 
 static int encode(lua_State* L) {
@@ -44,5 +42,3 @@ LUAMOD_API int luaopen_json(lua_State* L)
 	return 1;
 }
 const Pluto::PreloadedLibrary Pluto::preloaded_json{ "json", funcs, &luaopen_json };
-
-#endif

--- a/src/ljson.hpp
+++ b/src/ljson.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#ifdef PLUTO_USE_SOUP
+
 // https://github.com/calamity-inc/Soup-Lua-Bindings/blob/main/soup_lua_bindings.hpp
 
 #include "vendor/Soup/json.hpp"
@@ -148,5 +148,3 @@ static void pushFromJson(lua_State* L, const soup::JsonNode& node)
 		lua_pushnil(L);
 	}
 }
-
-#endif

--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -26,9 +26,7 @@
 #include "lualib.h"
 
 
-#ifdef PLUTO_USE_SOUP
 #include "vendor/Soup/urlenc.hpp"
-#endif
 
 
 /*
@@ -2379,7 +2377,6 @@ static int str_repeat (lua_State *L) {
 }
 
 
-#ifdef PLUTO_USE_SOUP
 static int str_urlencode (lua_State* L) {
   const auto input = pluto_checkstring(L, 1);
   pluto_pushstring(L, soup::urlenc::encode(input));
@@ -2392,7 +2389,6 @@ static int str_urldecode (lua_State *L) {
   pluto_pushstring(L, soup::urlenc::decode(input));
   return 1;
 }
-#endif
 
 
 /* }====================================================== */
@@ -2400,10 +2396,8 @@ static int str_urldecode (lua_State *L) {
 
 static const luaL_Reg strlib[] = {
   {"repeat", str_repeat},
-#ifdef PLUTO_USE_SOUP
   {"urldecode", str_urldecode},
   {"urlencode", str_urlencode},
-#endif
   {"formatint", str_formatint},
   {"replace", str_replace},
   {"truncate", str_truncate},

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -803,12 +803,6 @@
 ** =====================================================================}
 */
 
-// !!IMPORTANT!!
-// Enabling this macro will greatly expand the preloaded standard libraries to your access.
-//   However, it will complicate the build process. Look at what features you need, and if they require Soup.
-// If defined, Pluto will link with Soup.
-//#define PLUTO_USE_SOUP
-
 // If defined, Pluto errors will use ANSI color codes.
 //#define PLUTO_USE_COLORED_OUTPUT
 

--- a/src/lualib.h
+++ b/src/lualib.h
@@ -44,32 +44,26 @@ LUAMOD_API int (luaopen_package) (lua_State *L);
 
 namespace Pluto {
   extern const PreloadedLibrary preloaded_crypto;
-#ifdef PLUTO_USE_SOUP
   extern const PreloadedLibrary preloaded_json;
   extern const PreloadedLibrary preloaded_base32;
   extern const PreloadedLibrary preloaded_base64;
-#endif
   extern const PreloadedLibrary preloaded_assert;
   extern const PreloadedLibrary preloaded_vector3;
 
   inline const PreloadedLibrary* const all_preloaded[] = {
     &preloaded_crypto,
-#ifdef PLUTO_USE_SOUP
     &preloaded_json,
     &preloaded_base32,
     &preloaded_base64,
-#endif
     &preloaded_assert,
     &preloaded_vector3,
   };
 }
 
 LUAMOD_API int (luaopen_crypto) (lua_State *L);
-#ifdef PLUTO_USE_SOUP
 LUAMOD_API int (luaopen_json)   (lua_State *L);
 LUAMOD_API int (luaopen_base32) (lua_State *L);
 LUAMOD_API int (luaopen_base64) (lua_State *L);
-#endif
 LUAMOD_API int (luaopen_assert) (lua_State *L);
 LUAMOD_API int (luaopen_vector3) (lua_State *L);
 

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1041,17 +1041,13 @@ do
     assert($crypto.hexdigest(1045060183) == "0x3e4a5a57")
     assert($crypto.joaat("hello world") == $tonumber($crypto.hexdigest($crypto.joaat("hello world"))))
 end
-if _PSOUP then -- Soup is linked.
-    do
-        local base64 = require("base64")
-        assert(base64.encode("Hello") == "SGVsbG8")
-        assert(base64.decode("SGVsbG8") == "Hello")
-        assert(base64.urlencode("Hello") == "SGVsbG8")
-        assert(base64.urldecode("SGVsbG8") == "Hello")
-        assert(base64.decode(base64.encode("Hello", true)) == "Hello")
-    end
-else
-    print("Soup is not linked, skipping relevant tests.")
+do
+    local base64 = require("base64")
+    assert(base64.encode("Hello") == "SGVsbG8")
+    assert(base64.decode("SGVsbG8") == "Hello")
+    assert(base64.urlencode("Hello") == "SGVsbG8")
+    assert(base64.urldecode("SGVsbG8") == "Hello")
+    assert(base64.decode(base64.encode("Hello", true)) == "Hello")
 end
 do
     local t = { key = "value" }
@@ -1191,12 +1187,10 @@ do
     assert(string.formatint("+3249230492345645324234234234234234234234234324242343243242342343423242344") == "+3,249,230,492,345,645,324,234,234,234,234,234,234,234,234,324,242,343,243,242,342,343,423,242,344")
     assert(string.formatint("-3249230492345645324234234234234234234234234324242343243242342343423242344") == "-3,249,230,492,345,645,324,234,234,234,234,234,234,234,234,324,242,343,243,242,342,343,423,242,344")
 
-    if _PSOUP then
-        local str = "Hello, World! == %% 20 <> //\\"
-        assert(string.urlencode(str) == "Hello%2C%20World%21%20%3D%3D%20%25%25%2020%20%3C%3E%20%2F%2F%5C")
-        assert(string.urlencode(str):urldecode() == str)
-    end
-
+    local str = "Hello, World! == %% 20 <> //\\"
+    assert(string.urlencode(str) == "Hello%2C%20World%21%20%3D%3D%20%25%25%2020%20%3C%3E%20%2F%2F%5C")
+    assert(string.urlencode(str):urldecode() == str)
+    
     assert("*":repeat(3) == "***")
     assert(string.repeat("*", 3) == "***")
     _, err = pcall(|| -> "*":repeat(0))
@@ -1252,7 +1246,7 @@ do
     assert(t[3] == 6)
     assert(t.key == 8)
 end
-if _PSOUP then
+do
     assert(version_compare("0.1.0", "0.1.0") == 0)
     assert(version_compare("0.1.0", "0.2.0") ~= 0)
     assert(version_compare("0.2.0", "0.1.0") > 0)


### PR DESCRIPTION
'make' now also works with Soup. There is no reason for us to allow building without Soup anymore, so no matter how Pluto was built, the standard library will be identical.