### PR TITLE
Fix safecall with mulret

### DIFF
--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -2044,6 +2044,6 @@ void luaK_invertcond (FuncState *fs, int list) {
 
 
 void luaK_settop (FuncState *fs, int reg) {
-  /* OP_CONCAT with R(B) = 1 is a no-op BUT it does set L->top to R(A) - R(B), so that's a bytecode-compatible 'set top' for us. :) */
+  /* OP_CONCAT with R(B) = 1 is a no-op BUT it does set L->top to R(A) + R(B), so that's a bytecode-compatible 'set top' for us. :) */
   luaK_codeABC(fs, OP_CONCAT, reg - 1, 1, 0);
 }

--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -2041,3 +2041,9 @@ void luaK_invertcond (FuncState *fs, int list) {
   e.u.pc = list;
   negatecondition(fs, &e);
 }
+
+
+void luaK_settop (FuncState *fs, int reg) {
+  /* OP_CONCAT with R(B) = 1 is a no-op BUT it does set L->top to R(A) - R(B), so that's a bytecode-compatible 'set top' for us. :) */
+  luaK_codeABC(fs, OP_CONCAT, reg - 1, 1, 0);
+}

--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -2047,3 +2047,10 @@ void luaK_settop (FuncState *fs, int reg) {
   /* OP_CONCAT with R(B) = 1 is a no-op BUT it does set L->top to R(A) + R(B), so that's a bytecode-compatible 'set top' for us. :) */
   luaK_codeABC(fs, OP_CONCAT, reg - 1, 1, 0);
 }
+
+
+void luaK_dectop (FuncState *fs, int from, int to) {
+  lua_assert(from > to);
+  luaK_settop(fs, to);
+  luaK_nil(fs, to, from - to);
+}

--- a/src/lcode.h
+++ b/src/lcode.h
@@ -102,3 +102,4 @@ LUAI_FUNC l_noret luaK_semerror (LexState *ls, const char *msg);
 LUAI_FUNC void luaK_exp2reg (FuncState *fs, expdesc *e, int reg);
 LUAI_FUNC void luaK_freeexp (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_invertcond (FuncState *fs, int list);
+LUAI_FUNC void luaK_settop (FuncState *fs, int reg);

--- a/src/lcode.h
+++ b/src/lcode.h
@@ -103,3 +103,4 @@ LUAI_FUNC void luaK_exp2reg (FuncState *fs, expdesc *e, int reg);
 LUAI_FUNC void luaK_freeexp (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_invertcond (FuncState *fs, int list);
 LUAI_FUNC void luaK_settop (FuncState *fs, int reg);
+LUAI_FUNC void luaK_dectop (FuncState *fs, int from, int to);

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -2036,7 +2036,12 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         vmDumpInit();
         vmDumpAddA();
         vmDumpAddB();
-        vmDumpOut ("; concat the last " << n << " elements on the stack");
+        if (n != 1) {
+          vmDumpOut("; concat the last " << n << " elements on the stack");
+        }
+        else {
+          vmDumpOut("; Pluto hackily updating the stack pointer");
+        }
         vmbreak;
       }
       vmcase(OP_CLOSE) {

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -438,6 +438,10 @@ do
     end
     local inst = new Class()
 
+    local function assert_1_ret(...args)
+        assert(table.limit(args) == 1)
+    end
+
     assert(inst?:method() == true)
     assert(optinst?:method() == nil)
     assert(inst:method?() == true)
@@ -450,11 +454,23 @@ do
     local r1, r2 = inst:optmethod?()
     assert(r1 == nil)
     assert(r2 == nil)
+    r1, r2 = optinst?:optmethod?()
+    assert(r1 == nil)
+    assert(r2 == nil)
+    r1, r2 = inst?:optmethod?()
+    assert(r1 == nil)
+    assert(r2 == nil)
+    assert_1_ret(inst:optmethod?())
+    assert_1_ret(inst?:optmethod?())
+    assert_1_ret(optinst?:optmethod?())
     inst?:method()
     inst?:optmethod?()
     optinst?:method()
     optinst?:optmethod?()
     r1, r2 = inst:method?()
+    assert(r1 == true)
+    assert(r2 == 69)
+    r1, r2 = inst?:method?()
     assert(r1 == true)
     assert(r2 == 69)
 end

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -433,11 +433,11 @@ do
         val: bool = true
 
         function method()
-            return self.val
+            return self.val, 69
         end
     end
-
     local inst = new Class()
+
     assert(inst?:method() == true)
     assert(optinst?:method() == nil)
     assert(inst:method?() == true)
@@ -454,6 +454,9 @@ do
     inst?:optmethod?()
     optinst?:method()
     optinst?:optmethod?()
+    r1, r2 = inst:method?()
+    assert(r1 == true)
+    assert(r2 == 69)
 end
 
 print "Testing shorthand ternary."


### PR DESCRIPTION
Previously, safecall would trim results to a single value. Now it works as expected.

Only thing is that `LUAI_ASSERT` is not at all happy with this blatant misuse of the codegen just to get the VM to do the right thing (without introducing new opcodes).