### PR TITLE
Add pipe operator

### DIFF
--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -1165,6 +1165,8 @@ void luaK_prepcallfirstarg (FuncState *fs, expdesc *e, expdesc *func) {
     luaK_codeABC(fs, OP_MOVE, basereg + 1, ereg, 0);
   }
 
+  fs->freereg = basereg + 2;  /* luaK_dischargevars may have free'd registers */
+
   /* finally, update expdesc */
   e->u.reg = basereg;
   e->k = VNONRELOC;  /* expression has a fixed register */

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -62,7 +62,7 @@ static const char *const luaX_tokens [] = {
     "//", "..", "...", "==", ">=", "<=", "~=", "<=>",
     "<<", ">>", "::", "<eof>",
     "<number>", "<integer>", "<name>", "<string>",
-    "**", "??", ":=", "->",
+    "**", "??", ":=", "->", "|>",
 };
 
 
@@ -951,10 +951,24 @@ static int llex (LexState *ls, SemInfo *seminfo) {
           return '*';
         }
       }
+      case '|': {
+        int c = ls->current;
+        next(ls);
+        ls->appendLineBuff(c);
+        if (check_next1(ls, '=')) {
+          seminfo->i = c;
+          ls->appendLineBuff('=');
+          return '=';
+        }
+        if (check_next1(ls, '>')) {
+          ls->appendLineBuff('>');
+          return TK_PIPE;
+        }
+        return c;
+      }
       /* compound support */
-      case '+':
-      case '^': case '%':
-      case '|': case '&': { 
+      case '+': case '^':
+      case '%': case '&': {
         int c = ls->current;
         next(ls);
         if (check_next1(ls, '=')) {

--- a/src/llex.h
+++ b/src/llex.h
@@ -56,6 +56,7 @@ enum RESERVED {
   TK_COAL,    /* null coal.        */
   TK_WALRUS,  /* walrus operator   */
   TK_ARROW,
+  TK_PIPE,
 };
 
 #define FIRST_COMPAT TK_PUSE

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2801,7 +2801,7 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         luaK_setoneret(ls->fs, v);
         expdesc func;
         singlevar(ls, &func);
-        luaK_prepcallfirstarg(fs, v, &func);  // TODO: the way luaK_prepcallfirstarg is currently designed does not account for 'func' being able to be discharged into a VRELOC, so the bytecode generated for this is rather bad.
+        luaK_prepcallfirstarg(fs, v, &func);
         lua_assert(v->k == VNONRELOC);
         int base = v->u.reg;  /* base register for call */
         constexpr int nparams = 1;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1774,6 +1774,7 @@ static void setvararg (FuncState *fs, int nparams) {
 enum expflags {
   E_NO_COLON = 1 << 0,
   E_NO_CALL  = 1 << 1,
+  E_NO_BOR   = 1 << 2,
 };
 
 static void simpleexp (LexState *ls, expdesc *v, int flags = 0, TypeHint *prop = nullptr);
@@ -2799,11 +2800,20 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
       case TK_PIPE: {  /* '|>' NAME */
         luaX_next(ls);
         expdesc func;
-        singlevar(ls, &func);
+        expr(ls, &func, nullptr, E_NO_CALL | E_NO_BOR);
         luaK_prepcallfirstarg(fs, v, &func);
         lua_assert(v->k == VNONRELOC);
         int base = v->u.reg;  /* base register for call */
-        constexpr int nparams = 1;
+        int nparams = 1;
+        if (testnext(ls, '|')) {
+          do {
+            expdesc arg;
+            expr(ls, &arg, nullptr, E_NO_BOR);
+            luaK_exp2nextreg(fs, &arg);
+            ++nparams;
+          } while (testnext(ls, ','));
+          checknext(ls, '|');
+        }
         init_exp(v, VCALL, luaK_codeABC(fs, OP_CALL, base, nparams + 1, 2));
         luaK_fixline(fs, line);
         fs->freereg = base + 1;
@@ -3394,6 +3404,8 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
   }
   /* expand while operators have priorities higher than 'limit' */
   op = getbinopr(ls->t.token);
+  if ((flags & E_NO_BOR) && op == OPR_BOR)
+    op = OPR_NOBINOPR;
   while (op != OPR_NOBINOPR && priority[op].left > limit) {
     if (prop && op != OPR_COAL)
       prop->clear();

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2808,6 +2808,8 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         init_exp(v, VCALL, luaK_codeABC(fs, OP_CALL, base, nparams + 1, 2));
         luaK_fixline(fs, line);
         fs->freereg = base + 1;
+        if (ls->t.token == '(' || ls->t.token == TK_STRING || ls->t.token == '{')
+          return;
         break;
       }
       default: return;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2798,6 +2798,9 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         break;
       }
       case TK_PIPE: {  /* '|>' NAME */
+        if (flags & E_NO_CALL) {
+          return;
+        }
         luaX_next(ls);
         expdesc func;
         expr(ls, &func, nullptr, E_NO_CALL | E_NO_BOR);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2796,7 +2796,7 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         funcargs(ls, v, funcdesc);
         break;
       }
-      case TK_ARROW: {  /* '->' NAME */
+      case TK_PIPE: {  /* '|>' NAME */
         luaX_next(ls);
         luaK_setoneret(ls->fs, v);
         expdesc func;

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2796,6 +2796,20 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         funcargs(ls, v, funcdesc);
         break;
       }
+      case TK_ARROW: {  /* '->' NAME */
+        luaX_next(ls);
+        luaK_setoneret(ls->fs, v);
+        expdesc func;
+        singlevar(ls, &func);
+        luaK_prepcallfirstarg(fs, v, &func);  // TODO: the way luaK_prepcallfirstarg is currently designed does not account for 'func' being able to be discharged into a VRELOC, so the bytecode generated for this is rather bad.
+        lua_assert(v->k == VNONRELOC);
+        int base = v->u.reg;  /* base register for call */
+        constexpr int nparams = 1;
+        init_exp(v, VCALL, luaK_codeABC(fs, OP_CALL, base, nparams + 1, 2));
+        luaK_fixline(fs, line);
+        fs->freereg = base + 1;
+        break;
+      }
       default: return;
     }
   }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2798,7 +2798,6 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
       }
       case TK_PIPE: {  /* '|>' NAME */
         luaX_next(ls);
-        luaK_setoneret(ls->fs, v);
         expdesc func;
         singlevar(ls, &func);
         luaK_prepcallfirstarg(fs, v, &func);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1775,6 +1775,7 @@ enum expflags {
   E_NO_COLON = 1 << 0,
   E_NO_CALL  = 1 << 1,
   E_NO_BOR   = 1 << 2,
+  E_PIPERHS  = 1 << 3,
 };
 
 static void simpleexp (LexState *ls, expdesc *v, int flags = 0, TypeHint *prop = nullptr);
@@ -2755,6 +2756,9 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         if (flags & E_NO_CALL) {
           return;
         }
+        if ((flags & E_PIPERHS) && ls->t.token == '(') {
+          return;
+        }
         if (luaX_lookbehind(ls).line != ls->t.line && (ls->getContext() == PARCTX_LAMBDA_BODY || v->k == VCALL)) {
           throw_warn(ls, "possibly unwanted function call", luaO_fmt(ls->L, "possibly unwanted continuation of the expression on line %d.", luaX_lookbehind(ls).line), WT_POSSIBLE_TYPO);
           ls->L->top.p--;
@@ -2798,12 +2802,12 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         break;
       }
       case TK_PIPE: {  /* '|>' NAME */
-        if (flags & E_NO_CALL) {
+        if ((flags & E_NO_CALL) || (flags & E_PIPERHS)) {
           return;
         }
         luaX_next(ls);
         expdesc func;
-        expr(ls, &func, nullptr, E_NO_CALL | E_NO_BOR);
+        expr(ls, &func, nullptr, E_NO_BOR | E_PIPERHS);
         luaK_prepcallfirstarg(fs, v, &func);
         lua_assert(v->k == VNONRELOC);
         int base = v->u.reg;  /* base register for call */

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2314,6 +2314,18 @@ do
     assert(get_val() <=> get_val() == 0)
 end
 
+print "Testing pipe operator."
+do
+    local function f(x)
+        assert(x == 69)
+    end
+
+    -- If pipe operator is used, subsequent function calls in the chain must also use pipe operator.
+    -- So, this should be interpreted as 'f(x) f(x)' and not 'f(f(69)(69))'.
+    (69) |> f
+    (69) |> f
+end
+
 print("Testing modified require semantics.")
 do
     local currentdir = io.absolute(io.currentdir())

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2320,12 +2320,15 @@ do
         assert(x == 69)
     end
 
-    -- If pipe operator is used, subsequent function calls in the chain must also use pipe operator.
-    -- So, this should be interpreted as 'f(x) f(x)' and not 'f(f(69)(69))'.
-    (69) |> f
-    (69) |> f
-
+    -- Additional arguments shorthand (longhand would be writing a lambda)
     assert(("69") |> tonumber|16| == 0x69)
+
+    -- Try to avoid syntax ambiguity by not allowing function call with '(' in the chain after pipe operator was used.
+    ;(69) |> f (69) |> f
+
+    -- Other types of function calls are still okay, tho, since string and table are not valid statements.
+    ;("Hello") |> require"json".encode |> |x| -> assert(x == [["Hello"]])
+    ;("Hello") |> (require"json".encode) |> |x| -> assert(x == [["Hello"]])
 end
 
 print("Testing modified require semantics.")

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2324,6 +2324,8 @@ do
     -- So, this should be interpreted as 'f(x) f(x)' and not 'f(f(69)(69))'.
     (69) |> f
     (69) |> f
+
+    assert(("69") |> tonumber|16| == 0x69)
 end
 
 print("Testing modified require semantics.")


### PR DESCRIPTION
Piping is probably most well-known from Bash:
```Bash
cat /proc/cpuinfo | grep vendor_id
```
However, instead of `|`, we use `|>` for the pipe operator, as do Elixir and F#, but also Hack, Meta's fork of PHP. There is also an ongoing proposal to add this operator to JavaScript, although it's being blocked by async/await concerns.
```Elixir
("Hello, world!") |> print
```
Of course, in such a trivial example, it looks silly, but its benefits become increasingly obvious with more complex code.
```Elixir
print(dumpvar(f()))
f() |> dumpvar |> print
```
Some of the advantages of the pipe operator:
- The flow of data is more obvious as it goes left-to-right
- You don't have to backtrack (potentially over multiple lines) when you want to print the result of an expression to place `print(` or `print(vardump(` before it
- You don't need to count parentheses when finishing the statement
---
Already with this, we also have some interesting emergent properties, e.g. being able to concatenate the result of an expression using lambdas:
```Lua
("abc") |> |x|->$"[{x}]" |> print -- "[abc]"
```
---
This syntax can also be used to pass more than 1 argument, although I reckon this generally won't be needed:
```Haskell
("69") |> tonumber|16| |> print -- 105 (= 0x69)
```
