### PR TITLE
[0.8.0] Improve primaryexp warnings

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2662,21 +2662,6 @@ static void primaryexp (LexState *ls, expdesc *v) {
       luaK_dischargevars(ls->fs, v);
       return;
     }
-    case '}':
-    case '{': { // Unfinished table constructors.
-       if (ls->t.token == '{') {
-         throwerr(ls, "unfinished table constructor", "did you mean to close with '}'?");
-       }
-       else {
-         throwerr(ls, "unfinished table constructor", "did you mean to enter with '{'?");
-       }
-       return;
-    }
-    case '|': { // Potentially mistyped lambda expression. People may confuse '->' with '=>'.
-      while (testnext(ls, '|') || testnext(ls, TK_NAME) || testnext(ls, ','));
-      throwerr(ls, "unexpected symbol", "impromper or stranded lambda expression.");
-      return;
-    }
     case '$': {
       luaX_next(ls); /* skip '$' */
       const_expr(ls, v);
@@ -2687,6 +2672,9 @@ static void primaryexp (LexState *ls, expdesc *v) {
       luaX_next(ls);
       parentexp(ls, v);
       return;
+    }
+    case '{': {
+      throwerr(ls, "unexpected symbol near '{'", "if you meant to begin this statement with a table, wrap it in parentheses.");
     }
     default: {
       if (ls->t.token == ')' && ls->getContext() == PARCTX_BODY) {


### PR DESCRIPTION
The previous warnings seemed a bit silly, because this mainly happens within statement/statlist, so an example of erroneous code would be:
```Lua
{ 1, 2, 3 }:foreach(print)
```
In which case, I think it's better to point out that this is not a valid statement instead of "unfinished table constructor" which is completely false.