### PR TITLE
[0.8.0] Raise warning when possibly unwanted call is found in lambda body

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -304,6 +304,7 @@ enum ParserContext : lu_byte {
   PARCTX_CREATE_VARS,
   PARCTX_FUNCARGS,
   PARCTX_BODY,
+  PARCTX_LAMBDA_BODY,
 };
 
 struct ClassData {


### PR DESCRIPTION
It doesn't address the root cause, but it's good enough I suppose.