### PR TITLE
Improve windows console stuff

### DIFF
--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -674,19 +674,11 @@ static int pmain (lua_State *L) {
 }
 
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(PLUTO_NO_UTF8)
 int wmain (int argc, wchar_t **wargv) {
-#ifdef PLUTO_USE_COLORED_OUTPUT
-  if (auto hSTDOUT = GetStdHandle(STD_OUTPUT_HANDLE); hSTDOUT != INVALID_HANDLE_VALUE) {
-    DWORD mode;
-    if (GetConsoleMode(hSTDOUT, &mode))
-      SetConsoleMode(hSTDOUT, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_WINDOW_INPUT);
-  }
-#endif
-#ifndef PLUTO_NO_UTF8
   SetConsoleCP(CP_UTF8);
   SetConsoleOutputCP(CP_UTF8);
-#endif
+
   std::vector<char*> argv_arr; argv_arr.reserve(argc + 1);
   std::vector<std::string> argv_buf; argv_buf.reserve(argc);
   for (int i = 0; i != argc; ++i) {
@@ -696,6 +688,13 @@ int wmain (int argc, wchar_t **wargv) {
   char **argv = &argv_arr[0];
 #else
 int main (int argc, char **argv) {
+#endif
+#ifdef PLUTO_USE_COLORED_OUTPUT
+  if (auto hSTDOUT = GetStdHandle(STD_OUTPUT_HANDLE); hSTDOUT != INVALID_HANDLE_VALUE) {
+    DWORD mode;
+    if (GetConsoleMode(hSTDOUT, &mode))
+      SetConsoleMode(hSTDOUT, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_WINDOW_INPUT);
+  }
 #endif
   int status, result;
   lua_State *L = luaL_newstate();  /* create state */

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -676,6 +676,17 @@ static int pmain (lua_State *L) {
 
 #ifdef _WIN32
 int wmain (int argc, wchar_t **wargv) {
+#ifdef PLUTO_USE_COLORED_OUTPUT
+  if (auto hSTDOUT = GetStdHandle(STD_OUTPUT_HANDLE); hSTDOUT != INVALID_HANDLE_VALUE) {
+    DWORD mode;
+    if (GetConsoleMode(hSTDOUT, &mode))
+      SetConsoleMode(hSTDOUT, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_WINDOW_INPUT);
+  }
+#endif
+#ifndef PLUTO_NO_UTF8
+  SetConsoleCP(CP_UTF8);
+  SetConsoleOutputCP(CP_UTF8);
+#endif
   std::vector<char*> argv_arr; argv_arr.reserve(argc + 1);
   std::vector<std::string> argv_buf; argv_buf.reserve(argc);
   for (int i = 0; i != argc; ++i) {


### PR DESCRIPTION
- If `PLUTO_USE_COLORED_OUTPUT` is defined, enable ANSI color modes for the console.
- Set console codepage to UTF-8 unless `PLUTO_NO_UTF8` is defined.
- Disable argv being converted to UTF-8 if `PLUTO_NO_UTF8` is defined.