### PR TITLE
Fix possibly reading uninitialised variables due to continue

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3795,16 +3795,12 @@ static void repeatstat (LexState *ls) {
   luaX_next(ls);  /* skip REPEAT */
   statlist(ls);
   luaK_patchtohere(fs, bl1.scopeend);
-  if (testnext(ls, TK_UNTIL)) {
-    int nactvar = fs->nactvar;
-    if (bl1.nactvarbeforecontinue != MAX_INT)
-      fs->nactvar = bl1.nactvarbeforecontinue;
-    condexit = cond(ls);  /* read condition (inside scope block) */
-    fs->nactvar = nactvar;
-  }
-  else {
-    error_expected(ls, TK_UNTIL);
-  }
+  checknext(ls, TK_UNTIL);
+  int nactvar = fs->nactvar;
+  if (bl1.nactvarbeforecontinue != MAX_INT)
+    fs->nactvar = bl1.nactvarbeforecontinue;
+  condexit = cond(ls);  /* read condition (inside scope block) */
+  fs->nactvar = nactvar;
   leaveblock(fs);  /* finish scope */
   if (bl2.upval) {  /* upvalues? */
     int exit = luaK_jump(fs);  /* normal exit must jump over fix */

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -355,6 +355,20 @@ do
         assert(line != "This" and line != "Lines")
     end
 end
+do
+    assert(select(2, pcall(load[[--@pluto_warnings disable-all
+    repeat
+        continue
+        local a = 1
+    until a > 0]])):contains("attempt to compare number with nil"))
+    assert(select(2, pcall(load[[--@pluto_warnings disable-all
+    repeat
+        if true then
+            continue
+        end
+        local a = 1
+    until a > 0]])):contains("attempt to compare number with nil"))
+end
 
 print "Testing table length cache."
 do


### PR DESCRIPTION
```Lua
repeat
    continue
    local a = 1
until a > 0
```
This code is now treated like `a > 0` refers to a global called 'a'.