### PR TITLE
Fix memory leaks

### DIFF
--- a/src/ldo.cpp
+++ b/src/ldo.cpp
@@ -968,6 +968,7 @@ int luaD_pcall (lua_State *L, Pfunc func, void *u,
 ** Execute a protected parser.
 */
 struct SParser {  /* data to 'f_parser' */
+  LexState lexstate;
   ZIO *z;
   Mbuffer buff;  /* dynamic structure used by the scanner */
   Dyndata dyd;  /* dynamic structures used by the parser */
@@ -998,7 +999,7 @@ static void f_parser (lua_State *L, void *ud) {
 #endif
   {
     checkmode(L, p->mode, "text");
-    cl = luaY_parser(L, p->z, &p->buff, &p->dyd, p->name, c);
+    cl = luaY_parser(L, p->lexstate, p->z, &p->buff, &p->dyd, p->name, c);
   }
   lua_assert(cl->nupvalues == cl->p->sizeupvalues);
   luaF_initupvals(L, cl);

--- a/src/ldo.cpp
+++ b/src/ldo.cpp
@@ -52,7 +52,7 @@
 */
 #if !defined(LUAI_THROW)				/* { */
 
-#if defined(__cplusplus) && defined(PLUTO_USE_THROW)	/* { */
+#if defined(__cplusplus) && !defined(LUA_USE_LONGJMP)	/* { */
 
 /* C++ exceptions */
 #define LUAI_THROW(L,c)		throw(c)

--- a/src/lerrormessage.hpp
+++ b/src/lerrormessage.hpp
@@ -18,11 +18,11 @@ namespace Pluto {
 			: ls(ls) {
 		}
 
-		ErrorMessage(LexState* ls, const std::string& initial_msg)
+		ErrorMessage(LexState* ls, const char* initial_msg)
 			: ls(ls), content(initial_msg) {
 		}
 
-		ErrorMessage& addMsg(const std::string& msg) {
+		ErrorMessage& addMsg(const char* msg) {
 			this->content.append(msg);
 			return *this;
 		}
@@ -41,16 +41,19 @@ namespace Pluto {
 			return *this;
 		}
 
-		ErrorMessage& addGenericHere(const std::string& msg) { // TO-DO: Add '^^^' strings for specific keywords. Not accurate with a simple string search.
+		ErrorMessage& addGenericHere(const char* msg) { // TO-DO: Add '^^^' strings for specific keywords. Not accurate with a simple string search.
 #ifndef PLUTO_SHORT_ERRORS
-			if (msg.empty()) {
+			if (*msg == '\0') {
 				return addGenericHere();
 			}
 			this->content.push_back('\n');
-			this->content.append(std::string(this->line_len, ' ') + "| ");
-			this->content.append(HBLU + std::string(this->src_len, '^'));
+			this->content.append(this->line_len, ' ');
+			this->content.append("| ");
+			this->content.append(HBLU);
+			this->content.append(this->src_len, '^');
 			this->content.append(" here: ");
-			this->content.append(msg + RESET);
+			this->content.append(msg);
+			this->content.append(RESET);
 #endif
 			return *this;
 		}
@@ -58,19 +61,21 @@ namespace Pluto {
 		ErrorMessage& addGenericHere() {
 #ifndef PLUTO_SHORT_ERRORS
 			this->content.push_back('\n');
-			this->content.append(std::string(this->line_len, ' ') + "| ");
-			this->content.append(HBLU + std::string(this->src_len, '^'));
+			this->content.append(this->line_len, ' ');
+			this->content.append("| ");
+			this->content.append(HBLU);
+			this->content.append(this->src_len, '^');
 			this->content.append(" here");
 			this->content.append(RESET);
 #endif
 			return *this;
 		}
 
-		ErrorMessage& addNote(const std::string& msg) {
+		ErrorMessage& addNote(const char* msg) {
 #ifndef PLUTO_SHORT_ERRORS
-			const auto pad = std::string(this->line_len, ' ');
 			this->content.push_back('\n');
-			this->content.append(pad + HCYN + "+ note: " + RESET);
+			this->content.append(this->line_len, ' ');
+			this->content.append(HCYN "+ note: " RESET);
 			this->content.append(msg);
 #endif
 			return *this;

--- a/src/lerrormessage.hpp
+++ b/src/lerrormessage.hpp
@@ -84,7 +84,9 @@ namespace Pluto {
 
 		[[noreturn]] void finalizeAndThrow() {
 			this->finalize();
-			luaD_throw(ls->L, LUA_ERRSYNTAX);
+			lua_State* L = ls->L;
+			delete this;
+			luaD_throw(L, LUA_ERRSYNTAX);
 		}
 	};
 }

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -155,20 +155,21 @@ const char* luaX_reserved2str (int token) {
 
 static l_noret lexerror (LexState *ls, const char *msg, int token) {
   msg = luaG_addinfo(ls->L, msg, ls->source, ls->getLineNumber());
-  Pluto::ErrorMessage err{ ls, HRED "syntax error: " BWHT };
-  err.addMsg(msg);
+  auto err = new Pluto::ErrorMessage{ ls, HRED "syntax error: " BWHT };
+  err->addMsg(msg);
   if (token) {
-    err.addMsg(" near ")
+    err->addMsg(" near ")
        .addMsg(luaX_token2str(ls, token))
        .addSrcLine(ls->getLineNumber())
        .addGenericHere()
        .finalize();
   }
   else {
-    err.addSrcLine(ls->getLineNumber())
+    err->addSrcLine(ls->getLineNumber())
        .addGenericHere()
        .finalize();
   }
+  delete err;
   luaD_throw(ls->L, LUA_ERRSYNTAX);
 }
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "lobject.h"
@@ -335,6 +336,11 @@ enum KeywordState : lu_byte {
   KS_DISABLED_BY_USER,
 };
 
+struct FuncArgsState {
+  std::vector<void*> argdescs{};
+  std::vector<size_t> argtis{};
+};
+
 struct LexState {
   int current;  /* current character (charint) */
   std::vector<std::string> lines;  /* A vector of all the lines processed by the lexer. */
@@ -361,8 +367,12 @@ struct LexState {
   std::vector<WarningConfig> warnconfs;
   std::stack<ParserContext> parser_context_stck{};
   std::stack<ClassData> classes{};
+  std::stack<FuncArgsState> funcargsstates{};
   std::vector<EnumDesc> enums{};
   std::vector<void*> parse_time_allocations{};
+  std::unordered_set<TString*> localstat_variable_names{};
+  std::unordered_set<TString*> localstat_expression_names{};
+  std::vector<void*> localstat_ts{};
   std::unordered_map<const TString*, void*> global_props{};
   KeywordState keyword_states[NUM_NON_COMPAT];
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -341,6 +341,11 @@ struct FuncArgsState {
   std::vector<size_t> argtis{};
 };
 
+struct BodyState {
+  std::vector<std::pair<TString*, TString*>> promotions{};
+  std::vector<size_t> fallbacks{};
+};
+
 struct LexState {
   int current;  /* current character (charint) */
   std::vector<std::string> lines;  /* A vector of all the lines processed by the lexer. */
@@ -368,6 +373,7 @@ struct LexState {
   std::stack<ParserContext> parser_context_stck{};
   std::stack<ClassData> classes{};
   std::stack<FuncArgsState> funcargsstates{};
+  std::stack<BodyState> bodystates{};
   std::vector<EnumDesc> enums{};
   std::vector<void*> parse_time_allocations{};
   std::unordered_set<TString*> localstat_variable_names{};

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -5307,9 +5307,8 @@ static void mainfunc (LexState *ls, FuncState *fs) {
 }
 
 
-LClosure *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff,
+LClosure *luaY_parser (lua_State *L, LexState& lexstate, ZIO *z, Mbuffer *buff,
                        Dyndata *dyd, const char *name, int firstchar) {
-  LexState lexstate;
   FuncState funcstate;
   LClosure *cl = luaF_newLclosure(L, 1);  /* create main closure */
   setclLvalue2s(L, L->top.p, cl);  /* anchor it (to avoid being collected) */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -130,14 +130,13 @@ static l_noret throwerr (LexState *ls, const char *err, const char *here) {
 
 
 // No note.
-static void throw_warn (LexState *ls, const char *raw_err, const char *here, int line, WarningType warningType) {
-  std::string err(raw_err);
+static void throw_warn (LexState *ls, const char *err, const char *here, int line, WarningType warningType) {
   if (ls->shouldEmitWarning(line, warningType)) {
     auto msg = new Pluto::ErrorMessage{ ls, luaG_addinfo(ls->L, YEL "warning: " BWHT, ls->source, line) };
-    err.append(" [");
-    err.append(ls->getWarningConfig().getWarningName(warningType));
-    err.push_back(']');
     msg->addMsg(err)
+      .addMsg(" [")
+      .addMsg(ls->getWarningConfig().getWarningName(warningType))
+      .addMsg("]")
       .addSrcLine(line)
       .addGenericHere(here)
       .finalize();
@@ -152,14 +151,13 @@ static void throw_warn (LexState *ls, const char *raw_err, const char *here, int
 }
 
 // Note.
-static void throw_warn(LexState* ls, const char* raw_err, const char* here, const char* note, int line, WarningType warningType) {
+static void throw_warn(LexState* ls, const char* err, const char* here, const char* note, int line, WarningType warningType) {
   if (ls->shouldEmitWarning(line, warningType)) {
-    std::string err(raw_err);
     auto msg = new Pluto::ErrorMessage{ ls, luaG_addinfo(ls->L, YEL "warning: " BWHT, ls->source, line) };
-    err.append(" [");
-    err.append(ls->getWarningConfig().getWarningName(warningType));
-    err.push_back(']');
     msg->addMsg(err)
+      .addMsg(" [")
+      .addMsg(ls->getWarningConfig().getWarningName(warningType))
+      .addMsg("]")
       .addSrcLine(line)
       .addGenericHere(here)
       .addNote(note)
@@ -338,7 +336,7 @@ static void check_match (LexState *ls, int what, int who, int where) {
           .addMsg(" expected (to close ")
           .addMsg(luaX_token2str(ls, who))
           .addMsg(" on line ")
-          .addMsg(std::to_string(where))
+          .addMsg(luaO_fmt(ls->L, "%d", where))
           .addMsg(")")
           .addSrcLine(ls->getLineNumberOfLastNonEmptyLine())
           .addGenericHere()

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -321,14 +321,13 @@ static void check_match (LexState *ls, int what, int who, int where) {
       if (what == TK_END) {
         if (ls->else_if)
           throw_warn(ls, "'else if' is not the same as 'elseif' in Lua/Pluto", "did you mean 'elseif'?", ls->else_if, WT_POSSIBLE_TYPO);
-        std::string msg = "missing 'end' to terminate ";
-        msg.append(luaX_token2str(ls, who));
+        const char *msg;
         if (who != TK_BEGIN) {
-          msg.append(" block");
+          msg = luaO_fmt(ls->L, "missing 'end' to terminate %s on line %d", luaX_token2str(ls, who), where);
         }
-        msg.append(" on line ");
-        msg.append(std::to_string(where));
-        throwerr(ls, msg.c_str(), "this was the last statement.", ls->getLineNumberOfLastNonEmptyLine());
+        else
+          msg = luaO_fmt(ls->L, "missing 'end' to terminate %s block on line %d", luaX_token2str(ls, who), where);
+        throwerr(ls, msg, "this was the last statement.", ls->getLineNumberOfLastNonEmptyLine());
       }
       else {
         auto err = new Pluto::ErrorMessage{ ls, RED "syntax error: " BWHT };

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -407,7 +407,7 @@ typedef struct FuncState {
 
 
 LUAI_FUNC int luaY_nvarstack (FuncState *fs);
-LUAI_FUNC LClosure *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff,
+LUAI_FUNC LClosure *luaY_parser (lua_State *L, LexState& lexstate, ZIO *z, Mbuffer *buff,
                                  Dyndata *dyd, const char *name, int firstchar);
 
 

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -820,10 +820,6 @@
 // This will generally improve runtime performance but can add minutes to compile time, depending on the setup.
 //#define PLUTO_FORCE_JUMPTABLE
 
-// If defined, Pluto will use C++ exceptions to implement Lua longjumps.
-// This is generally slower and complicates exception handling.
-//#define PLUTO_USE_THROW
-
 // If defined, Pluto won't imbue tables with a metatable by default.
 //#define PLUTO_NO_DEFAULT_TABLE_METATABLE
 


### PR DESCRIPTION
Due to the longjump, we cannot rely on RAII to free resources for us, as loading an erroneous chunk of code would then leak memory, e.g.:
```Lua
load[[deez"]]
```

Another forward-looking change is that I've removed the `PLUTO_USE_THROW` option, instead integrators should specify `LUA_USE_LONGJUMP` if they're sure they don't need RAII, as otherwise they might accidentally leak memory.