### PR TITLE
Add `--@fallthrough` + warning for unannotated fallthrough

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -57,7 +57,7 @@ static const char *const luaX_tokens [] = {
     "pluto_switch", "pluto_continue", "pluto_enum", "pluto_new", "pluto_class", "pluto_parent", "pluto_export", "pluto_try", "pluto_catch",
           "switch",       "continue",       "enum",       "new",       "class",       "parent",       "export",       "try",       "catch",
     "let", "const", "global",
-    "pluto_suggest_0", "pluto_suggest_1",
+    "pluto_suggest_0", "pluto_suggest_1", "<fallthrough annotation>",
     "return", "then", "true", "until", "while",
     "//", "..", "...", "==", ">=", "<=", "~=", "<=>",
     "<<", ">>", "::", "<eof>",
@@ -597,11 +597,13 @@ static int llex (LexState *ls, SemInfo *seminfo) {
             next(ls);
             while (lislalnum(ls->current))
               save_and_next(ls);
+            ls->appendLineBuff(luaZ_buffer(ls->buff), luaZ_bufflen(ls->buff));
             if (strncmp(luaZ_buffer(ls->buff), "pluto_use", luaZ_bufflen(ls->buff)) == 0) {
-              ls->appendLineBuff("pluto_use");
               return TK_PUSE;
             }
-            ls->appendLineBuff(luaZ_buffer(ls->buff), luaZ_bufflen(ls->buff));
+            if (strncmp(luaZ_buffer(ls->buff), "fallthrough", luaZ_bufflen(ls->buff)) == 0) {
+              return TK_FALLTHROUGH;
+            }
             luaZ_resetbuffer(ls->buff);
           }
           while (!currIsNewline(ls) && ls->current != EOZ) {

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -580,9 +580,11 @@ static int llex (LexState *ls, SemInfo *seminfo) {
             size_t sep = skip_sep(ls);
             luaZ_resetbuffer(ls->buff);  /* 'skip_sep' may dirty the buffer */
             if (sep >= 2) {
+              ls->appendLineBuff(sep, '[');
               SemInfo si;
               read_long_string(ls, &si, sep);  /* skip long comment */
               ls->appendLineBuff(getstr(si.ts));
+              ls->appendLineBuff(sep, ']');
               luaZ_resetbuffer(ls->buff);  /* previous call may dirty the buff. */
               if (ls->getLineBuff().find("@fallthrough") != std::string::npos)
                 return TK_FALLTHROUGH;

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -584,6 +584,8 @@ static int llex (LexState *ls, SemInfo *seminfo) {
               read_long_string(ls, &si, sep);  /* skip long comment */
               ls->appendLineBuff(getstr(si.ts));
               luaZ_resetbuffer(ls->buff);  /* previous call may dirty the buff. */
+              if (ls->getLineBuff().find("@fallthrough") != std::string::npos)
+                return TK_FALLTHROUGH;
               break;
             }
           }
@@ -601,15 +603,14 @@ static int llex (LexState *ls, SemInfo *seminfo) {
             if (strncmp(luaZ_buffer(ls->buff), "pluto_use", luaZ_bufflen(ls->buff)) == 0) {
               return TK_PUSE;
             }
-            if (strncmp(luaZ_buffer(ls->buff), "fallthrough", luaZ_bufflen(ls->buff)) == 0) {
-              return TK_FALLTHROUGH;
-            }
             luaZ_resetbuffer(ls->buff);
           }
           while (!currIsNewline(ls) && ls->current != EOZ) {
             ls->appendLineBuff(ls->current);
             next(ls);  /* skip until end of line (or end of file) */
           }
+          if (ls->getLineBuff().find("@fallthrough") != std::string::npos)
+            return TK_FALLTHROUGH;
           break;
         }
       }

--- a/src/llex.h
+++ b/src/llex.h
@@ -459,6 +459,10 @@ struct LexState {
     getLineBuff().push_back(c);
   }
 
+  void appendLineBuff(size_t cnt, char chr) {
+    getLineBuff().append(cnt, chr);
+  }
+
   [[nodiscard]] ParserContext getContext() const noexcept {
     return parser_context_stck.top();
   }

--- a/src/llex.h
+++ b/src/llex.h
@@ -170,6 +170,7 @@ enum WarningType : int {
   WT_NON_PORTABLE_BYTECODE,
   WT_NON_PORTABLE_NAME,
   WT_IMPLICIT_GLOBAL,
+  WT_UNANNOTATED_FALLTHROUGH,
 
   NUM_WARNING_TYPES
 };
@@ -189,6 +190,7 @@ inline const char* const luaX_warnNames[] = {
   "non-portable-bytecode",
   "non-portable-name",
   "implicit-global",
+  "unannotated-fallthrough",
 };
 static_assert(sizeof(luaX_warnNames) / sizeof(const char*) == NUM_WARNING_TYPES);
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -45,7 +45,7 @@ enum RESERVED {
   TK_PSWITCH, TK_PCONTINUE, TK_PENUM, TK_PNEW, TK_PCLASS, TK_PPARENT, TK_PEXPORT, TK_PTRY, TK_PCATCH,
   TK_SWITCH, TK_CONTINUE, TK_ENUM, TK_NEW, TK_CLASS, TK_PARENT, TK_EXPORT, TK_TRY, TK_CATCH, // New non-compatible keywords.
   TK_LET, TK_CONST, TK_GLOBAL, // New optional keywords.
-  TK_SUGGEST_0, TK_SUGGEST_1, // New special keywords.
+  TK_SUGGEST_0, TK_SUGGEST_1, TK_FALLTHROUGH, // New special keywords.
   TK_RETURN, TK_THEN, TK_TRUE, TK_UNTIL, TK_WHILE,
   /* other terminal symbols */
   TK_IDIV, TK_CONCAT, TK_DOTS,

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3161,7 +3161,7 @@ static void switchstat (LexState *ls) {
         }
       }
       while (gett(ls) != TK_CASE && gett(ls) != TK_DEFAULT && gett(ls) != TK_END && gett(ls) != TK_FALLTHROUGH);
-      if (ls->t.token == TK_CASE && ls->laststat.token != TK_BREAK && ls->laststat.token != TK_RETURN) {
+      if (ls->t.token == TK_CASE && ls->laststat.token != TK_BREAK && ls->laststat.token != TK_RETURN && ls->laststat.token != TK_GOTO) {
         throw_warn(ls, "possibly unwanted fallthrough", luaO_fmt(ls->L, "the case on line %d flows into this case", case_line), "place `--@fallthrough` before this case if this is intended", ls->getLineNumber(), WT_POSSIBLE_TYPO);
         ls->L->top.p--;
       }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3161,7 +3161,7 @@ static void switchstat (LexState *ls) {
         }
       }
       while (gett(ls) != TK_CASE && gett(ls) != TK_DEFAULT && gett(ls) != TK_END && gett(ls) != TK_FALLTHROUGH);
-      if (ls->t.token == TK_CASE) {
+      if (ls->t.token == TK_CASE && ls->laststat.token != TK_BREAK && ls->laststat.token != TK_RETURN) {
         throw_warn(ls, "possibly unwanted fallthrough", luaO_fmt(ls->L, "the case on line %d flows into this case", case_line), "place `--@fallthrough` before this case if this is intended", ls->getLineNumber(), WT_POSSIBLE_TYPO);
         ls->L->top.p--;
       }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3162,7 +3162,7 @@ static void switchstat (LexState *ls) {
       }
       while (gett(ls) != TK_CASE && gett(ls) != TK_DEFAULT && gett(ls) != TK_END && gett(ls) != TK_FALLTHROUGH);
       if (ls->t.token == TK_CASE && ls->laststat.token != TK_BREAK && ls->laststat.token != TK_RETURN && ls->laststat.token != TK_GOTO) {
-        throw_warn(ls, "possibly unwanted fallthrough", luaO_fmt(ls->L, "the case on line %d flows into this case", case_line), "place `--@fallthrough` before this case if this is intended", ls->getLineNumber(), WT_POSSIBLE_TYPO);
+        throw_warn(ls, "possibly unwanted fallthrough", luaO_fmt(ls->L, "the case on line %d flows into this case", case_line), "place `--@fallthrough` before this case if this is intended", ls->getLineNumber(), WT_UNANNOTATED_FALLTHROUGH);
         ls->L->top.p--;
       }
       else testnext(ls, TK_FALLTHROUGH);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3126,9 +3126,11 @@ static void switchimpl (LexState *ls, int tk, void(*caselist)(LexState*,void*), 
 
 static void switchstat (LexState *ls) {
   switchimpl(ls, ':', [](LexState* ls, void*) {
+    const int case_line = luaX_lookbehind(ls).line;
     while (gett(ls) != TK_CASE
         && gett(ls) != TK_DEFAULT
         && gett(ls) != TK_END
+        && gett(ls) != TK_FALLTHROUGH
       ) {
       if (gett(ls) == TK_PCONTINUE
           || gett(ls) == TK_CONTINUE
@@ -3139,6 +3141,11 @@ static void switchstat (LexState *ls) {
         statement(ls);
       }
     }
+    if (ls->t.token == TK_CASE) {
+      throw_warn(ls, "possibly unwanted fallthrough", luaO_fmt(ls->L, "the case on line %d flows into this case", case_line), "place `--@fallthrough` before this case if this is intended", ls->getLineNumber(), WT_POSSIBLE_TYPO);
+      ls->L->top.p--;
+    }
+    else testnext(ls, TK_FALLTHROUGH);
     ls->laststat.token = TK_EOS;  /* We don't want warnings for trailing control flow statements. */
   });
 }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -880,6 +880,7 @@ do
     switch true do
         default:
             error()
+            break
         case (87 == 87):
     end
 end
@@ -889,6 +890,7 @@ do
     switch x do
         default:
             error()
+            break
         case y + 1: -- x == y + 1
     end
 end


### PR DESCRIPTION
This raises a warning:
```Lua
switch 1 do
    case 1:
        print("1")
    case 2:
        print("2")
end
```
This doesn't:
```Lua
switch 1 do
    case 1:
        print("1")
        --@fallthrough
    case 2:
        print("2")
end
```
There is also no warning for empty cases (`case 1: case 2:`) nor when `break` is used.