### PR TITLE
Also raise "possibly unwanted function call" for method calls

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2742,7 +2742,12 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
           return;
         }
         expdesc key;
-        luaX_next(ls);
+        const auto colon_line = ls->t.line;
+        luaX_next(ls);  /* skip ':' */
+        if (l_unlikely(colon_line != ls->t.line)) {
+          throw_warn(ls, "possibly unwanted function call", luaO_fmt(ls->L, "possibly unwanted continuation of the expression on line %d.", colon_line), WT_POSSIBLE_TYPO);
+          ls->L->top.p--;
+        }
         codename(ls, &key);
         luaK_self(fs, v, &key);
         method_call_funcargs(ls, v);


### PR DESCRIPTION
This catches cases like this:
```Lua
local t = {
    function getVal() return 1 end
}

switch 1 do
    case t:getVal():
        print("1")
end
```