### PR TITLE
Enable padding in base32 & base64 encode by default

### DIFF
--- a/src/lbase32.cpp
+++ b/src/lbase32.cpp
@@ -6,7 +6,7 @@
 #include "vendor/Soup/soup/base32.hpp"
 
 static int encode(lua_State* L) {
-	lua_pushstring(L, soup::base32::encode(luaL_checkstring(L, 1), (bool)lua_toboolean(L, 2)).c_str());
+	lua_pushstring(L, soup::base32::encode(luaL_checkstring(L, 1), (bool)(lua_gettop(L) >= 2 ? lua_toboolean(L, 2) : true)).c_str());
 	return 1;
 }
 

--- a/src/lbase64.cpp
+++ b/src/lbase64.cpp
@@ -7,7 +7,7 @@
 #include "vendor/Soup/soup/base64.hpp"
 
 static int encode(lua_State* L) {
-	lua_pushstring(L, soup::base64::encode(luaL_checkstring(L, 1), (bool)lua_toboolean(L, 2)).c_str());
+	lua_pushstring(L, soup::base64::encode(luaL_checkstring(L, 1), (bool)(lua_gettop(L) >= 2 ? lua_toboolean(L, 2) : true)).c_str());
 	return 1;
 }
 

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1145,11 +1145,13 @@ do
 end
 do
     local base64 = require("base64")
-    assert(base64.encode("Hello") == "SGVsbG8")
+    assert(base64.encode("Hello") == "SGVsbG8=")
+    assert(base64.encode("Hello", false) == "SGVsbG8")
     assert(base64.decode("SGVsbG8") == "Hello")
+    assert(base64.decode("SGVsbG8=") == "Hello")
+
     assert(base64.urlencode("Hello") == "SGVsbG8")
     assert(base64.urldecode("SGVsbG8") == "Hello")
-    assert(base64.decode(base64.encode("Hello", true)) == "Hello")
 end
 do
     local t = { key = "value" }


### PR DESCRIPTION
Both of these are used with padding more often than not. The reason for doing this is that some decoders (Python) error if the padding is not present. BASE64URL is an exception, since `=` is not filename/URL-safe.