### PR TITLE
Add warning coverage for possible ternary colon confusion

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -88,7 +88,7 @@ union SemInfo {
 struct Token {
   int token;
   SemInfo seminfo;
-  int line;
+  int line, column;
 
   Token() = default;
 
@@ -305,6 +305,7 @@ enum ParserContext : lu_byte {
   PARCTX_FUNCARGS,
   PARCTX_BODY,
   PARCTX_LAMBDA_BODY,
+  PARCTX_TERNARY_C,  /* 'c' in 'a ? b : c' */
 };
 
 struct ClassData {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2743,10 +2743,14 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         }
         expdesc key;
         const auto colon_line = ls->t.line;
+        const auto colon_column = ls->t.column;
         luaX_next(ls);  /* skip ':' */
         if (l_unlikely(colon_line != ls->t.line)) {
           throw_warn(ls, "possibly unwanted function call", luaO_fmt(ls->L, "possibly unwanted continuation of the expression on line %d.", colon_line), WT_POSSIBLE_TYPO);
           ls->L->top.p--;
+        }
+        else if (l_unlikely(ls->t.column != (colon_column + 1) && ls->getContext() == PARCTX_TERNARY_C)) {
+          throw_warn(ls, "possible confusion with colons", "the second colon is interpreted as a method call instead of the first colon", "wrap the method call in parentheses", ls->t.line, WT_POSSIBLE_TYPO);
         }
         codename(ls, &key);
         luaK_self(fs, v, &key);
@@ -3467,7 +3471,9 @@ static void expr (LexState *ls, expdesc *v, TypeHint *prop, int flags) {
     luaK_concat(fs, &escape, luaK_jump(fs));
     luaK_patchtohere(fs, condition);
     checknext(ls, ':');
+    ls->pushContext(PARCTX_TERNARY_C);
     expr(ls, v, prop);
+    ls->popContext(PARCTX_TERNARY_C);
     luaK_exp2reg(fs, v, reg);
     luaK_patchtohere(fs, escape);
   }


### PR DESCRIPTION
Closes #622. Since we already have warning coverage for switch case method call confusion, this just adds it for ternaries as well:
```Lua
local t = { function doSomething() return "something" end }
print(t ? t:doSomething() : nil)
```
```
basic.pluto:2: warning: possible confusion with colons [possible-typo]
    2 | print(t ? t:doSomething() : nil)
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ here: the second colon is interpreted as a method call instead of the first colon
      + note: wrap the method call in parentheses
```