### PR TITLE
Support 'do' as a "universal block opener"

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4082,7 +4082,11 @@ static void test_then_block (LexState *ls, int *escapelist, TypeHint *prop) {
   const bool alwaystrue = luaK_isalwaystrue(ls, &v);
   if (luaK_isalwaysfalse(ls, &v))
     throw_warn(ls, "unreachable code", "this condition will never be truthy.", WT_UNREACHABLE_CODE);
-  if (!testnext(ls, TK_DO))  /* [Pluto] Universal block opener */
+  if (ls->t.token == TK_DO) {  /* Universal block opener? */
+    throw_warn(ls, "non-portable code", "usage of 'do' instead of 'then' in if-statements is Pluto-specific", WT_NON_PORTABLE_CODE);
+    luaX_next(ls);
+  }
+  else
     checknext(ls, TK_THEN);
   if (ls->t.token == TK_BREAK && luaX_lookahead(ls) != TK_INT) {  /* 'if x then break' and not 'if x then break int' ? */
     ls->laststat.token = TK_BREAK;


### PR DESCRIPTION
A lot of people would like `{` ... `}`, and I think at least part of the reason is that it's mindless. Currently, control flow statements like `if`, `for`, and `while` in Lua/Pluto require people to think about what statement they are writing a block for, as opposed to just being able to write `STATEMENT EXPR BLOCK`. By allowing `do` for `if` statements as well as `then`, the programmer can avoid this cognitive overhead.

 `do` is also already the unofficial "universal block opener" of Lua, since it's what's used to create freestanding blocks in statlists, e.g. to restrict variable scopes.