### PR TITLE
Add expanded mode to cat.decode

### DIFF
--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1595,6 +1595,11 @@ do
     t = cat.decode(data)
     assert(t.Hello == "World")
     assert(cat.encode(t) == data)
+
+    data = "First\nSecond"
+    t = cat.decode(data, true)
+    assert(t[1].name == "First")
+    assert(t[2].name == "Second")
 end
 do
     local { base64, crypto } = require"*"


### PR DESCRIPTION
The resulting structure is more verbose, but maintains order. I would've done something like `__order`, but there is no guarantee that a "key" is unique in CaT.

Although I'm not sure if this should not be its own function outright, e.g. `cat.decodeex`?