### PR TITLE
Add table.clear

### DIFF
--- a/src/ltable.cpp
+++ b/src/ltable.cpp
@@ -1027,6 +1027,16 @@ LUAI_FUNC unsigned int luaH_gethsize (const Table *t) {
 }
 
 
+LUAI_FUNC void luaH_clear (lua_State *L, Table *t) {
+  /* clear array part */
+  luaM_freearray(L, t->array, luaH_realasize(t));
+  t->array = NULL;
+  t->alimit = 0;
+  /* clear hash part */
+  freehash(L, t);
+  setnodevector(L, t, 0);
+}
+
 
 #if defined(LUA_DEBUG)
 

--- a/src/ltable.h
+++ b/src/ltable.h
@@ -55,6 +55,11 @@ LUAI_FUNC unsigned int luaH_realasize (const Table *t);
 LUAI_FUNC unsigned int luaH_gethsize (const Table *t);
 
 
+#ifndef PLUTO_LUA_LINKABLE
+LUAI_FUNC void luaH_clear (lua_State *L, Table *t);
+#endif
+
+
 #if defined(LUA_DEBUG)
 LUAI_FUNC Node *luaH_mainposition (const Table *t, const TValue *key);
 #endif

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -767,10 +767,18 @@ static int checkall (lua_State *L) {
 }
 
 
+static int tclear (lua_State *L) {
+  luaL_checktype(L, 1, LUA_TTABLE);
+  luaH_clear(L, hvalue(index2value(L, 1)));
+  return 0;
+}
+
+
 /* }====================================================== */
 
 
 static const luaL_Reg tab_funcs[] = {
+  {"clear", tclear},
   {"checkall", checkall},
   {"find", tfind},
   {"reduce", treduce},

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1593,6 +1593,12 @@ do
     assert({ 2, 4, 6 }:checkall(|x| -> x % 2 == 0) == true)
 end
 do
+    local t = { 1, 2, 3, "foo", "bar" }
+    assert(t:size() == 5)
+    t:clear()
+    assert(t:size() == 0)
+end
+do
     assert(compareversions("0.1.0", "0.1.0") == 0)
     assert(compareversions("0.1.0", "0.2.0") ~= 0)
     assert(compareversions("0.2.0", "0.1.0") > 0)


### PR DESCRIPTION
On Lua 5.5, we need a slightly different logic to free the array part:

```C
unsigned int realsize = luaH_realasize(t);
size_t sizeb = concretesize(realsize);
luaM_freemem(L, t->array, sizeb);
```