### PR TITLE
Improve cat.decode

### DIFF
--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1630,6 +1630,11 @@ do
     t = cat.decode(data, "expanded")
     assert(t[1].name == "First")
     assert(t[2].name == "Second")
+
+    -- Expanded Mode Metatable
+    data = "List: With Value\n\tChild: With Value\n"
+    t = cat.decode(data, "expanded")
+    assert(t.List.Child.value == "With Value")
 end
 do
     local { base64, bigint, crypto } = require"*"

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1616,18 +1616,18 @@ do
     local cat = require"pluto:cat"
 
     local data = "List: With Value\n\tChild: With Value\n"
-    local t = cat.decode(data)
+    local t = cat.decode(data, "flat")
     assert(t.List.__value == "With Value")
     assert(t.List.Child == "With Value")
     assert(cat.encode(t) == data)
 
     data = "Hello: World\n"
-    t = cat.decode(data)
+    t = cat.decode(data, "flat")
     assert(t.Hello == "World")
     assert(cat.encode(t) == data)
 
     data = "First\nSecond"
-    t = cat.decode(data, cat.expanded)
+    t = cat.decode(data, "expanded")
     assert(t[1].name == "First")
     assert(t[2].name == "Second")
 end


### PR DESCRIPTION
#732 shows that flattening the tree is a rather imperfect conversion, so I don't think it should be the default, hence I'm changing the second argument of `cat.decode` to take an "output format" which can either be "flat", "flatwithorder" or "expanded" (now the default).

This also implements #734 so this API is maintains its simplicity.