### PR TITLE
Make scheduler a class, add yieldfunc property

### DIFF
--- a/src/linit.cpp
+++ b/src/linit.cpp
@@ -80,7 +80,7 @@ LUALIB_API void luaL_openlibs (lua_State *L) {
 pluto_use "0.6.0"
 
 class exception
-    __name = "exception"
+    __name = "pluto:exception"
 
     function __construct(public what)
         local caller

--- a/src/lschedulerlib.cpp
+++ b/src/lschedulerlib.cpp
@@ -10,45 +10,52 @@ static const luaL_Reg funcs[] = {
 LUAMOD_API int luaopen_scheduler (lua_State *L) {
 	const auto code = R"EOC(pluto_use "0.6.0"
 
-local scheduler = {}
-
-local coros = {}
 local function resume(coro)
     if select("#", coroutine.xresume(coro)) ~= 0 then
-        warn("Coroutine yielded values to scheduler lib. Discarding them.")
+        warn("Coroutine yielded values to scheduler. Discarding them.")
     end
 end
-local function add(f)
-    local coro = coroutine.create(f)
-    table.insert(coros, coro)
-    resume(coro)
-    return coro
-end
-scheduler.add = add
-function scheduler.addloop(f)
-    return add(function()
-        while f() ~= false do
-            coroutine.yield()
-        end
-    end)
-end
-scheduler.yieldfunc = || -> do os.sleep(1) end
-function scheduler.run()
-    local all_dead
-    repeat
-        all_dead = true
-        for i, coro in coros do
-            if coroutine.status(coro) == "suspended" then
-                resume(coro)
-                all_dead = false
-            elseif coroutine.status(coro) == "dead" then
-                coros[i] = nil
+
+return class
+    __name = "pluto:scheduler"
+
+    yieldfunc = || -> do os.sleep(1) end
+
+    function __construct()
+        self.coros = {}
+    end
+
+    function add(f)
+        local coro = coroutine.create(f)
+        table.insert(self.coros, coro)
+        resume(coro)
+        return coro
+    end
+
+    function addloop(f)
+        return self:add(function()
+            while f() ~= false do
+                coroutine.yield()
             end
-        end
-        scheduler.yieldfunc()
-    until all_dead
-end
-return scheduler)EOC";
+        end)
+    end
+
+    function run()
+        local all_dead
+        repeat
+            all_dead = true
+            for i, coro in self.coros do
+                if coroutine.status(coro) == "suspended" then
+                    resume(coro)
+                    all_dead = false
+                elseif coroutine.status(coro) == "dead" then
+                    coros[i] = nil
+                end
+            end
+            self.yieldfunc()
+        until all_dead
+    end
+end)EOC";
 	luaL_loadbuffer(L, code, strlen(code), "pluto:scheduler");
 	lua_call(L, 0, 1);
 	return 1;

--- a/src/lvector3lib.cpp
+++ b/src/lvector3lib.cpp
@@ -12,7 +12,7 @@ LUAMOD_API int luaopen_vector3(lua_State* L) {
 
 local vector3
  class vector3
-  __name = "vector3"
+  __name = "pluto:vector3"
 
   function __construct(x, y, z)
     if x ~= nil and y == nil and z == nil then


### PR DESCRIPTION
To allow for more flexibility in the use-cases of this library.

```lua
local { pluto_scheduler = scheduler } = require "*"

local scheduler = new pluto_scheduler()
scheduler.yieldfunc = || -> do os.sleep(1000) end
scheduler:addloop(|| -> print("hi"))
scheduler:run()
```