### PR TITLE
Re-add compile-time concat optimization

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3630,23 +3630,25 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
       if (op == OPR_CONCAT) {
         if (prop)
           prop->emplaceTypeDesc(VT_STR);
-        TString *lhs = nullptr;
-        if (v->k == VKSTR)
-          lhs = v->u.strval;
-        else if (v->k == VCONST && ttisstring(&ls->dyd->actvar.arr[v->u.info].k))
-          lhs = tsvalue(&ls->dyd->actvar.arr[v->u.info].k);
-        if (lhs && ls->t.token == TK_STRING) {
-          setsvalue2s(ls->L, ls->L->top.p, lhs);
-          ls->L->top.p++;
-          setsvalue2s(ls->L, ls->L->top.p, ls->t.seminfo.ts);
-          ls->L->top.p++;
-          luaV_concat(ls->L, 2);
-          ls->L->top.p--;
-          v->k = VKSTR;
-          v->u.strval = tsvalue(s2v(ls->L->top.p));
-          luaX_next(ls);
-          op = getbinopr(ls->t.token);
-          continue;
+        if (v->t == NO_JUMP && v->f == NO_JUMP) {
+          TString *lhs = nullptr;
+          if (v->k == VKSTR)
+            lhs = v->u.strval;
+          else if (v->k == VCONST && ttisstring(&ls->dyd->actvar.arr[v->u.info].k))
+            lhs = tsvalue(&ls->dyd->actvar.arr[v->u.info].k);
+          if (lhs && ls->t.token == TK_STRING) {
+            setsvalue2s(ls->L, ls->L->top.p, lhs);
+            ls->L->top.p++;
+            setsvalue2s(ls->L, ls->L->top.p, ls->t.seminfo.ts);
+            ls->L->top.p++;
+            luaV_concat(ls->L, 2);
+            ls->L->top.p--;
+            v->k = VKSTR;
+            v->u.strval = tsvalue(s2v(ls->L->top.p));
+            luaX_next(ls);
+            op = getbinopr(ls->t.token);
+            continue;
+          }
         }
       }
       else if (op == OPR_COAL) {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3627,7 +3627,29 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
     }
     else {
       TypeHint *subexpr_prop = nullptr;
-      if (op == OPR_COAL) {
+      if (op == OPR_CONCAT) {
+        if (prop)
+          prop->emplaceTypeDesc(VT_STR);
+        TString *lhs = nullptr;
+        if (v->k == VKSTR)
+          lhs = v->u.strval;
+        else if (v->k == VCONST && ttisstring(&ls->dyd->actvar.arr[v->u.info].k))
+          lhs = tsvalue(&ls->dyd->actvar.arr[v->u.info].k);
+        if (lhs && ls->t.token == TK_STRING) {
+          setsvalue2s(ls->L, ls->L->top.p, lhs);
+          ls->L->top.p++;
+          setsvalue2s(ls->L, ls->L->top.p, ls->t.seminfo.ts);
+          ls->L->top.p++;
+          luaV_concat(ls->L, 2);
+          ls->L->top.p--;
+          v->k = VKSTR;
+          v->u.strval = tsvalue(s2v(ls->L->top.p));
+          luaX_next(ls);
+          op = getbinopr(ls->t.token);
+          continue;
+        }
+      }
+      else if (op == OPR_COAL) {
         if (luaK_isalwaysnil(ls, v)) {
           /* weird, but nothing worth talking about... */
         }

--- a/testes/literals.lua
+++ b/testes/literals.lua
@@ -229,7 +229,7 @@ do  -- reuse of long strings
   assert(a1 == getadd(foo2()))
 
   local sd = "0123456789" .. "0123456789012345678901234567890123456789"
-  assert(sd == s1 and getadd(sd) ~= a1)
+  assert(sd == s1) -- [Pluto] removed the check that addresses are not identical, because we do this concat at compile-time.
 end
 
 


### PR DESCRIPTION
Could probably be done correctly by moving it more towards the lexer.

Alternatively, check for conditional code generation.