### PR TITLE
Jumbo build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,1 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> <PropertyGroup> <EnableUnitySupport>true</EnableUnitySupport> </PropertyGroup> </Project>

--- a/src/lauxlib.h
+++ b/src/lauxlib.h
@@ -54,7 +54,7 @@ namespace Pluto {
 }
 
 
-#define PLUTO_NEWLIB(name) LUAMOD_API int luaopen_##name(lua_State *L) { luaL_newlib(L, funcs); return 1; } const Pluto::PreloadedLibrary Pluto::preloaded_##name { #name, funcs, &luaopen_##name };
+#define PLUTO_NEWLIB(name) LUAMOD_API int luaopen_##name(lua_State *L) { luaL_newlib(L, funcs_##name); return 1; } const Pluto::PreloadedLibrary Pluto::preloaded_##name { #name, funcs_##name, &luaopen_##name };
 
 
 #define LUAL_NUMSIZES	(sizeof(lua_Integer)*16 + sizeof(lua_Number))

--- a/src/lbase32.cpp
+++ b/src/lbase32.cpp
@@ -15,7 +15,7 @@ static int decode(lua_State* L) {
 	return 1;
 }
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_base32[] = {
 	{"encode", encode},
 	{"decode", decode},
 	{nullptr, nullptr}

--- a/src/lbase64.cpp
+++ b/src/lbase64.cpp
@@ -40,7 +40,7 @@ static int urlDecodeDeprecated(lua_State* L) {
 	return urlDecode(L);
 }
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_base64[] = {
 	{"encode", encode},
 	{"decode", decode},
 	{"urlencode", urlEncode},  /* added in Pluto 0.8.0 */

--- a/src/lbigint.cpp
+++ b/src/lbigint.cpp
@@ -113,7 +113,7 @@ void pushbigint (lua_State *L, soup::Bigint&& x) {
   luaL_setmetatable(L, "pluto:bigint");
 }
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_bigint[] = {
   {"new", bigint_new},
   {"add", bigint_add},
   {"sub", bigint_sub},

--- a/src/lcatlib.cpp
+++ b/src/lcatlib.cpp
@@ -193,7 +193,7 @@ static int cat_decode (lua_State *L) {
   return 0;
 }
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_cat[] = {
   {"encode", cat_encode},
   {"decode", cat_decode},
   {nullptr, nullptr}

--- a/src/lcryptolib.cpp
+++ b/src/lcryptolib.cpp
@@ -695,7 +695,7 @@ static int l_adler32 (lua_State *L) {
 }
 
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_crypto[] = {
   {"hexdigest", hexdigest},  /* deprecated since 0.8.0 */
   {"random", random},
   {"sha1", l_sha1},

--- a/src/lhttplib.cpp
+++ b/src/lhttplib.cpp
@@ -202,7 +202,7 @@ static int http_hasconnection (lua_State *L) {
 }
 #endif
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_http[] = {
   {"request", http_request},
 #if !SOUP_WASM
   {"hasconnection", http_hasconnection},

--- a/src/lsocketlib.cpp
+++ b/src/lsocketlib.cpp
@@ -262,7 +262,7 @@ static int l_listen (lua_State *L) {
   return l.serv.bind(port, &l.srv) ? 1 : 0;
 }
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_socket[] = {
   {"connect", l_connect},
   {"send", l_send},
   {"recv", l_recv},
@@ -274,7 +274,7 @@ static const luaL_Reg funcs[] = {
 };
 
 LUAMOD_API int luaopen_socket (lua_State *L) {
-  luaL_newlib(L, funcs);
+  luaL_newlib(L, funcs_socket);
 
   lua_pushliteral(L, "bind");
   luaL_loadstring(L, R"EOC(
@@ -293,6 +293,6 @@ end)EOC");
 
   return 1;
 }
-const Pluto::PreloadedLibrary Pluto::preloaded_socket{ "socket", funcs, &luaopen_socket };
+const Pluto::PreloadedLibrary Pluto::preloaded_socket{ "socket", funcs_socket, &luaopen_socket };
 
 #endif

--- a/src/lurllib.cpp
+++ b/src/lurllib.cpp
@@ -42,7 +42,7 @@ static int url_parse (lua_State *L) {
 }
 
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_url[] = {
   {"encode", url_encode},
   {"decode", url_decode},
   {"parse", url_parse},

--- a/src/lvector3lib.cpp
+++ b/src/lvector3lib.cpp
@@ -3,7 +3,7 @@
 #define LUA_LIB
 #include "lualib.h"
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_vector3[] = {
   {nullptr, nullptr}
 };
 
@@ -203,4 +203,4 @@ return vector3)EOC";
     return 1;
 }
 
-const Pluto::PreloadedLibrary Pluto::preloaded_vector3{ "vector3", funcs, &luaopen_vector3 };
+const Pluto::PreloadedLibrary Pluto::preloaded_vector3{ "vector3", funcs_vector3, &luaopen_vector3 };

--- a/src/lxml.cpp
+++ b/src/lxml.cpp
@@ -134,7 +134,7 @@ static int xml_decode (lua_State *L) {
   return 1;
 }
 
-static const luaL_Reg funcs[] = {
+static const luaL_Reg funcs_xml[] = {
   {"encode", xml_encode},
   {"decode", xml_decode},
   {nullptr, nullptr}

--- a/src/vendor/Soup/soup/ecc.cpp
+++ b/src/vendor/Soup/soup/ecc.cpp
@@ -155,6 +155,8 @@ namespace soup
 #endif
 	}
 
+#undef max
+
 	EccPoint EccCurve::multiplyAndAdd(const EccPoint& G, const Bigint& u1, const EccPoint& Q, const Bigint& u2) const
 	{
 		EccPoint R;


### PR DESCRIPTION
On my machine, this makes Pluto compile in \~5 seconds, down from 7\~8 seconds. Not particularly insane, but might help some integrators.

This basically squashes multiple .cpp files into the same one, so this breaks some assumptions about name pollution and static linkage. That's not an issue for Lua, and also not a huge issue for our own code, but might make development slightly more confusing.