### PR TITLE
Revert "Reduce LUAI_MAXCCALLS to avoid stack overflows"

### DIFF
--- a/src/llimits.h
+++ b/src/llimits.h
@@ -249,7 +249,7 @@ typedef l_uint32 Instruction;
 ** the size of the C stack.)
 */
 #if !defined(LUAI_MAXCCALLS)
-#define LUAI_MAXCCALLS		160
+#define LUAI_MAXCCALLS		200
 #endif
 
 


### PR DESCRIPTION
The sieve.lua at https://www.lua.org/extras/ throws "C stack overflow" on its default setting of 500 with our C stack limit.

Raising it back to Lua's limit of 200 does not seem to have any adverse effects. I'm also not sure why exactly we lowered it in the first place, tho we should probably aim to deal with that in a better way (not taking up so much stack space) if we do encounter it again.