### PR TITLE
Fix instances of E_NO_COLON getting lost or ignored

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3080,7 +3080,7 @@ static void newexpr (LexState *ls, expdesc *v) {
 
 
 static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop = nullptr, int flags = 0);
-static BinOpr custombinaryoperator (LexState *ls, expdesc *v, TString *impl) {
+static BinOpr custombinaryoperator (LexState *ls, expdesc *v, int flags, TString *impl) {
   FuncState *fs = ls->fs;
   int line = ls->getLineNumber();
 
@@ -3092,7 +3092,7 @@ static BinOpr custombinaryoperator (LexState *ls, expdesc *v, TString *impl) {
   int base = v->u.reg;  /* base register for call */
 
   expdesc arg2;
-  auto nextop = subexpr(ls, &arg2, 3);
+  auto nextop = subexpr(ls, &arg2, 3, nullptr, flags);
   luaK_exp2nextreg(fs, &arg2);
 
   int nparams = fs->freereg - (base + 1);
@@ -3619,11 +3619,11 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
     int line = ls->getLineNumber();
     luaX_next(ls);  /* skip operator */
     if (op == OPR_INSTANCEOF) {
-      custombinaryoperator(ls, v, luaS_newliteral(ls->L, "Pluto_operator_instanceof"));
+      custombinaryoperator(ls, v, flags, luaS_newliteral(ls->L, "Pluto_operator_instanceof"));
       nextop = getbinopr(ls->t.token);
     }
     else if (op == OPR_SPACESHIP) {
-      custombinaryoperator(ls, v, luaS_newliteral(ls->L, "Pluto_operator_spaceship"));
+      custombinaryoperator(ls, v, flags, luaS_newliteral(ls->L, "Pluto_operator_spaceship"));
       nextop = getbinopr(ls->t.token);
     }
     else {

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3443,13 +3443,13 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, TypeHint *prop) {
 }
 
 
-static void inexpr (LexState *ls, expdesc *v) {
+static void inexpr (LexState *ls, expdesc *v, int flags) {
   expdesc v2;
   checknext(ls, TK_IN);
   luaK_exp2nextreg(ls->fs, v);
   lua_assert(v->k == VNONRELOC);
   int base = v->u.reg;
-  simpleexp(ls, &v2);
+  simpleexp(ls, &v2, flags);
   luaK_dischargevars(ls->fs, &v2);
   luaK_exp2nextreg(ls->fs, &v2);
   luaK_codeABC(ls->fs, OP_IN, v->u.reg, v2.u.reg, 0);
@@ -3597,7 +3597,7 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
     simpleexp(ls, v, flags, prop);
     if (ls->t.token == TK_IN) {
       throw_warn(ls, "non-portable operator usage", "this operator generates bytecode which is incompatible with Lua.", WT_NON_PORTABLE_BYTECODE);
-      inexpr(ls, v);
+      inexpr(ls, v, flags);
       if (prop) prop->emplaceTypeDesc(VT_BOOL);
     }
   }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2999,7 +2999,7 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         }
         luaX_next(ls);
         int nparams = 1;
-        if (luaX_lookahead(ls) == ':') {
+        if (!(flags & E_NO_COLON) && luaX_lookahead(ls) == ':') {
           luaK_reserveregs(fs, 2);
           luaK_exp2nextreg(fs, v);
           fs->freereg -= 3;
@@ -3012,7 +3012,7 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, TypeHint *
         }
         else {
           expdesc func;
-          simpleexp(ls, &func, E_PIPERHS);
+          simpleexp(ls, &func, flags | E_PIPERHS);
           luaK_prepcallfirstarg(fs, v, &func);
         }
         lua_assert(v->k == VNONRELOC);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3703,7 +3703,7 @@ static void expr (LexState *ls, expdesc *v, TypeHint *prop, int flags) {
     luaK_patchtohere(fs, condition);
     checknext(ls, ':');
     ls->pushContext(PARCTX_TERNARY_C);
-    expr(ls, v, prop);
+    expr(ls, v, prop, flags & E_NO_COLON);
     ls->popContext(PARCTX_TERNARY_C);
     luaK_exp2reg(fs, v, reg);
     luaK_patchtohere(fs, escape);


### PR DESCRIPTION
To allow `a ? b in c : e` to be parsed as expected