### PR TITLE
Don't use safecall as an "out-top" instruction, but allow fixed multret

### DIFF
--- a/src/lcode.h
+++ b/src/lcode.h
@@ -102,5 +102,3 @@ LUAI_FUNC l_noret luaK_semerror (LexState *ls, const char *msg);
 LUAI_FUNC void luaK_exp2reg (FuncState *fs, expdesc *e, int reg);
 LUAI_FUNC void luaK_freeexp (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_invertcond (FuncState *fs, int list);
-LUAI_FUNC void luaK_settop (FuncState *fs, int reg);
-LUAI_FUNC void luaK_dectop (FuncState *fs, int from, int to);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2455,9 +2455,8 @@ static void method_call_funcargs (LexState *ls, expdesc *v) {
     v->k = VSAFECALL;
     v->u.pc = pc;  /* instruction pc */
     int jt = luaK_jump(fs);
-    luaK_patchtohere(fs, jf);    
-    luaK_dectop(fs, v->u.reg + 2, v->u.reg + 1);  /* because VSAFECALL is mulret, we need to manage L->top.
-                                                     specifically, decrement it to discard the table that OP_SELF pushed. */
+    luaK_patchtohere(fs, jf);
+    luaK_nil(fs, v->u.reg + 1, 1);  /* failed to call, push nil */
     luaK_patchtohere(fs, jt);
   }
   else
@@ -2517,7 +2516,7 @@ static void safe_navigation (LexState *ls, expdesc *v) {
   }
   if (is_method_call) {
     v->k = VSAFECALL;
-    luaK_dectop(fs, v->u.reg + 2, v->u.reg + 1);
+    luaK_nil(fs, v->u.reg + 1, 1);  /* failed to call, push nil */
     luaK_patchtohere(fs, jt);
   }
 }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -45,7 +45,7 @@
 
 
 
-#define hasmultret(k)		((k) == VCALL || (k) == VSAFECALL || (k) == VVARARG)
+#define hasmultret(k)		((k) == VCALL || (k) == VVARARG)
 
 
 /*
@@ -886,7 +886,7 @@ inline int gett(LexState *ls) {
 static void adjust_assign (LexState *ls, int nvars, int nexps, expdesc *e) {
   FuncState *fs = ls->fs;
   int needed = nvars - nexps;  /* extra values needed */
-  if (hasmultret(e->k)) {  /* last expression has multiple returns? */
+  if (hasmultret(e->k) || e->k == VSAFECALL) {  /* last expression has multiple returns? */
     int extra = needed + 1;  /* discount last expression itself */
     if (extra < 0)
       extra = 0;
@@ -2356,7 +2356,7 @@ static void funcargs (LexState *ls, expdesc *f, TypeDesc *funcdesc = nullptr) {
           explist_nonlinear(ls, &args, argtis, fas.argdescs);
           luaX_setpos(ls, tidx);
         }
-        if (hasmultret(args.k))
+        if (hasmultret(args.k) && args.k != VSAFECALL)
           luaK_setmultret(fs, &args);
       }
       check_match(ls, ')', '(', line);
@@ -2418,7 +2418,7 @@ static void funcargs (LexState *ls, expdesc *f, TypeDesc *funcdesc = nullptr) {
   }
   lua_assert(f->k == VNONRELOC);
   base = f->u.reg;  /* base register for call */
-  if (hasmultret(args.k))
+  if (hasmultret(args.k) && args.k != VSAFECALL)
     nparams = LUA_MULTRET;  /* open call */
   else {
     if (args.k != VVOID)

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -1356,7 +1356,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
     lua_assert(base == ci->func.p + 1);
     lua_assert(base <= L->top.p && L->top.p <= L->stack_last.p);
     /* invalidate top for instructions not expecting it */
-    //lua_assert(isIT(i) || (cast_void(L->top.p = base), 1));  /* [Pluto] we don't do this because we generate very cursed bytecode */
+    lua_assert(isIT(i) || (cast_void(L->top.p = base), 1));
     vmdispatch (GET_OPCODE(i)) {
       vmcase(OP_MOVE) {
         StkId ra = RA(i);

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -1355,7 +1355,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
     #endif
     lua_assert(base == ci->func.p + 1);
     lua_assert(base <= L->top.p && L->top.p <= L->stack_last.p);
-    /* invalidate top for instructions not expecting it */
+    /* invalidate top for instructions not expecting it - [Pluto] this is similar to a debug hook being active */
     lua_assert(isIT(i) || (cast_void(L->top.p = base), 1));
     vmdispatch (GET_OPCODE(i)) {
       vmcase(OP_MOVE) {

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -613,6 +613,8 @@ end
 
 print "Testing safe navigation."
 do
+    debug.sethook(function() end, "c", 1)
+
     local a = A?.B?.C?.D
     assert(a == nil)
     a = A?["B"]?["C"]?["D"]
@@ -670,6 +672,8 @@ do
     r1, r2 = inst?:method?()
     assert(r1 == true)
     assert(r2 == 69)
+
+    debug.sethook()
 end
 do
     do


### PR DESCRIPTION
This sucks a little, but at least we can get rid of the inconsistent behavior and cursed bytecode.