### PR TITLE
Autodetect if keywords should be enabled if not explicitly declared

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -362,10 +362,18 @@ struct EnumDesc {
 };
 
 enum KeywordState : lu_byte {
+  /* "Uninformed" means this is the default state of the keyword and may be adjusted based on observed usage. */
+  KS_ENABLED_BY_PLUTO_UNINFORMED,
+  KS_DISABLED_BY_PLUTO_UNINFORMED,
+  /* "Informed" means the state of the keyword has been informed by observed usage. */
+  KS_ENABLED_BY_PLUTO_INFORMED,
+  KS_DISABLED_BY_PLUTO_INFORMED,
+  /* Environment settings overwrite Pluto. */
   KS_ENABLED_BY_ENV,
   KS_DISABLED_BY_ENV,
-  KS_ENABLED_BY_USER,
-  KS_DISABLED_BY_USER,
+  /* 'pluto_use' overwrites environment and Pluto. */
+  KS_ENABLED_BY_SCRIPTER,
+  KS_DISABLED_BY_SCRIPTER,
 };
 
 struct FuncArgsState {
@@ -431,12 +439,12 @@ struct LexState {
   LexState() : lines{ std::string{} }, warnconfs{ WarningConfig(0) } {
     laststat = Token {};
     laststat.token = TK_EOS;
-    parser_context_stck.push(PARCTX_NONE); /* ensure there is at least 1 item on the parser context stack */
+    parser_context_stck.push(PARCTX_NONE);  /* ensure there is at least 1 item on the parser context stack */
     for (int i = FIRST_NON_COMPAT; i != END_NON_COMPAT; ++i) {
-      setKeywordState(i, KS_ENABLED_BY_ENV);
+      setKeywordState(i, KS_ENABLED_BY_PLUTO_UNINFORMED);
     }
     for (int i = FIRST_OPTIONAL; i != END_OPTIONAL; ++i) {
-      setKeywordState(i, KS_DISABLED_BY_ENV);
+      setKeywordState(i, KS_DISABLED_BY_ENV);  /* optional keywords are not applicable for auto-detection */
     }
   }
 
@@ -559,9 +567,9 @@ struct LexState {
 #endif
 
   [[nodiscard]] bool isKeywordEnabled(int t) const noexcept {
-    static_assert((KS_ENABLED_BY_USER & 1) == 0);
+    static_assert((KS_ENABLED_BY_SCRIPTER & 1) == 0);
     static_assert((KS_ENABLED_BY_ENV & 1) == 0);
-    static_assert((KS_DISABLED_BY_USER & 1) != 0);
+    static_assert((KS_DISABLED_BY_SCRIPTER & 1) != 0);
     static_assert((KS_DISABLED_BY_ENV & 1) != 0);
     return (getKeywordState(t) & 1) == 0;
   }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -5685,6 +5685,17 @@ static void mainfunc (LexState *ls, FuncState *fs) {
 }
 
 
+static void applyenvkeywordpreference (LexState *ls, int t, bool b) {
+  if (b) {
+    ls->setKeywordState(t, KS_ENABLED_BY_ENV);
+  }
+  else {
+    disablekeyword(ls, t);
+    ls->setKeywordState(t, KS_DISABLED_BY_ENV);
+  }
+}
+
+
 LClosure *luaY_parser (lua_State *L, LexState& lexstate, ZIO *z, Mbuffer *buff,
                        Dyndata *dyd, const char *name, int firstchar) {
   FuncState funcstate;
@@ -5702,42 +5713,24 @@ LClosure *luaY_parser (lua_State *L, LexState& lexstate, ZIO *z, Mbuffer *buff,
   lexstate.dyd = dyd;
   dyd->actvar.n = dyd->gt.n = dyd->label.n = 0;
   luaX_setinput(L, &lexstate, z, funcstate.f->source, firstchar);
-  if (L->l_G->compatible_switch) {
-    disablekeyword(&lexstate, TK_SWITCH);
-    lexstate.setKeywordState(TK_SWITCH, KS_DISABLED_BY_ENV);
-  }
-  if (L->l_G->compatible_continue) {
-    disablekeyword(&lexstate, TK_CONTINUE);
-    lexstate.setKeywordState(TK_CONTINUE, KS_DISABLED_BY_ENV);
-  }
-  if (L->l_G->compatible_enum) {
-    disablekeyword(&lexstate, TK_ENUM);
-    lexstate.setKeywordState(TK_ENUM, KS_DISABLED_BY_ENV);
-  }
-  if (L->l_G->compatible_new) {
-    disablekeyword(&lexstate, TK_NEW);
-    lexstate.setKeywordState(TK_NEW, KS_DISABLED_BY_ENV);
-  }
-  if (L->l_G->compatible_class) {
-    disablekeyword(&lexstate, TK_CLASS);
-    lexstate.setKeywordState(TK_CLASS, KS_DISABLED_BY_ENV);
-  }
-  if (L->l_G->compatible_parent) {
-    disablekeyword(&lexstate, TK_PARENT);
-    lexstate.setKeywordState(TK_PARENT, KS_DISABLED_BY_ENV);
-  }
-  if (L->l_G->compatible_export) {
-    disablekeyword(&lexstate, TK_EXPORT);
-    lexstate.setKeywordState(TK_EXPORT, KS_DISABLED_BY_ENV);
-  }
-  if (L->l_G->compatible_try) {
-    disablekeyword(&lexstate, TK_TRY);
-    lexstate.setKeywordState(TK_TRY, KS_DISABLED_BY_ENV);
-  }
-  if (L->l_G->compatible_catch) {
-    disablekeyword(&lexstate, TK_CATCH);
-    lexstate.setKeywordState(TK_CATCH, KS_DISABLED_BY_ENV);
-  }
+  if (L->l_G->have_preference_switch)
+    applyenvkeywordpreference(&lexstate, TK_SWITCH, L->l_G->preference_switch);
+  if (L->l_G->have_preference_continue)
+    applyenvkeywordpreference(&lexstate, TK_CONTINUE, L->l_G->preference_continue);
+  if (L->l_G->have_preference_enum)
+    applyenvkeywordpreference(&lexstate, TK_ENUM, L->l_G->preference_enum);
+  if (L->l_G->have_preference_new)
+    applyenvkeywordpreference(&lexstate, TK_NEW, L->l_G->preference_new);
+  if (L->l_G->have_preference_class)
+    applyenvkeywordpreference(&lexstate, TK_CLASS, L->l_G->preference_class);
+  if (L->l_G->have_preference_parent)
+    applyenvkeywordpreference(&lexstate, TK_PARENT, L->l_G->preference_parent);
+  if (L->l_G->have_preference_export)
+    applyenvkeywordpreference(&lexstate, TK_EXPORT, L->l_G->preference_export);
+  if (L->l_G->have_preference_try)
+    applyenvkeywordpreference(&lexstate, TK_TRY, L->l_G->preference_try);
+  if (L->l_G->have_preference_catch)
+    applyenvkeywordpreference(&lexstate, TK_CATCH, L->l_G->preference_catch);
 #ifndef PLUTO_USE_LET
   disablekeyword(&lexstate, TK_LET);
 #endif

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -190,10 +190,14 @@ static void throw_warn(LexState* ls, const char* err, WarningType warningType) {
 **   - Non-portable keyword usage. (class, switch, etc)
 */
 static void check_for_non_portable_code (LexState *ls) {
-  if (ls->t.IsNonCompatible() && !ls->t.IsOverridable() && ls->getKeywordState(ls->t.token) == KS_ENABLED_BY_ENV) {
-    throw_warn(ls, "non-portable keyword usage", luaO_fmt(ls->L, "use 'pluto_%s' instead, or 'pluto_use' this keyword: https://pluto.do/compat", luaX_token2str_noq(ls, ls->t.token)), WT_NON_PORTABLE_CODE);
-    ls->L->top.p--;
-    return;
+  if (ls->t.IsNonCompatible() && !ls->t.IsOverridable()) {
+    if (ls->getKeywordState(ls->t.token) == KS_ENABLED_BY_PLUTO_UNINFORMED) {
+      ls->setKeywordState(ls->t.token, KS_ENABLED_BY_PLUTO_INFORMED);
+    }
+    if (ls->getKeywordState(ls->t.token) == KS_ENABLED_BY_PLUTO_INFORMED || ls->getKeywordState(ls->t.token) == KS_ENABLED_BY_ENV) {  /* enabled by a means other than 'pluto_use'? */
+      throw_warn(ls, "non-portable keyword usage", luaO_fmt(ls->L, "use 'pluto_%s' instead, or 'pluto_use' this keyword: https://pluto.do/compat", luaX_token2str_noq(ls, ls->t.token)), WT_NON_PORTABLE_CODE);
+      ls->L->top.p--;
+    }
   }
 }
 
@@ -370,8 +374,16 @@ enum NameFlags {
   return 0;
 }
 
+static void disablekeyword (LexState *ls, int token) {
+  auto i = ls->tokens.begin();
+  if (ls->tidx != -1)
+    i += ls->tidx;  /* don't apply retroactively */
+  for (; i != ls->tokens.end(); ++i)
+    if (i->token == token)
+      i->token = TK_NAME;
+}
+
 static TString *str_checkname (LexState *ls, int flags = N_RESERVED_NON_VALUE) {
-  TString *ts;
 #ifdef PLUTO_PARSER_SUGGESTIONS
   if (ls->shouldSuggest()) {
     SuggestionsState ss(ls);
@@ -380,15 +392,21 @@ static TString *str_checkname (LexState *ls, int flags = N_RESERVED_NON_VALUE) {
 #endif
   if (!isnametkn(ls, flags)) {
     if (ls->t.IsNonCompatible()) {
+      if (ls->getKeywordState(ls->t.token) == KS_ENABLED_BY_PLUTO_UNINFORMED) {
+        disablekeyword(ls, ls->t.token);
+        ls->setKeywordState(ls->t.token, KS_DISABLED_BY_PLUTO_INFORMED);
+        luaX_setpos(ls, luaX_getpos(ls));  /* update ls->t */
+        return str_checkname(ls, flags);  /* try again */
+      }
       throwerr(ls, luaO_fmt(ls->L, "expected a name, found %s", luaX_token2str(ls, ls->t.token)), luaO_fmt(ls->L, "%s has a different meaning in Pluto, but you can disable this: https://pluto.do/compat", luaX_token2str(ls, ls->t.token)));
     }
     error_expected(ls, TK_NAME);
   }
-  ts = ls->t.seminfo.ts;
+  TString *ts = ls->t.seminfo.ts;
   lua_assert(ts != nullptr);
   if (!(flags & N_RESERVED) && !(flags & N_RESERVED_NON_VALUE)) {
     if (auto t = find_non_compat_tkn_by_name(ls, getstr(ts)); t != 0 && t != TK_PARENT) {
-      if (ls->getKeywordState(t) != KS_DISABLED_BY_USER) {
+      if (ls->getKeywordState(t) != KS_DISABLED_BY_SCRIPTER) {
         throw_warn(
           ls,
           luaO_fmt(ls->L, "'%s' is a non-portable name", getstr(ts)),
@@ -1824,9 +1842,6 @@ static void localclass (LexState *ls) {
   ls->classes.emplace();
 
   size_t name_pos = luaX_getpos(ls);
-  if (ls->t.token == '=') {
-    throwerr(ls, "expected a class name, found '='", "'class' has a different meaning in Pluto, but you can disable this: https://pluto.do/compat");
-  }
   TString *name = str_checkname(ls, 0);
   size_t parent_pos = checkextends(ls);
 
@@ -4661,7 +4676,16 @@ static void exprstat (LexState *ls) {
   }
   else {  /* stat -> func */
     Instruction *inst;
-    check_condition(ls, v.v.k == VCALL || v.v.k == VSAFECALL, "syntax error");
+    if (l_unlikely(v.v.k != VCALL && v.v.k != VSAFECALL)) {
+      if (luaX_lookbehind(ls).token == TK_NAME) {
+        if (auto t = find_non_compat_tkn_by_name(ls, getstr(luaX_lookbehind(ls).seminfo.ts))) {
+          if (ls->getKeywordState(t) == KS_DISABLED_BY_PLUTO_INFORMED) {
+            throwerr(ls, luaO_fmt(ls->L, "syntax error near %s", luaX_token2str(ls, ls->t.token)), luaO_fmt(ls->L, "%s was not recognized as a statement because it was previously used as an identifier", luaX_token2str(ls, t)));
+          }
+        }
+      }
+      luaX_syntaxerror(ls, "syntax error");
+    }
     inst = &getinstruction(fs, &v.v);
     SETARG_C(*inst, 1);  /* call statement uses no results */
     if (ls->nodiscard) {
@@ -4730,17 +4754,6 @@ static int checkkeyword (LexState *ls) {
   return token;
 }
 
-static void disablekeyword (LexState *ls, int token, bool due_to_compat_mode = false) {
-  if (due_to_compat_mode)
-    ls->setKeywordState(token, KS_DISABLED_BY_ENV);
-  auto i = ls->tokens.begin();
-  if (ls->tidx != -1)
-    i += ls->tidx;  /* don't apply retroactively */
-  for (; i != ls->tokens.end(); ++i)
-    if (i->token == token)
-      i->token = TK_NAME;
-}
-
 static void enablekeyword (LexState *ls, int token) {
   const char* str = luaX_reserved2str(token);
   auto i = ls->tokens.begin() + ls->tidx;
@@ -4761,11 +4774,11 @@ static void enablekeyword (LexState *ls, int token) {
 
 static void togglekeyword (LexState *ls, int token, bool enable) {
   if (ls->isKeywordEnabled(token) != enable) {
-    ls->setKeywordState(token, enable ? KS_ENABLED_BY_USER : KS_DISABLED_BY_USER);
+    ls->setKeywordState(token, enable ? KS_ENABLED_BY_SCRIPTER : KS_DISABLED_BY_SCRIPTER);
     if (enable)
       enablekeyword(ls, token);
     else
-      disablekeyword(ls, token, false);
+      disablekeyword(ls, token);
   }
 }
 
@@ -4838,8 +4851,8 @@ static void usestat (LexState *ls) {
         /* disable all non-compatible keywords as of this Pluto version, then enable those from the elected Pluto version. */
         for (int i = FIRST_NON_COMPAT; i != END_OPTIONAL; ++i) {
           if (ls->isKeywordEnabled(i)) {
-            ls->setKeywordState(i, KS_DISABLED_BY_USER);
-            disablekeyword(ls, i, false);
+            ls->setKeywordState(i, KS_DISABLED_BY_SCRIPTER);
+            disablekeyword(ls, i);
           }
         }
       }
@@ -5160,8 +5173,23 @@ static void statement (LexState *ls, TypeHint *prop) {
 #endif
       if (testnext(ls, TK_FUNCTION))  /* local function? */
         localfunc(ls);
-      else if (testnext2(ls, TK_CLASS, TK_PCLASS))
-        localclass(ls);
+      else if (testnext2(ls, TK_CLASS, TK_PCLASS)) {
+        if (ls->t.token == '=') {
+          if (luaX_lookbehind(ls).token == TK_CLASS && ls->getKeywordState(TK_CLASS) == KS_ENABLED_BY_PLUTO_UNINFORMED) {
+            luaX_prev(ls);
+            disablekeyword(ls, TK_CLASS);
+            ls->setKeywordState(TK_CLASS, KS_DISABLED_BY_PLUTO_INFORMED);
+            luaX_setpos(ls, luaX_getpos(ls));  /* update ls->t */
+            localstat(ls);
+          }
+          else {
+            throwerr(ls, "expected a class name, found '='", "'class' has a different meaning in Pluto, but you can disable this: https://pluto.do/compat");
+          }
+        }
+        else {
+          localclass(ls);
+        }
+      }
       else
         localstat(ls);
       break;
@@ -5674,24 +5702,42 @@ LClosure *luaY_parser (lua_State *L, LexState& lexstate, ZIO *z, Mbuffer *buff,
   lexstate.dyd = dyd;
   dyd->actvar.n = dyd->gt.n = dyd->label.n = 0;
   luaX_setinput(L, &lexstate, z, funcstate.f->source, firstchar);
-  if (L->l_G->compatible_switch)
-    disablekeyword(&lexstate, TK_SWITCH, true);
-  if (L->l_G->compatible_continue)
-    disablekeyword(&lexstate, TK_CONTINUE, true);
-  if (L->l_G->compatible_enum)
-    disablekeyword(&lexstate, TK_ENUM, true);
-  if (L->l_G->compatible_new)
-    disablekeyword(&lexstate, TK_NEW, true);
-  if (L->l_G->compatible_class)
-    disablekeyword(&lexstate, TK_CLASS, true);
-  if (L->l_G->compatible_parent)
-    disablekeyword(&lexstate, TK_PARENT, true);
-  if (L->l_G->compatible_export)
-    disablekeyword(&lexstate, TK_EXPORT, true);
-  if (L->l_G->compatible_try)
-    disablekeyword(&lexstate, TK_TRY, true);
-  if (L->l_G->compatible_catch)
-    disablekeyword(&lexstate, TK_CATCH, true);
+  if (L->l_G->compatible_switch) {
+    disablekeyword(&lexstate, TK_SWITCH);
+    lexstate.setKeywordState(TK_SWITCH, KS_DISABLED_BY_ENV);
+  }
+  if (L->l_G->compatible_continue) {
+    disablekeyword(&lexstate, TK_CONTINUE);
+    lexstate.setKeywordState(TK_CONTINUE, KS_DISABLED_BY_ENV);
+  }
+  if (L->l_G->compatible_enum) {
+    disablekeyword(&lexstate, TK_ENUM);
+    lexstate.setKeywordState(TK_ENUM, KS_DISABLED_BY_ENV);
+  }
+  if (L->l_G->compatible_new) {
+    disablekeyword(&lexstate, TK_NEW);
+    lexstate.setKeywordState(TK_NEW, KS_DISABLED_BY_ENV);
+  }
+  if (L->l_G->compatible_class) {
+    disablekeyword(&lexstate, TK_CLASS);
+    lexstate.setKeywordState(TK_CLASS, KS_DISABLED_BY_ENV);
+  }
+  if (L->l_G->compatible_parent) {
+    disablekeyword(&lexstate, TK_PARENT);
+    lexstate.setKeywordState(TK_PARENT, KS_DISABLED_BY_ENV);
+  }
+  if (L->l_G->compatible_export) {
+    disablekeyword(&lexstate, TK_EXPORT);
+    lexstate.setKeywordState(TK_EXPORT, KS_DISABLED_BY_ENV);
+  }
+  if (L->l_G->compatible_try) {
+    disablekeyword(&lexstate, TK_TRY);
+    lexstate.setKeywordState(TK_TRY, KS_DISABLED_BY_ENV);
+  }
+  if (L->l_G->compatible_catch) {
+    disablekeyword(&lexstate, TK_CATCH);
+    lexstate.setKeywordState(TK_CATCH, KS_DISABLED_BY_ENV);
+  }
 #ifndef PLUTO_USE_LET
   disablekeyword(&lexstate, TK_LET);
 #endif

--- a/src/lstate.cpp
+++ b/src/lstate.cpp
@@ -414,34 +414,62 @@ LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud) {
   setgcparam(g->genmajormul, LUAI_GENMAJORMUL);
   g->genminormul = LUAI_GENMINORMUL;
   for (i=0; i < LUA_NUMTAGS; i++) g->mt[i] = NULL;
-  g->setCompatibilityMode(false);
+
 #ifdef PLUTO_COMPATIBLE_SWITCH
-  g->compatible_switch = true;
+  g->have_preference_switch = true;
+  g->preference_switch = false;
+#else
+  g->have_preference_switch = false;
 #endif
 #ifdef PLUTO_COMPATIBLE_CONTINUE
-  g->compatible_continue = true;
+  g->have_preference_continue = true;
+  g->preference_continue = false;
+#else
+  g->have_preference_continue = false;
 #endif
 #ifdef PLUTO_COMPATIBLE_ENUM
-  g->compatible_enum = true;
+  g->have_preference_enum = true;
+  g->preference_enum = false;
+#else
+  g->have_preference_enum = false;
 #endif
 #ifdef PLUTO_COMPATIBLE_NEW
-  g->compatible_new = true;
+  g->have_preference_new = true;
+  g->preference_new = false;
+#else
+  g->have_preference_new = false;
 #endif
 #ifdef PLUTO_COMPATIBLE_CLASS
-  g->compatible_class = true;
+  g->have_preference_class = true;
+  g->preference_class = false;
+#else
+  g->have_preference_class = false;
 #endif
 #ifdef PLUTO_COMPATIBLE_PARENT
-  g->compatible_parent = true;
+  g->have_preference_parent = true;
+  g->preference_parent = false;
+#else
+  g->have_preference_parent = false;
 #endif
 #ifdef PLUTO_COMPATIBLE_EXPORT
-  g->compatible_export = true;
+  g->have_preference_export = true;
+  g->preference_export = false;
+#else
+  g->have_preference_export = false;
 #endif
 #ifdef PLUTO_COMPATIBLE_TRY
-  g->compatible_try = true;
+  g->have_preference_try = true;
+  g->preference_try = false;
+#else
+  g->have_preference_try = false;
 #endif
 #ifdef PLUTO_COMPATIBLE_CATCH
-  g->compatible_catch = true;
+  g->have_preference_catch = true;
+  g->preference_catch = false;
+#else
+  g->have_preference_catch = false;
 #endif
+
   g->scheduler = nullptr;
 #ifdef PLUTO_ETL_ENABLE
   g->deadline = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count() + PLUTO_ETL_NANOS;

--- a/src/lstate.h
+++ b/src/lstate.h
@@ -304,15 +304,32 @@ typedef struct global_State {
   void *ud_warn;         /* auxiliary data to 'warnf' */
 #ifndef PLUTO_LUA_LINKABLE
   void* user_data;  /* a pointer to data you, the user, would like to specify */
-  bool compatible_switch : 1;
-  bool compatible_continue : 1;
-  bool compatible_enum : 1;
-  bool compatible_new : 1;
-  bool compatible_class : 1;
-  bool compatible_parent : 1;
-  bool compatible_export : 1;
-  bool compatible_try : 1;
-  bool compatible_catch : 1;
+
+  /*
+  ** Each non-compatible keyword has 2 bools here: "have_preference" and "preference".
+  ** "have_preference" declares that you would like to overwrite the default enable/disable state of a given keyword,
+  ** and "preference" declares if you would like it to be enabled or disabled.
+  ** For example: If have_preference_switch is true, and preference_switch is false, the 'switch' keyword will be disabled.
+  */
+  bool have_preference_switch : 1;
+  bool preference_switch : 1;
+  bool have_preference_continue : 1;
+  bool preference_continue : 1;
+  bool have_preference_enum : 1;
+  bool preference_enum : 1;
+  bool have_preference_new : 1;
+  bool preference_new : 1;
+  bool have_preference_class : 1;
+  bool preference_class : 1;
+  bool have_preference_parent : 1;
+  bool preference_parent : 1;
+  bool have_preference_export : 1;
+  bool preference_export : 1;
+  bool have_preference_try : 1;
+  bool preference_try : 1;
+  bool have_preference_catch : 1;
+  bool preference_catch : 1;
+
   void* scheduler;  /* internal use only; do not use this in your own code. */
 #endif
 #ifdef PLUTO_ETL_ENABLE
@@ -323,15 +340,24 @@ typedef struct global_State {
 #endif
 
   void setCompatibilityMode(bool b) noexcept {
-    compatible_switch = b;
-    compatible_continue = b;
-    compatible_enum = b;
-    compatible_new = b;
-    compatible_class = b;
-    compatible_parent = b;
-    compatible_export = b;
-    compatible_try = b;
-    compatible_catch = b;
+    have_preference_switch = true;
+    preference_switch = !b;
+    have_preference_continue = true;
+    preference_continue = !b;
+    have_preference_enum = true;
+    preference_enum = !b;
+    have_preference_new = true;
+    preference_new = !b;
+    have_preference_class = true;
+    preference_class = !b;
+    have_preference_parent = true;
+    preference_parent = !b;
+    have_preference_export = true;
+    preference_export = !b;
+    have_preference_try = true;
+    preference_try = !b;
+    have_preference_catch = true;
+    preference_catch = !b;
   }
 } global_State;
 

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -651,7 +651,9 @@ static int pmain (lua_State *L) {
     lua_pushboolean(L, 1);  /* signal for libraries to ignore env. vars. */
     lua_setfield(L, LUA_REGISTRYINDEX, "LUA_NOENV");
   }
-  L->l_G->setCompatibilityMode(args & has_c);
+  if (args & has_c) {
+    L->l_G->setCompatibilityMode(true);
+  }
   luaL_openlibs(L);  /* open standard libraries */
   createargtable(L, argv, argc, script);  /* create table 'arg' */
   lua_gc(L, LUA_GCRESTART);  /* start GC... */

--- a/src/luac.cpp
+++ b/src/luac.cpp
@@ -184,7 +184,9 @@ static int pmain(lua_State* L)
  int i;
  tmname=G(L)->tmname;
  if (!lua_checkstack(L,argc)) fatal("too many input files");
- L->l_G->setCompatibilityMode(compat);
+ if (compat) {
+   L->l_G->setCompatibilityMode(compat);
+ }
  for (i=0; i<argc; i++)
  {
   const char* filename=IS("-") ? NULL : argv[i];


### PR DESCRIPTION
Also specialized error message for this case:
```lua
local enum = {}

enum begin end
```
```
pluto: syntax error: basic.pluto:3: syntax error near 'begin'
    3 | enum begin end
      | ^^^^^^^^^^^^^^ here: 'enum' was not recognized as a statement because it was previously used as an identifier
```