### PR TITLE
Allow usage of walrus operator in unconditional subexpressions

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2799,7 +2799,7 @@ static void primaryexp (LexState *ls, expdesc *v, int flags = 0) {
     const bool is_overridable = ls->t.IsOverridable();
     TString *varname = str_checkname(ls, N_RESERVED_NON_VALUE | N_OVERRIDABLE);
     if (gett(ls) == TK_WALRUS) {
-      if (!(flags & E_WALRUS))
+      if (!(flags & E_WALRUS) || ls->fs->freereg != luaY_nvarstack(ls->fs))
         throwerr(ls, "':=' is not allowed in this context", "unexpected ':='");
       luaX_next(ls);
       new_localvar(ls, varname);

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2112,6 +2112,32 @@ do -- Local can be used for subsequent binary operators
         assert(a == 0)
     end
 end
+do
+    local class Obj
+        function isValid()
+            return true
+        end
+    end
+
+    local function getobj()
+        return new Obj()
+    end
+
+    if (inst := getobj()):isValid() then
+        print(inst)
+    end
+end
+do
+    local function getvalue()
+        return 0
+    end
+
+    local val = 0
+
+    if val >= 0 and val == (cur := getvalue()) then
+        print(cur)
+    end
+end
 
 print "Testing for-as loop."
 do

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2052,6 +2052,11 @@ do
         error()
     end
 
+    if (walrusvar := 1) ~= 1 then
+    else
+        assert(walrusvar == 1)
+    end
+
     -- Complex Context: Walrus in function body of a lambda function that is passed an argument
     local function executeFunc(f)
         f()
@@ -2112,7 +2117,7 @@ do -- Local can be used for subsequent binary operators
         assert(a == 0)
     end
 end
-do
+do -- Method calls as well
     local class Obj
         function isValid()
             return true
@@ -2127,7 +2132,7 @@ do
         print(inst)
     end
 end
-do
+do -- Can be used in subexpressions
     local function getvalue()
         return 0
     end
@@ -2136,6 +2141,12 @@ do
 
     if val >= 0 and val == (cur := getvalue()) then
         print(cur)
+    end
+end
+do -- But scope may be cut short by conditional subexpressions
+    if false and walrusvar := 1 then
+    else
+        assert(walrusvar == nil)
     end
 end
 


### PR DESCRIPTION
Fixes #815, fixes #816. Doesn't seem to make any regressions with regards to #776.