### PR TITLE
Improve try catch

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1181,9 +1181,7 @@ static void open_func (LexState *ls, FuncState *fs, BlockCnt *bl) {
   fs->nactvar = 0;
   fs->needclose = 0;
   fs->istrybody = 0;
-  fs->hadnoargret = 0;
-  fs->hadsingleargret = 0;
-  fs->hadmultiargret = 0;
+  fs->seenrets = 0;
   fs->firstlocal = ls->dyd->actvar.n;
   fs->firstlabel = ls->dyd->label.n;
   fs->bl = NULL;
@@ -1287,7 +1285,7 @@ static void statlist (LexState *ls, TypeHint *prop = nullptr, bool no_ret_implie
       ++i;
       return true;
     });
-    ls->fs->hadsingleargret = 1;
+    ls->fs->seenrets = 1<<1;
     // TODO: Handle in try / catch block
     luaK_ret(ls->fs, luaK_exp2anyreg(ls->fs, &t), 1);
     leavelevel(ls);
@@ -2226,7 +2224,7 @@ static void lambdabody (LexState *ls, expdesc *e, int line, TypeDesc *funcdesc =
   else {
     ls->pushContext(PARCTX_LAMBDA_BODY);
     expr(ls, e, &retprop);
-    ls->fs->hadsingleargret = 1;
+    ls->fs->seenrets |= 1<<1;
     luaK_ret(&new_fs, luaK_exp2anyreg(&new_fs, e), 1);
     ls->popContext(PARCTX_LAMBDA_BODY);
   }
@@ -4686,11 +4684,12 @@ static void retstat (LexState *ls, TypeHint *prop) {
   expdesc e;
   int nret;  /* number of values being returned */
   int first = luaY_nvarstack(fs);  /* first slot to be returned */
+  int startpc = fs->pc;
+  int endpc = -1;
   if (block_follow(ls, 1) || ls->t.token == ';'
     || ls->t.token == TK_CASE || ls->t.token == TK_DEFAULT
   ) {
     nret = 0;  /* return no values */
-    fs->hadnoargret = 1;
     if (prop) prop->emplaceTypeDesc(VT_VOID);
   }
   else {
@@ -4702,12 +4701,13 @@ static void retstat (LexState *ls, TypeHint *prop) {
       luaK_indexed(ls->fs, &e, &key);
       luaK_exp2nextreg(ls->fs, &e);
       lua_assert(first == e.u.reg);
+      endpc = fs->pc-1;
+      lua_assert(endpc >= startpc);
     }
     nret = explist(ls, &e, prop);  /* optional return values */
     if (prop && prop->empty())
       prop->emplaceTypeDesc(VT_DUNNO);  /* we are returning something, but we don't know what. (this is needed for trystat.) */
     if (hasmultret(e.k)) {
-      fs->hadmultiargret = 1;
       luaK_setmultret(fs, &e);
       if (e.k == VCALL && nret == 1 && !fs->bl->insidetbc && !fs->istrybody) {  /* tail call? */
         SET_OPCODE(getinstruction(fs,&e), OP_TAILCALL);
@@ -4716,8 +4716,6 @@ static void retstat (LexState *ls, TypeHint *prop) {
       nret = LUA_MULTRET;  /* return all values */
     }
     else {
-      if (nret == 1) fs->hadsingleargret = 1;
-      else fs->hadmultiargret = 1;
       if (nret == 1 && !fs->istrybody) /* only one single value? */
         first = luaK_exp2anyreg(fs, &e);  /* can use original slot */
       else {  /* values must go to the top of the stack */
@@ -4726,20 +4724,25 @@ static void retstat (LexState *ls, TypeHint *prop) {
       }
     }
   }
+  fs->seenrets |= 1 << (nret >= 0 && nret <= 3 ? nret : 3);
   if (fs->istrybody) {
     if (nret == 0) {
       init_exp(&e, VKINT, 0);
       e.u.ival = 0;
       first = luaK_exp2anyreg(fs, &e);  /* can use original slot */
-    } else if (nret == 1) {
-      // TODO: Optimize single arg return
-      luaK_codeABC(ls->fs, OP_CALL, first, nret + 1, 2);
-      ls->fs->freereg = first + 1;
+      nret = 1;
+    } else if (nret == 1 || nret == 2) {
+      fs->f->code[endpc] = CREATE_ABx(OP_LOADI, first, nret + OFFSET_sBx);
+      while (startpc<endpc) {
+        fs->f->code[startpc] = CREATE_sJ(OP_JMP, (endpc-startpc-1) + OFFSET_sJ, 0);
+        startpc++;
+      }
+      nret++;
     } else {
       luaK_codeABC(ls->fs, OP_CALL, first, nret + 1, 2);
       ls->fs->freereg = first + 1;
+      nret = 1;
     }
-    nret = 1;
   }
   luaK_ret(fs, first, nret);
   testnext(ls, ';');  /* skip optional semicolon */
@@ -4918,7 +4921,7 @@ static void trystat (LexState *ls) {
   expdesc ex;
   FuncState new_fs;
   BlockCnt bl;
-  int exitjump;
+  int exitjump = NO_JUMP;
 
   enterblock(ls->fs, &trybl, BlockType::BT_DEFAULT);
 
@@ -4926,26 +4929,25 @@ static void trystat (LexState *ls) {
   luaX_next(ls);
   const bool vararg = ls->fs->f->is_vararg;
 
-  /* local (try status), (try result) = */
-  const auto status_vidx = new_localvarliteral(ls, "(try status)");
-  const auto result_vidx = new_localvarliteral(ls, "(try result)");
+  /* temp (try status), (try result), (try result2), (try result3) = */
+  const auto status_reg = ls->fs->freereg;
+  const auto result_reg = ls->fs->freereg+1;
 
-  /* local (try status), (try result) = pcall */
+  /* temp (try status), (try result), (try result2), (try result3) = pcall */
   singlevar(ls, &ex, luaX_newliteral(ls, "pcall"));
   luaK_exp2nextreg(ls->fs, &ex);
-  auto base = ex.u.reg;
 
-  /* local (try status), (try result) = pcall(function() */
+  /* temp (try status), (try result), (try result2), (try result3) = pcall(function() */
   new_fs.f = addprototype(ls);
   new_fs.f->linedefined = ls->getLineNumber();
   open_func(ls, &new_fs, &bl);
   new_fs.istrybody = 1;
   if (vararg) {
-    /* local (try status), (try result) = pcall(function(...) */
+    /* temp (try status), (try result), (try result2), (try result3) = pcall(function(...) */
     setvararg(&new_fs, 0);
   }
 
-  /* local (try status), (try result) = pcall(function(...) STATLIST */
+  /* temp (try status), (try result), (try result2), (try result3) = pcall(function(...) STATLIST */
   TypeHint prop{};
   statlist(ls, &prop);
 
@@ -4957,7 +4959,7 @@ static void trystat (LexState *ls) {
     removevars(&new_fs, bl.nactvar);  /* remove function locals */
     lua_assert(bl.nactvar == new_fs.nactvar);  /* no variables should remain */
     /* correct pending gotos to current block */
-    int id = 1; // Next id of the goto return status
+    int id = 3; // Next id of the goto return status
     for (int i = bl.firstgoto; i < gl->n; i++) {  /* for each pending goto */
       Labeldesc *gt = &gl->arr[i];
       int lab = luaK_getlabel(&new_fs);
@@ -4977,33 +4979,37 @@ static void trystat (LexState *ls) {
     bl.firstgoto = gl->n; /* Prevent undefgoto errors here on the close_func */
   }
 
-  /* local (try status), (try result) = pcall(function(...) STATLIST end */
+  /* temp (try status), (try result), (try result2), (try result3) = pcall(function(...) STATLIST end */
   new_fs.f->lastlinedefined = ls->getLineNumber();
   codeclosure(ls, &ex);
   close_func(ls);
   luaK_exp2nextreg(ls->fs, &ex);
-  lua_assert(base+1 == ex.u.reg);
+  lua_assert(status_reg+1 == ex.u.reg);
 
   if (vararg) {
-    /* local (try status), (try result) = pcall(function(...) STATLIST end, ... */
+    /* temp (try status), (try result), (try result2), (try result3) = pcall(function(...) STATLIST end, ... */
     init_exp(&ex, VVARARG, luaK_codeABC(ls->fs, OP_VARARG, 0, 0, 1));
     luaK_setmultret(ls->fs, &ex);
   }
 
-  /* local (try status), (try result) = pcall(function(...) STATLIST end, ...) */
-  init_exp(&ex, VCALL, luaK_codeABC(ls->fs, OP_CALL, base, (vararg ? LUA_MULTRET : 1) + 1, 2));
-  ls->fs->freereg = base + 1;
+  /* temp (try status), (try result), (try result2), (try result3) = pcall(function(...) STATLIST end, ...) */
+  init_exp(&ex, VCALL, luaK_codeABC(ls->fs, OP_CALL, status_reg, (vararg ? LUA_MULTRET : 1) + 1, 2));
+  ls->fs->freereg = status_reg+1;
 
-  adjust_assign(ls, 2, 1, &ex);
-  adjustlocalvars(ls, 2);
+  int num_out = new_fs.seenrets & (1<<2) ? 4 : new_fs.seenrets & (1<<1) ? 3 : 2;
+  adjust_assign(ls, num_out, 1, &ex);
+  lua_assert(status_reg+num_out == ls->fs->freereg);
 
   if (!testnext(ls, TK_CATCH))
     check_match(ls, TK_PCATCH, TK_PTRY, line);
 
-  /* if (try status) then */
-  init_var(ls->fs, &ex, status_vidx);
+  auto old_pin = ls->fs->pinnedreg;
 
-  if (trybl.firstgoto == gl->n && !new_fs.hadsingleargret && !new_fs.hadmultiargret && !new_fs.hadnoargret) {
+  /* if not (try status) then jump to catch block */
+  ls->fs->pinnedreg = status_reg;
+  init_exp(&ex, VNONRELOC, status_reg);
+
+  if (trybl.firstgoto == gl->n && !new_fs.seenrets) {
     /* Simple case */
     /* Try body with only a falltrough case */
     /* Just jump over the catch block if there is no error */
@@ -5016,19 +5022,20 @@ static void trystat (LexState *ls) {
     luaK_goiftrue(ls->fs, &ex);
     int skip = ex.f;
 
-    /* Jump to end of try/catch if there is no error */
-    init_var(ls->fs, &ex, result_vidx);
+    /* Jump to end of try/catch in case of falltrough */
+    ls->fs->pinnedreg = result_reg;
+    init_exp(&ex, VNONRELOC, result_reg);
     luaK_goiftrue(ls->fs, &ex);
     exitjump = ex.f;
 
     /* For every goto from the try body make a if case and update the jump */
-    int id = 1;
+    int id = 3;
     int j = trybl.firstgoto;
     for (int i = trybl.firstgoto; i < gl->n; i++) {
       Labeldesc *gt = &gl->arr[i];
       Labeldesc *lb = gt->special ? 0 : findlabel(ls, (TString*)gt->name);
       if (gt->pc != NO_JUMP) {
-        init_var(ls->fs, &ex, result_vidx);
+        init_exp(&ex, VNONRELOC, result_reg);
         test_eqi(ls, &ex, id++, OPR_EQ);
 
         if (lb) {  /* found a label */
@@ -5062,33 +5069,34 @@ static void trystat (LexState *ls) {
     gl->n = j;
 
     /* Update return status */
-    ls->fs->hadsingleargret |= new_fs.hadsingleargret;
-    ls->fs->hadmultiargret |= new_fs.hadmultiargret;
-    ls->fs->hadnoargret |= new_fs.hadnoargret;
+    ls->fs->seenrets |= new_fs.seenrets;
 
     if (ls->fs->istrybody) {
       /* We are ourselves in a try body */
-      if (new_fs.hadnoargret || new_fs.hadsingleargret || new_fs.hadmultiargret) {
+      if (new_fs.seenrets) {
         /* Just return the result as is */
-        init_var(ls->fs, &ex, result_vidx);
-        luaK_exp2anyreg(ls->fs, &ex);
-        luaK_ret(ls->fs, ex.u.reg, 1);
+        luaK_ret(ls->fs, result_reg, num_out-1);
       }
     } else {
-      if (new_fs.hadnoargret) {
-        /* In the try body was a return without arguments */
-        ex.f = NO_JUMP;
-        if (new_fs.hadsingleargret || new_fs.hadmultiargret) {
-          init_var(ls->fs, &ex, result_vidx);
-          test_eqi(ls, &ex, 0, OPR_EQ);
-          luaK_goiftrue(ls->fs, &ex);
+      for (int i=0; i<3; i++) {
+        /* Add specialized returns for specific numbers */
+        /* This is required for the correct number of returns */
+        if (new_fs.seenrets & (1<<i)) {
+          ex.f = NO_JUMP;
+          if (new_fs.seenrets >> (i+1)) {
+            init_exp(&ex, VNONRELOC, result_reg);
+            test_eqi(ls, &ex, i, OPR_EQ);
+            luaK_goiftrue(ls->fs, &ex);
+          }
+          luaK_ret(ls->fs, result_reg+1, i);
+          luaK_patchtohere(ls->fs, ex.f);
         }
-        luaK_ret(ls->fs, luaY_nvarstack(ls->fs), 0);
-        luaK_patchtohere(ls->fs, ex.f);
       }
 
-      if (new_fs.hadsingleargret || new_fs.hadmultiargret) {
-        /* In the try body was a return with one or more returns */
+      if (new_fs.seenrets & (1<<3)) {
+        /* In the try body was a return with more then two returns */
+
+        ls->fs->freereg = status_reg+2;
 
         /* table.unpack */
         expdesc key;
@@ -5096,39 +5104,35 @@ static void trystat (LexState *ls) {
         luaK_exp2anyregup(ls->fs, &ex);
         codestring(&key, luaX_newliteral(ls, "unpack"));
         luaK_indexed(ls->fs, &ex, &key);
-        luaK_exp2nextreg(ls->fs, &ex);
+        luaK_exp2reg(ls->fs, &ex, status_reg);
         lua_assert(ex.k == VNONRELOC);
-        base = ex.u.reg;
 
-        /* table.unpack(results */
-        init_var(ls->fs, &ex, result_vidx);
-        luaK_exp2nextreg(ls->fs, &ex);
-        lua_assert(base+1 == ex.u.reg);
+        /* results is already in result_reg == status_reg+1 */
 
         /* table.unpack(results, 1 */
         init_exp(&ex, VKINT, 0);
         ex.u.ival = 1;
         luaK_exp2nextreg(ls->fs, &ex);
-        lua_assert(base+2 == ex.u.reg);
+        lua_assert(status_reg+2 == ex.u.reg);
 
         /* table.unpack(results, 1, results.n */
-        init_var(ls->fs, &ex, result_vidx);
+        init_exp(&ex, VNONRELOC, result_reg);
         codestring(&key, luaX_newliteral(ls, "n"));
         luaK_indexed(ls->fs, &ex, &key);
         luaK_exp2nextreg(ls->fs, &ex);
-        lua_assert(base+3 == ex.u.reg);
+        lua_assert(status_reg+3 == ex.u.reg);
 
         /* table.unpack(results, 1, results.n) */
-        luaK_codeABC(ls->fs, OP_CALL, base, 4 /* 3 params */, LUA_MULTRET + 1);
-        luaK_ret(ls->fs, base, LUA_MULTRET);  /* final return */
-        ls->fs->freereg = base;
+        luaK_codeABC(ls->fs, trybl.insidetbc ? OP_CALL : OP_TAILCALL, status_reg, 4 /* 3 params */, LUA_MULTRET + 1);
+        luaK_ret(ls->fs, status_reg, LUA_MULTRET);
       }
     }
 
     luaK_patchtohere(ls->fs, skip);
   }
 
-  enterblock(ls->fs, &bl, BlockType::BT_DEFAULT);
+  ls->fs->freereg = status_reg+2;
+  ls->fs->pinnedreg = old_pin;
 
   /* local (e) */
   new_localvar(ls, str_checkname(ls, N_OVERRIDABLE));
@@ -5137,9 +5141,14 @@ static void trystat (LexState *ls) {
   checknext(ls, TK_THEN);
 
   /* local (e) = (try result) */
-  init_var(ls->fs, &ex, result_vidx);
-  adjust_assign(ls, 1, 1, &ex);
+  init_exp(&ex, VNONRELOC, result_reg);
+  luaK_exp2reg(ls->fs, &ex, status_reg);
+  lua_assert(status_reg == luaY_nvarstack(ls->fs));
+  lua_assert(status_reg+1 == ls->fs->freereg);
   adjustlocalvars(ls, 1);
+
+  enterblock(ls->fs, &bl, BlockType::BT_DEFAULT);
+  bl.nactvar--; /* Move e into this block */
 
   statlist(ls);
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4964,9 +4964,9 @@ static void trystat (LexState *ls) {
       if (gt->pc != NO_JUMP) { /* Needs patching up */
         luaK_patchlist(&new_fs, gt->pc, lab);
         for (int j = i + 1; j < gl->n; j++) { /* Look for other gotos with the same name and patch them together */
-          if (samelabelnames(&gl->arr[i], gt)) {
-            luaK_patchlist(&new_fs, gt->pc, lab);
-            gt->pc = NO_JUMP; /* This goto will also later be found, make sure it is later skipped but reamins in this list */
+          if (samelabelnames(&gl->arr[j], gt)) {
+            luaK_patchlist(&new_fs, gl->arr[j].pc, lab);
+            gl->arr[j].pc = NO_JUMP; /* This goto will also later be found, make sure it is later skipped but reamins in this list */
           }
         }
         ret_int(&new_fs, id++); /* Return the goto status */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -1277,6 +1277,11 @@ static void statlist (LexState *ls, TypeHint *prop = nullptr, bool no_ret_implie
     enterlevel(ls);
     size_t i = 0;
     expdesc t;
+    if (ls->fs->istrybody) {
+      init_exp(&t, VKINT, 0);
+      t.u.ival = 1;
+      luaK_exp2nextreg(ls->fs, &t);
+    }
     newtable(ls, &t, [ls, &i](expdesc *k, expdesc *v) {
       if (i == ls->fs->bl->export_symbols.size())
         return false;
@@ -1286,8 +1291,7 @@ static void statlist (LexState *ls, TypeHint *prop = nullptr, bool no_ret_implie
       return true;
     });
     ls->fs->seenrets = 1<<1;
-    // TODO: Handle in try / catch block
-    luaK_ret(ls->fs, luaK_exp2anyreg(ls->fs, &t), 1);
+    luaK_ret(ls->fs, luaK_exp2anyreg(ls->fs, &t)-ls->fs->istrybody, 1+ls->fs->istrybody);
     leavelevel(ls);
     ls->fs->bl->export_symbols.clear();
   }

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -405,7 +405,11 @@ typedef struct FuncState {
   lu_byte nups;  /* number of upvalues */
   lu_byte freereg;  /* first free register */
   lu_byte iwthabs;  /* instructions issued since last absolute line info */
-  lu_byte needclose;  /* function needs to close upvalues when returning */
+  lu_byte needclose : 1;  /* function needs to close upvalues when returning */
+  lu_byte istrybody : 1; /* This is a function handling the try body */
+  lu_byte hadnoargret : 1; /* This function had a return without arguments */
+  lu_byte hadsingleargret : 1; /* This function had a return with a single argument */
+  lu_byte hadmultiargret : 1; /* This function had a return with multiarg return */
   short pinnedreg;  /* [Pluto] index of register that may not be free'd or -1 */
 } FuncState;
 

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -407,9 +407,7 @@ typedef struct FuncState {
   lu_byte iwthabs;  /* instructions issued since last absolute line info */
   lu_byte needclose : 1;  /* function needs to close upvalues when returning */
   lu_byte istrybody : 1; /* This is a function handling the try body */
-  lu_byte hadnoargret : 1; /* This function had a return without arguments */
-  lu_byte hadsingleargret : 1; /* This function had a return with a single argument */
-  lu_byte hadmultiargret : 1; /* This function had a return with multiarg return */
+  lu_byte seenrets : 4; /* Type of returns the function has seen */
   short pinnedreg;  /* [Pluto] index of register that may not be free'd or -1 */
 } FuncState;
 

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2888,6 +2888,17 @@ do
     assert(reteq(26, nil, nil)(testtry(26)))
     assert(reteq(26, 4, 4)(testtry(26, 4)))
 end
+do
+    -- Export in try body
+    local function f()
+        try
+            export function a() end
+        catch e then
+        end
+    end
+
+    assert(type(f().a)=='function')
+end
 
 print "Testing compatibility."
 do

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2794,6 +2794,8 @@ do
                     if state == 8 then state = -1 continue 1 end
                     if state == 9 then state = -1 continue 2 end
                     if state == 10 then goto b end
+                    if state == 27 then return 27 end
+                    if state == 28 then return 28, p, p end
                     if state ~= 11 then
                         try
                             if state == 12 then return end
@@ -2808,6 +2810,8 @@ do
                             if state == 21 then state = -1 continue 2 end
                             if state == 22 then goto b end
                             if state == 23 then goto c end
+                            if state == 25 then return 25 end
+                            if state == 26 then return 26, p, p end
                         catch ee then
                             return 12, ee
                         end
@@ -2859,6 +2863,9 @@ do
     assert(reteq(10)(testtry(9)))
     assert(reteq(11)(testtry(10)))
     assert(reteq(4)(testtry(11)))
+    assert(reteq(27)(testtry(27)))
+    assert(reteq(28, nil, nil)(testtry(28)))
+    assert(reteq(28, 4, 4)(testtry(28, 4)))
 
     assert(select('#', testtry(12)) == 0)
     assert(reteq(13, 2)(testtry(13, ||->2)))
@@ -2877,6 +2884,9 @@ do
     assert(reteq(11)(testtry(22)))
     assert(reteq(15)(testtry(23)))
     assert(reteq(4)(testtry(24)))
+    assert(reteq(25)(testtry(25)))
+    assert(reteq(26, nil, nil)(testtry(26)))
+    assert(reteq(26, 4, 4)(testtry(26, 4)))
 end
 
 print "Testing compatibility."

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2769,6 +2769,115 @@ do
     end
     assert(f() == true)
 end
+do
+    -- Test gotos, break and continues in try body as well as nested try/catch blocks
+    local function testtry(state, p)
+        goto start
+        ::b::
+        do
+            return 11
+        end
+        ::start::
+        while true do
+            if state < 0 then return 10 end
+            while true do
+                if state < 0 then return 10 + state end
+                try
+                    if state == 0 then return end
+                    if state == 1 then return 1, p() end
+                    if state == 2 then return 2, p end
+                    if state == 3 then break end
+                    if state == 4 then break 1 end
+                    if state == 5 then break 2 end
+                    if state == 6 then goto e end
+                    if state == 7 then state = -2 continue end
+                    if state == 8 then state = -1 continue 1 end
+                    if state == 9 then state = -1 continue 2 end
+                    if state == 10 then goto b end
+                    if state ~= 11 then
+                        try
+                            if state == 12 then return end
+                            if state == 13 then return 13, p() end
+                            if state == 14 then return 14, p end
+                            if state == 15 then break end
+                            if state == 16 then break 1 end
+                            if state == 17 then break 2 end
+                            if state == 18 then goto e end
+                            if state == 19 then state = -2 continue end
+                            if state == 20 then state = -1 continue 1 end
+                            if state == 21 then state = -1 continue 2 end
+                            if state == 22 then goto b end
+                            if state == 23 then goto c end
+                        catch ee then
+                            return 12, ee
+                        end
+                    end
+                    goto skip
+                    ::c::
+                    do return 15 end
+                    ::skip::
+                catch e then
+                    return 3, e
+                end
+                return 4
+            end
+            return 5
+        end
+        do
+            return 6
+        end
+        ::e::
+        return 7
+    end
+
+    local function reteq(...)
+        local n = select('#', ...)
+        local tab = {...}
+        return function(...)
+            if n ~= select('#', ...) then return false end
+            for i = 1, n do
+                if select(i, ...) ~= tab[i] then return false end
+            end
+            return true
+        end
+    end
+
+    assert(select('#', testtry(0)) == 0)
+    assert(reteq(1, 2)(testtry(1, ||->2)))
+    assert(reteq(1)(testtry(1, function()end)))
+    assert(reteq(1, 2, 3, 4, 5)(testtry(1, function() return 2, 3, 4, 5 end)))
+    local t = {}
+    assert(reteq(3, t)(testtry(1, ||->error(t))))
+    assert(reteq(2, nil)(testtry(2)))
+    assert(reteq(2, 4)(testtry(2, 4)))
+    assert(reteq(5)(testtry(3)))
+    assert(reteq(5)(testtry(4)))
+    assert(reteq(6)(testtry(5)))
+    assert(reteq(7)(testtry(6)))
+    assert(reteq(8)(testtry(7)))
+    assert(reteq(9)(testtry(8)))
+    assert(reteq(10)(testtry(9)))
+    assert(reteq(11)(testtry(10)))
+    assert(reteq(4)(testtry(11)))
+
+    assert(select('#', testtry(12)) == 0)
+    assert(reteq(13, 2)(testtry(13, ||->2)))
+    assert(reteq(13)(testtry(13, function()end)))
+    assert(reteq(13, 2, 3, 4, 5)(testtry(13, function() return 2, 3, 4, 5 end)))
+    assert(reteq(12, t)(testtry(13, ||->error(t))))
+    assert(reteq(14, nil)(testtry(14)))
+    assert(reteq(14, 4)(testtry(14, 4)))
+    assert(reteq(5)(testtry(15)))
+    assert(reteq(5)(testtry(16)))
+    assert(reteq(6)(testtry(17)))
+    assert(reteq(7)(testtry(18)))
+    assert(reteq(8)(testtry(19)))
+    assert(reteq(9)(testtry(20)))
+    assert(reteq(10)(testtry(21)))
+    assert(reteq(11)(testtry(22)))
+    assert(reteq(15)(testtry(23)))
+    assert(reteq(4)(testtry(24)))
+end
 
 print "Testing compatibility."
 do


### PR DESCRIPTION
Improve the try catch block.

Currently the try catch block has a bug where mixed return and fallthrough in a try block will always return, even in the fallthrough case.

Furthermore, try blocks did not allow for break, continue, and gotos to jump out of the body.

Now, the try block function will return a return type and up to two extra results for the one and two argument returns.
Some of the return types are
- `nil`: Fallthrough of the try block
- 0: Return with zero arguments
- 1: Return of the argument in the first extra result slot
- 2: Return of two arguments found in the two extra result slots
- 3...: Dynamically assigned for gotos including break & continue
- table: Return of three or more or multiple arguments packed into the table with `table.pack(...)`.