### PR TITLE
Add socket.getpeer

### DIFF
--- a/src/lsocketlib.cpp
+++ b/src/lsocketlib.cpp
@@ -174,6 +174,18 @@ static int socket_close (lua_State *L) {
   return 0;
 }
 
+static int socket_getpeer (lua_State *L) {
+  StandaloneSocket& ss = *checksocket(L, 1);
+  auto ipstr = ss.sock->peer.ip.toString();
+  if (!ss.sock->peer.ip.isV4()) {
+    ipstr.insert(0, 1, '[');
+    ipstr.push_back(']');
+  }
+  pluto_pushstring(L, std::move(ipstr));
+  lua_pushinteger(L, ss.sock->peer.getPort());
+  return 2;
+}
+
 struct Listener {
   soup::Server serv;
   soup::ServerService srv{ &onTunnelEstablished };
@@ -269,6 +281,7 @@ static const luaL_Reg funcs_socket[] = {
   {"unrecv", unrecv},
   {"starttls", starttls},
   {"close", socket_close},
+  {"getpeer", socket_getpeer},
   {"listen", l_listen},
   {NULL, NULL}
 };


### PR DESCRIPTION
```lua
local { scheduler, socket } = require "*"

local sched = new scheduler()
socket.bind(sched, 80, |s| -> do
    local ip, port = s:getpeer()
    local content = ip..":"..port
    s:send("HTTP/1.1 200 OK\r\nConnection: Close\r\nContent-Length: "..#content.."\r\n\r\n"..content)
end)
sched:run()
```