### PR TITLE
Require $define statement to have a righthand side

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -135,11 +135,23 @@ const char *luaX_token2str_noq (LexState *ls, const Token& t) {
       ls->L->top.p--;
       break;
     case TK_FLT:
-      ret = luaO_pushfstring(ls->L, "%f", t.seminfo.r);
+      if (!ls->hasDoneLexerPass()) {
+        save(ls, '\0');
+        ret = luaO_pushfstring(ls->L, "%s", luaZ_buffer(ls->buff));
+      }
+      else {
+        ret = luaO_pushfstring(ls->L, "%f", t.seminfo.r);
+      }
       ls->L->top.p--;
       break;
     case TK_INT:
-      ret = luaO_pushfstring(ls->L, "%I", t.seminfo.i);
+      if (!ls->hasDoneLexerPass()) {
+        save(ls, '\0');
+        ret = luaO_pushfstring(ls->L, "%s", luaZ_buffer(ls->buff));
+      }
+      else {
+        ret = luaO_pushfstring(ls->L, "%I", t.seminfo.i);
+      }
       ls->L->top.p--;
       break;
     default:

--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -134,12 +134,20 @@ const char *luaX_token2str_noq (LexState *ls, int token) {
       ret = luaO_pushfstring(ls->L, "%s", getstr(ls->t.seminfo.ts));
       ls->L->top.p--;
       break;
-    case TK_FLT: case TK_INT:
-      save(ls, '\0');
-      ret = luaO_pushfstring(ls->L, "%s", luaZ_buffer(ls->buff));
+    case TK_FLT:
+      if (token != ls->t.token)
+        goto _default;
+      ret = luaO_pushfstring(ls->L, "%f", ls->t.seminfo.r);
+      ls->L->top.p--;
+      break;
+    case TK_INT:
+      if (token != ls->t.token)
+        goto _default;
+      ret = luaO_pushfstring(ls->L, "%I", ls->t.seminfo.i);
       ls->L->top.p--;
       break;
     default:
+    _default:
       const char *s = luaX_tokens[token - FIRST_RESERVED];
       if (token < TK_EOS) { /* fixed format (symbols and reserved words)? */
           ret = luaO_pushfstring(ls->L, "%s", s);

--- a/src/llex.h
+++ b/src/llex.h
@@ -603,6 +603,6 @@ LUAI_FUNC void luaX_setpos(LexState *ls, size_t pos);
 LUAI_FUNC int luaX_lookahead(LexState *ls);
 LUAI_FUNC const Token& luaX_lookbehind(LexState *ls);
 LUAI_FUNC l_noret luaX_syntaxerror (LexState *ls, const char *s);
-LUAI_FUNC const char *luaX_token2str (LexState *ls, int token);
-LUAI_FUNC const char *luaX_token2str_noq (LexState *ls, int token);
+LUAI_FUNC const char *luaX_token2str (LexState *ls, const Token& t);
+LUAI_FUNC const char *luaX_token2str_noq (LexState *ls, const Token& t);
 LUAI_FUNC const char *luaX_reserved2str (int token);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -237,7 +237,7 @@ static l_noret error_expected (LexState *ls, int token) {
     }
     default: {
       _default:
-      throwerr(ls, luaO_fmt(ls->L, "%s expected", luaX_token2str(ls, token)), "this is invalid syntax.");
+      throwerr(ls, luaO_fmt(ls->L, "%s expected near %s", luaX_token2str(ls, token), luaX_token2str(ls, ls->t.token)), "this is invalid syntax.");
     }
   }
 }

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4294,13 +4294,11 @@ static void constexprdefinestat (LexState *ls, int line) {
   *var->vd.hint = hint;
 
   expdesc e;
-  init_exp(&e, VNIL, 0);
-  if (testnext(ls, '=')) {
-    ls->pushContext(PARCTX_CREATE_VAR);
-    TypeHint t;
-    expr_propagate(ls, &e, t);
-    ls->popContext(PARCTX_CREATE_VAR);
-  }
+  checknext(ls, '=');
+  ls->pushContext(PARCTX_CREATE_VAR);
+  TypeHint t;
+  expr_propagate(ls, &e, t);
+  ls->popContext(PARCTX_CREATE_VAR);
   if (!luaK_exp2const(fs, &e, &var->k))
     throwerr(ls, "variable was not assigned a compile-time constant value", "expression not constant", line);
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -115,7 +115,7 @@ static l_noret throwerr (LexState *ls, const char *err, const char *here, int li
   msg->addMsg(err);
   if (ls->t.token == TK_EOS && strstr(err, "near '<eof>'") == nullptr) {  /* for 'incomplete' in REPL */
     msg->addMsg(" near ")
-       .addMsg(luaX_token2str(ls, ls->t.token));
+       .addMsg(luaX_token2str(ls, ls->t));
   }
   msg->addSrcLine(line)
      .addGenericHere(here)
@@ -195,7 +195,7 @@ static void check_for_non_portable_code (LexState *ls) {
       ls->setKeywordState(ls->t.token, KS_ENABLED_BY_PLUTO_INFORMED);
     }
     if (ls->getKeywordState(ls->t.token) == KS_ENABLED_BY_PLUTO_INFORMED || ls->getKeywordState(ls->t.token) == KS_ENABLED_BY_ENV) {  /* enabled by a means other than 'pluto_use'? */
-      throw_warn(ls, "non-portable keyword usage", luaO_fmt(ls->L, "use 'pluto_%s' instead, or 'pluto_use' this keyword: https://pluto.do/compat", luaX_token2str_noq(ls, ls->t.token)), WT_NON_PORTABLE_CODE);
+      throw_warn(ls, "non-portable keyword usage", luaO_fmt(ls->L, "use 'pluto_%s' instead, or 'pluto_use' this keyword: https://pluto.do/compat", luaX_token2str_noq(ls, ls->t)), WT_NON_PORTABLE_CODE);
       ls->L->top.p--;
     }
   }
@@ -237,7 +237,7 @@ static l_noret error_expected (LexState *ls, int token) {
     }
     default: {
       _default:
-      throwerr(ls, luaO_fmt(ls->L, "%s expected near %s", luaX_token2str(ls, token), luaX_token2str(ls, ls->t.token)), "this is invalid syntax.");
+      throwerr(ls, luaO_fmt(ls->L, "%s expected near %s", luaX_token2str(ls, token), luaX_token2str(ls, ls->t)), "this is invalid syntax.");
     }
   }
 }
@@ -399,7 +399,7 @@ static TString *str_checkname (LexState *ls, int flags = N_RESERVED_NON_VALUE) {
         luaX_setpos(ls, luaX_getpos(ls));  /* update ls->t */
         return str_checkname(ls, flags);  /* try again */
       }
-      throwerr(ls, luaO_fmt(ls->L, "expected a name, found %s", luaX_token2str(ls, ls->t.token)), luaO_fmt(ls->L, "%s has a different meaning in Pluto, but you can disable this: https://pluto.do/compat", luaX_token2str(ls, ls->t.token)));
+      throwerr(ls, luaO_fmt(ls->L, "expected a name, found %s", luaX_token2str(ls, ls->t)), luaO_fmt(ls->L, "%s has a different meaning in Pluto, but you can disable this: https://pluto.do/compat", luaX_token2str(ls, ls->t)));
     }
     error_expected(ls, TK_NAME);
   }
@@ -1626,7 +1626,7 @@ static void field (LexState *ls, ConsControl *cc, bool for_class = false) {
     }
     default: {
       if (for_class)
-        throwerr(ls, luaO_fmt(ls->L, "unexpected token: %s", luaX_token2str(ls, ls->t.token)), "expected a class member");
+        throwerr(ls, luaO_fmt(ls->L, "unexpected token: %s", luaX_token2str(ls, ls->t)), "expected a class member");
       listfield(ls, cc);
       break;
     }
@@ -2635,7 +2635,7 @@ static void const_expr (LexState *ls, expdesc *v) {
       return;
     }
     default: {
-      const char *token = luaX_token2str(ls, ls->t.token);
+      const char *token = luaX_token2str(ls, ls->t);
       throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
     }
   }
@@ -2743,7 +2743,7 @@ static void enumexp (LexState *ls, expdesc *v, TString *varname) {
       return;
     }
     default: {
-      const char *token = luaX_token2str(ls, ls->t.token);
+      const char *token = luaX_token2str(ls, ls->t);
       throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
     }
   }
@@ -2853,7 +2853,7 @@ static void primaryexp (LexState *ls, expdesc *v, int flags = 0) {
       if (ls->t.token == ')' && ls->getContext() == PARCTX_BODY) {
         throwerr(ls, "unexpected ')', expected 'end' to close function.", "missing 'end' before ')'.");
       }
-      const char *token = luaX_token2str(ls, ls->t.token);
+      const char *token = luaX_token2str(ls, ls->t);
       throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
     }
   }
@@ -4315,7 +4315,7 @@ static void constexprstat (LexState *ls, int line) {
     constexprdefinestat(ls, line);
   }
   else {
-    const char *token = luaX_token2str(ls, ls->t.token);
+    const char *token = luaX_token2str(ls, ls->t);
     throwerr(ls, luaO_fmt(ls->L, "unexpected symbol near %s", token), "unexpected symbol.");
   }
 }
@@ -4643,7 +4643,7 @@ static void exprstat (LexState *ls) {
             const auto entry = ls->uninformed_reserved.find(t);
             const auto line = entry == ls->uninformed_reserved.end() ? -1 : entry->second;
             throwerr(ls,
-              luaO_fmt(ls->L, "syntax error near %s", luaX_token2str(ls, ls->t.token)),
+              luaO_fmt(ls->L, "syntax error near %s", luaX_token2str(ls, ls->t)),
               luaO_fmt(ls->L, "%s was not recognized as a statement because it was used as an identifier on line %d", luaX_token2str(ls, t), line)
             );
           }


### PR DESCRIPTION
Coming from C/C++, this is a very obvious mistake to make, and unfortunately the error reporting for it right now is very confusing. This should hopefully be a bit better. Also fixes some longstanding issues regarding how we convert tokens to strings.

---
```lua
$define MAGIC 69
print(MAGIC)
```
```
basic.pluto:1: '=' expected near '69'
    1 | $define MAGIC 69
      | ^^^^^^^^^^^^^^^^ here: this is invalid syntax.
```
---
```lua
$define MAGIC
print(MAGIC)
```
```
basic.pluto:2: '=' expected near 'print'
    2 | print(MAGIC)
      | ^^^^^^^^^^^^ here: this is invalid syntax.
```