### PR TITLE
Disallow usage of 'or' after walrus operator has been used

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -413,6 +413,7 @@ struct LexState {
   std::unordered_map<const TString*, void*> global_props{};
   KeywordState keyword_states[END_OPTIONAL - FIRST_NON_COMPAT];
   bool nodiscard = false;
+  bool used_walrus = false;
 
   LexState() : lines{ std::string{} }, warnconfs{ WarningConfig(0) } {
     laststat = Token {};

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2160,6 +2160,10 @@ do -- But scope may be cut short by conditional subexpressions
         assert(walrusvar == nil)
     end
 end
+do -- And may not be used in 'or' expressions
+    assert(load[[if false or (a := true) then print(a) end]] == nil)
+    assert(load[[if (false and (a := true)) or true then print(a) end]] == nil)
+end
 do -- Unary operators
     local function getstr()
         return "hello"


### PR DESCRIPTION
Also improves error message for the case(s) of walrus operator being mixed with 'or'.