### PR TITLE
Improve switch time complexity for constant cases

### DIFF
--- a/src/lcode.cpp
+++ b/src/lcode.cpp
@@ -2092,3 +2092,7 @@ void luaK_invertcond (FuncState *fs, int list) {
   e.u.pc = list;
   negatecondition(fs, &e);
 }
+
+void luaK_rollback (FuncState *fs, int to) {
+  while (fs->pc > to) removelastinstruction(fs);
+}

--- a/src/lcode.h
+++ b/src/lcode.h
@@ -102,3 +102,5 @@ LUAI_FUNC l_noret luaK_semerror (LexState *ls, const char *msg);
 LUAI_FUNC void luaK_exp2reg (FuncState *fs, expdesc *e, int reg);
 LUAI_FUNC void luaK_freeexp (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_invertcond (FuncState *fs, int list);
+
+LUAI_FUNC void luaK_rollback (FuncState *fs, int to);

--- a/src/llex.h
+++ b/src/llex.h
@@ -183,6 +183,8 @@ enum WarningType : int {
   WT_UNANNOTATED_FALLTHROUGH,
   WT_DISCARDED_RETURN,
   WT_FIELD_SHADOW,
+  WT_DUPLICATED_CASE,
+  WT_NAN_CASE,
 
   NUM_WARNING_TYPES
 };
@@ -205,6 +207,8 @@ inline const char* const luaX_warnNames[] = {
   "unannotated-fallthrough",
   "discarded-return",
   "field-shadow",
+  "duplicated-case",
+  "nan-case",
 };
 static_assert(sizeof(luaX_warnNames) / sizeof(const char*) == NUM_WARNING_TYPES);
 

--- a/src/llex.h
+++ b/src/llex.h
@@ -364,16 +364,6 @@ struct BodyState {
   std::vector<size_t> fallbacks{};
 };
 
-struct SwitchCase {
-  size_t tidx;
-  int pc;
-};
-
-struct SwitchState {
-  std::vector<int> first{};
-  std::vector<SwitchCase> cases{};
-};
-
 struct LexState {
   int current;  /* current character (charint) */
   std::vector<std::string> lines;  /* A vector of all the lines processed by the lexer. */
@@ -390,6 +380,7 @@ struct LexState {
   struct Dyndata *dyd;  /* dynamic structures used by the parser */
   TString *source;  /* current source name */
   TString *envn;  /* environment variable name */
+  int switchtables = 0;
 
   bool uses_new = false;
   bool uses_extends = false;
@@ -402,7 +393,6 @@ struct LexState {
   std::stack<ClassData> classes{};
   std::stack<FuncArgsState> funcargsstates{};
   std::stack<BodyState> bodystates{};
-  std::stack<SwitchState> switchstates{};
   std::stack<std::unordered_set<TString*>> constructorfieldsets{};
   std::vector<EnumDesc> enums{};
   std::vector<void*> parse_time_allocations{};

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3303,7 +3303,7 @@ static bool switchimpl (LexState *ls, int tk, const std::function<void(LexState*
                 had_const_case = true;
                 num_consts++;
               } else {
-                dup_case = ivalue(res);
+                dup_case = (int)ivalue(res);
                 dup_case = dup_case == case_pc.size() ? -2 : case_pc[dup_case];
               }
             }
@@ -3365,7 +3365,7 @@ static bool switchimpl (LexState *ls, int tk, const std::function<void(LexState*
     luaK_patchtohere(fs, entry);
     entry = NO_JUMP;
     int average_time_linear = num_consts/2;
-    int average_time_table = luaO_ceillog2(case_pc.size()) + 4; /* Load and check cache, load value, check nil case, then do the binary search */
+    int average_time_table = luaO_ceillog2((unsigned int)case_pc.size()) + 4; /* Load and check cache, load value, check nil case, then do the binary search */
     if (average_time_linear <= average_time_table) {
       /* Not worth the effort, just do a linear scan */
       const auto line = ls->getLineNumber();
@@ -3457,7 +3457,7 @@ static bool switchimpl (LexState *ls, int tk, const std::function<void(LexState*
 
       fs->pinnedreg = ctrl.u.reg;
 
-      gendispatch(fs, &e, 0, case_pc.size()-1, case_pc);
+      gendispatch(fs, &e, 0, (int)case_pc.size() - 1, case_pc);
       luaK_freeexp(fs, &e);
       int jump = luaK_jump(fs);
       luaK_patchlist(fs, jump, case_pc[case_pc.size()-1]);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3564,7 +3564,6 @@ static void switchexpr (LexState *ls, expdesc *v) {
   int data[2] = {NO_JUMP, v->u.reg};
   bool has_default = switchimpl(ls, TK_ARROW, [](LexState *ls, void* ud) {
     auto data = reinterpret_cast<int*>(ud);
-    const auto line = ls->getLineNumber();
     const auto reg = data[1];
     expdesc cv;
     expr(ls, &cv);
@@ -3572,7 +3571,6 @@ static void switchexpr (LexState *ls, expdesc *v) {
     luaK_concat(ls->fs, &data[0], luaK_jump(ls->fs));
   }, data);
   if (!has_default) {
-    const auto line = ls->getLineNumber();
     expdesc cv;
     init_exp(&cv, VNIL, 0);
     luaK_exp2reg(ls->fs, &cv, v->u.reg);

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3315,8 +3315,9 @@ static bool switchimpl (LexState *ls, int tk, const std::function<void(LexState*
       }
       if (tk == TK_ARROW) break;
       if (gett(ls) != TK_CASE && gett(ls) != TK_DEFAULT) {
-        if (!testnext(ls, TK_FALLTHROUGH)) break;
-        if (gett(ls) == TK_END) break;
+        // if (!testnext(ls, TK_FALLTHROUGH)) break;
+        // if (gett(ls) == TK_END) break;
+        break;
       }
     }
     fs->pinnedreg = old_pinned;
@@ -3344,6 +3345,7 @@ static bool switchimpl (LexState *ls, int tk, const std::function<void(LexState*
     caselist(ls);
     fs->freereg = base_reg;
   }
+  removevars(fs, nactvar);
 
   if (case_pc.size() > 0) {
     int fallthrough = jumps_before(ls) ? NO_JUMP : luaK_jump(fs);

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -180,6 +180,9 @@ end]]
     assert_no_warn[[if false and true then
 else
 end]]
+
+    -- Duplicated case warning
+    assert_warn[[switch a do case 1: case 1: end]]
 end
 
 print "Testing assertion library."
@@ -1282,6 +1285,32 @@ do
         return switch 42 do end
     end
     assert(f() == nil)
+end
+-- Test switch speed
+do
+    local N = 2000
+    local code = "return function(val)\nswitch val do"
+    for i=1, N do
+        code = code .. "\ncase " .. i .. ".5: return " .. i
+    end
+    code = code .. "\ndefault: return -1\nend\nend"
+    local f = load(code)()
+    -- Initialize, this might take more time
+    assert(f(0) == -1)
+    local function timeout()
+        debug.sethook()
+        assert(false)
+    end
+    local function test_with_timing(val)
+        debug.sethook(timeout, '', 40)
+        local ret = f(val)
+        debug.sethook()
+        return ret
+    end
+    for i=1, N do
+        assert(test_with_timing(i+0.5) == i)
+    end
+    assert(test_with_timing(0) == -1)
 end
 
 print "Testing table freezing."


### PR DESCRIPTION
First version of an improvement to the switch statement to change the time complexity from O(n) to O(log n) (see https://github.com/PlutoLang/Pluto/issues/860).

This does currently not pass the debug tests because of the extra code generated in the main chunk.