### PR TITLE
Allow fallthrough on empty cases

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3310,7 +3310,14 @@ static void switchimpl (LexState *ls, int tk, void(*caselist)(LexState*,void*), 
 static void switchstat (LexState *ls) {
   switchimpl(ls, ':', [](LexState* ls, void*) {
     const int case_line = luaX_lookbehind(ls).line;
-    if (gett(ls) != TK_CASE && gett(ls) != TK_DEFAULT && gett(ls) != TK_END && gett(ls) != TK_FALLTHROUGH) {  /* non-empty case? */
+    if (gett(ls) == TK_CASE || gett(ls) == TK_DEFAULT || gett(ls) == TK_END) {
+      /* this case is empty, nothing to do */
+    }
+    else if (gett(ls) == TK_FALLTHROUGH) {
+      /* empty case explicitly declaring itself to be a fallthrough */
+      luaX_next(ls);
+    }
+    else {
       do {
         statement(ls);
       }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1195,6 +1195,12 @@ switch 1 do
         print("OK")
 end
 ]] == nil)
+-- Fallthrough can be used on empty cases
+switch 1 do
+    case 1:
+        --[[@fallthrough]]
+    case 2:
+end
 
 print "Testing switch expression."
 do


### PR DESCRIPTION
It's a bit strange, but there's no _logical_ reason for why it should be a parse error. Fixes #859.