### PR TITLE
Reimplement null coalescing operator in a bytecode-compatible way

### DIFF
--- a/src/lcode.h
+++ b/src/lcode.h
@@ -78,7 +78,6 @@ LUAI_FUNC void luaK_indexed (FuncState *fs, expdesc *t, expdesc *k);
 LUAI_FUNC bool luaK_isalwaysnil (LexState *ls, expdesc *e, bool jumps_are_ok = false);
 LUAI_FUNC bool luaK_isalwaystrue (LexState *ls, expdesc *e, bool jumps_are_ok = false);
 LUAI_FUNC bool luaK_isalwaysfalse (LexState *ls, expdesc *e, bool jumps_are_ok = false);
-LUAI_FUNC void luaK_goifnil (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_goiftrue (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_goiffalse (FuncState *fs, expdesc *e);
 LUAI_FUNC void luaK_storevar (FuncState *fs, expdesc *var, expdesc *e);

--- a/src/lopcodes.h
+++ b/src/lopcodes.h
@@ -179,11 +179,6 @@ enum OpMode {iABC, iABx, iAsBx, iAx, isJ};  /* basic instruction formats */
 */
 #define NO_REG		MAXARG_A
 
-/*
-** Identifier used in R(C) for OP_TESTSET, to indicate whether 'false' should be falsy.
-*/
-#define NULL_COALESCE 2
-
 
 /*
 ** R[x] - register

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3676,7 +3676,6 @@ static BinOpr subexpr (LexState *ls, expdesc *v, int limit, TypeHint *prop, int 
         else {
           if (luaK_isalwaystrue(ls, v) || luaK_isalwaysfalse(ls, v))
             throw_warn(ls, "unreachable code", "the expression before the '?\?' is never nil, hence the expression after the '?\?' is never used.", WT_UNREACHABLE_CODE);
-          throw_warn(ls, "non-portable operator usage", "this operator generates bytecode which is incompatible with Lua.", WT_NON_PORTABLE_BYTECODE);
         }
         if (prop) {
           prop->erase(VT_NIL);
@@ -3873,8 +3872,6 @@ static void restassign (LexState *ls, struct LHS_assign *lh, int nvars) {
     if (compound_op != OPR_NOBINOPR) {  /* compound operator? */
       if (l_unlikely(ls->t.seminfo.i == TK_POW))
         throw_warn(ls, "'**' is deprecated", "use '^' instead", WT_DEPRECATED);
-      if (compound_op == OPR_COAL)
-        throw_warn(ls, "non-portable operator usage", "this operator generates bytecode which is incompatible with Lua.", WT_NON_PORTABLE_BYTECODE);
       check_condition(ls, nvars == 1, "unsupported tuple assignment");
       compoundassign(ls, &lh->v, compound_op);  /* perform binop & assignment */
       return;  /* avoid default */

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -2217,32 +2217,17 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         vmDumpInit();
         vmDumpAddA();
         vmDumpAddB();
-        vmDumpAddC();
         vmDumpAdd (GETARG_k(i));
         StkId ra = RA(i);
         TValue *rb = vRB(i);
-        if (GETARG_C(i) == NULL_COALESCE) { /* R(C) is used as an identifier, as it was previously unused. */
-          if (ttisnil(rb)) {
-            pc++;
-            vmDumpOut("; null coalesce, no assignment");
-          }
-          else {
-            setobj2s(L, ra, rb);
-            donextjump(ci);
-            vmDumpOut("; null coalesce, push/assign " << stringify_tvalue(rb));
-          }
+        if (l_isfalse(rb) == GETARG_k(i)) {
+          pc++;
+          vmDumpOut("; no assignment");
         }
         else {
-          if (l_isfalse(rb) == GETARG_k(i))
-          {
-            pc++;
-            vmDumpOut("; no assignment");
-          }
-          else {
-            setobj2s(L, ra, rb);
-            donextjump(ci);
-            vmDumpOut("; push/assign " << stringify_tvalue(rb));
-          }
+          setobj2s(L, ra, rb);
+          donextjump(ci);
+          vmDumpOut("; push/assign " << stringify_tvalue(rb));
         }
         vmbreak;
       }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -617,13 +617,16 @@ do
     b = "hello"
     c = a ?? b
     assert(c == "hello")
+    assert(not (a ?? b) == false)
     a = false
     b = "hello"
     a ??= b
     assert(a == false)
+    assert(not (a ?? b) == true)
     a = nil
     a ??= b
     assert(a == "hello")
+    assert(not (a ?? b) == false)
 end
 
 print "Testing safe navigation."


### PR DESCRIPTION
I didn't particularly want to rewrite this feature, but this was just fundamentally incompatible with various assumptions Lua made, which resulted in this not working as expected with the `not` operator. Fixes #867.