### PR TITLE
Bias json.encode more towards arrays, but allow __order to explicitly declare an object

### DIFF
--- a/src/ljson.hpp
+++ b/src/ljson.hpp
@@ -38,7 +38,7 @@ static bool isIndexBasedTable(lua_State* L, int i)
 		lua_pop(L, 2);
 	}
 	lua_pop(L, 1);
-	return k != 1; // say it's not an index based table if it's empty
+	return true;
 }
 
 static soup::UniquePtr<soup::JsonNode> checkJson(lua_State* L, int i)

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1476,6 +1476,10 @@ do
         assert(t.__order[2] == "b")
         assert(t.__order[3] == "c")
     end
+
+    assert(json.encode({}) == "[]")
+    assert(json.encode({ __order = {} }) == "{}")
+    assert(json.encode(json.decode("[{},[]]", json.withorder)) == "[{},[]]")
 end
 do
     local xml = require "pluto:xml"


### PR DESCRIPTION
Currently, the semantics are not so great:
- Can't encode an empty array
- `__order` doesn't really work on an otherwise-empty table

This fixes both by adding the following semantics:
```lua
assert(json.encode({}) == "[]")
assert(json.encode({ __order = {} }) == "{}")
```