### PR TITLE
Improve string.replace

### DIFF
--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -2284,13 +2284,12 @@ static int str_truncate (lua_State *L) {
 
 static int str_replace (lua_State *L) {
   size_t pos = 0;
-  size_t oglen = 0;
   size_t sublen = 0;
   size_t newlen = 0;
 
-  std::string og = luaL_checklstring(L, 1, &oglen);
-  const std::string_view sub = luaL_checklstring(L, 2, &sublen);
-  const std::string_view new_ = luaL_checklstring(L, 3, &newlen);
+  std::string og = pluto_checkstring(L, 1);
+  const char *sub = luaL_checklstring(L, 2, &sublen);
+  const char *new_ = luaL_checklstring(L, 3, &newlen);
   const auto max_replace = luaL_optinteger(L, 4, 0);
 
   luaL_check(L, sublen == 0, "argument 'substitute' for string.replace cannot be empty");
@@ -2298,7 +2297,7 @@ static int str_replace (lua_State *L) {
 
   const bool erase = newlen == 0;
   size_t replacements = 0;
-  while ((pos = og.find(sub, pos)) != std::string::npos) {
+  while ((pos = og.find(sub, pos, sublen)) != std::string::npos) {
     if (max_replace != 0 && replacements++ == max_replace) {
       break;
     }
@@ -2307,7 +2306,7 @@ static int str_replace (lua_State *L) {
       og.erase(pos, sublen);
     }
     else {
-      og.replace(pos, sublen, new_);
+      og.replace(pos, sublen, new_, newlen);
       pos += newlen;
     }
   }

--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -26,6 +26,7 @@
 #include "lualib.h"
 
 
+#include "vendor/Soup/soup/string.hpp"
 #include "vendor/Soup/soup/urlenc.hpp"
 
 
@@ -2294,6 +2295,17 @@ static int str_replace (lua_State *L) {
 
   luaL_check(L, sublen == 0, "argument 'substitute' for string.replace cannot be empty");
   luaL_check(L, max_replace < 0, "argument 'max_replace' for string.replace cannot be negative");
+
+  if (max_replace == 0) {
+    /* No limit on number of replaces; use a faster way to get it done. */
+    pluto_pushstring(L,
+      soup::string::join(
+        soup::string::explode(og, std::string(sub, sublen)),
+        std::string(new_, newlen)
+      )
+    );
+    return 1;
+  }
 
   const bool erase = newlen == 0;
   size_t replacements = 0;


### PR DESCRIPTION
Made string.replace binary-safe, which saves the time of needing to measure the length of the C strings, and added a fast path for the case of `max_replace == 0`.