### PR TITLE
Fix compatibility issue due to 'case' terminating 'return' statement

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4715,7 +4715,7 @@ static void retstat (LexState *ls, TypeHint *prop) {
   int startpc = fs->pc;
   int endpc = -1;
   if (block_follow(ls, 1) || ls->t.token == ';'
-    || ls->t.token == TK_CASE || ls->t.token == TK_DEFAULT
+    || (!ls->switchstates.empty() && (ls->t.token == TK_CASE || ls->t.token == TK_DEFAULT))
   ) {
     nret = 0;  /* return no values */
     if (prop) prop->emplaceTypeDesc(VT_VOID);

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -3107,6 +3107,12 @@ do
     assert(((true and "hello" or "goodbye") .. "world") == "helloworld")
 end
 assert({ load[[if then print("hello")]] }[2]:contains[[unexpected symbol near 'then']])
+do
+    local function well_in_that(case)
+        return case
+    end
+    assert(well_in_that("case") == "case")
+end
 
 print "Testing universal functions."
 do


### PR DESCRIPTION
This narrows this behavior to switch blocks.