### PR TITLE
Patch Soup to better fit this project

### DIFF
--- a/src/vendor/Soup/soup/base.hpp
+++ b/src/vendor/Soup/soup/base.hpp
@@ -4,10 +4,10 @@
 
 namespace soup
 {
-	namespace e1 {};
-	using namespace e1;
+	namespace pluto_vendored {};
+	using namespace pluto_vendored;
 };
-#define NAMESPACE_SOUP namespace soup::e1
+#define NAMESPACE_SOUP namespace soup::pluto_vendored
 
 // === Platform/ABI macros
 
@@ -173,12 +173,7 @@ namespace soup
 
 #ifndef SOUP_EXCAL
 	// An 'excal' function is 'noexcept' except it may throw std::bad_alloc.
-	//
-	// We generally don't attempt to handle allocation failures, not least because it's basically impossible on modern systems.
-	// Because of this, we declare that 'excal' functions are 'noexcept' to avoid superfluous unwind information.
-	//
-	// For visual distinction with IDE hover features, we use `throw()`, but it's functionally identical to `noexcept`.
-	#define SOUP_EXCAL throw()
+	#define SOUP_EXCAL
 #endif
 
 // === Development helpers

--- a/src/vendor/Soup/soup/sha384.cpp
+++ b/src/vendor/Soup/soup/sha384.cpp
@@ -86,7 +86,7 @@ NAMESPACE_SOUP
 		return std::move(sw.data);
 	}
 
-	std::string sha384::hash(const std::string& str) throw()
+	std::string sha384::hash(const std::string& str) SOUP_EXCAL
 	{
 		return hash(str.data(), str.size());
 	}


### PR DESCRIPTION
- The namespace is changed to be unique to Pluto, so it doesn't interfere with other usages of Soup with potentially-incompatible versions.
- SOUP_EXCAL is made empty so that std::bad_alloc may be raised. Given that Lua generally does attempt to handle allocation failures, we should, too.