### PR TITLE
Make crypto.random verifiably cryptographically secure

### DIFF
--- a/src/lcryptolib.cpp
+++ b/src/lcryptolib.cpp
@@ -10,13 +10,13 @@
 
 #include <ios>
 #include <string>
-#include <random>
 #include <sstream>
 #include <iomanip>
 
 #include "vendor/Soup/soup/adler32.hpp"
 #include "vendor/Soup/soup/aes.hpp"
 #include "vendor/Soup/soup/crc32.hpp"
+#include "vendor/Soup/soup/HardwareRng.hpp"
 #include "vendor/Soup/soup/rsa.hpp"
 #include "vendor/Soup/soup/sha1.hpp"
 #include "vendor/Soup/soup/sha256.hpp"
@@ -321,19 +321,9 @@ static int l_sha512(lua_State *L)
 }
 
 
-// This should be fairly secure on systems that employ a randomized device, like /dev/urandom, BCryptGenRandom, etc.
-// But, otherwise, it's not secure whatsoever.
 static int random(lua_State *L)
 {
-  std::random_device dev;
-#if defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(_M_X64) || defined(__aarch64__)
-  std::mt19937_64 rng(dev());
-  std::uniform_int_distribution<std::mt19937_64::result_type> dist(luaL_checkinteger(L, 1), luaL_checkinteger(L, 2));
-#else
-  std::mt19937 rng(dev());
-  std::uniform_int_distribution<std::mt19937::result_type> dist((std::mt19937::result_type)luaL_checkinteger(L, 1), (std::mt19937::result_type)luaL_checkinteger(L, 2));
-#endif
-  lua_pushinteger(L, dist(rng));
+  lua_pushinteger(L, static_cast<lua_Integer>(soup::FastHardwareRng::generate64()));
   return 1;
 }
 

--- a/src/vendor/Soup/soup/HardwareRng.cpp
+++ b/src/vendor/Soup/soup/HardwareRng.cpp
@@ -2,15 +2,23 @@
 
 #include "CpuInfo.hpp"
 
+#if SOUP_WINDOWS
+#include <windows.h>
+#include <bcrypt.h>
+#pragma comment(lib, "Bcrypt.lib")
+#elif SOUP_LINUX
+#include <sys/random.h>
+#else
+#include <fcntl.h> // open
+#include <unistd.h> // read, close
+#endif
+
 #if SOUP_X86 && defined(SOUP_USE_INTRIN)
 namespace soup_intrin
 {
 	extern uint16_t hardware_rng_generate16() noexcept;
 	extern uint32_t hardware_rng_generate32() noexcept;
 	extern uint64_t hardware_rng_generate64() noexcept;
-	extern uint16_t fast_hardware_rng_generate16() noexcept;
-	extern uint32_t fast_hardware_rng_generate32() noexcept;
-	extern uint64_t fast_hardware_rng_generate64() noexcept;
 }
 #endif
 
@@ -60,43 +68,37 @@ NAMESPACE_SOUP
 
 	// FastHardwareRng
 
-	bool FastHardwareRng::isAvailable() noexcept
+	void FastHardwareRng::generate(void* buf, size_t buflen) noexcept
 	{
-#if SOUP_X86 && defined(SOUP_USE_INTRIN)
-		return CpuInfo::get().supportsRDRAND();
+#if SOUP_WINDOWS
+		BCryptGenRandom(nullptr, (PUCHAR)buf, buflen, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+#elif SOUP_LINUX
+		getrandom(buf, buflen, 0);
 #else
-		return false;
+		const auto fd = open("/dev/urandom", O_RDONLY);
+		read(fd, buf, buflen);
+		close(fd);
 #endif
 	}
 
 	uint16_t FastHardwareRng::generate16() noexcept
 	{
-#if SOUP_X86 && defined(SOUP_USE_INTRIN)
-		return soup_intrin::fast_hardware_rng_generate16();
-#else
-		SOUP_ASSERT_UNREACHABLE;
-#endif
+		uint16_t res;
+		generate(&res, sizeof(res));
+		return res;
 	}
 
 	uint32_t FastHardwareRng::generate32() noexcept
 	{
-#if SOUP_X86 && defined(SOUP_USE_INTRIN)
-		return soup_intrin::fast_hardware_rng_generate32();
-#else
-		SOUP_ASSERT_UNREACHABLE;
-#endif
+		uint32_t res;
+		generate(&res, sizeof(res));
+		return res;
 	}
 
 	uint64_t FastHardwareRng::generate64() noexcept
 	{
-#if SOUP_X86 && defined(SOUP_USE_INTRIN)
-	#if SOUP_BITS >= 64
-		return soup_intrin::fast_hardware_rng_generate64();
-	#else
-		return (static_cast<uint64_t>(soup_intrin::fast_hardware_rng_generate32()) << 32) | soup_intrin::fast_hardware_rng_generate32();
-	#endif
-#else
-		SOUP_ASSERT_UNREACHABLE;
-#endif
+		uint64_t res;
+		generate(&res, sizeof(res));
+		return res;
 	}
 }

--- a/src/vendor/Soup/soup/HardwareRng.hpp
+++ b/src/vendor/Soup/soup/HardwareRng.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef> // size_t
 
 #include "RngInterface.hpp"
 
 NAMESPACE_SOUP
 {
-	// For the purposes of this class, "hardware RNG" is such that no bit is predictable to an attacker even with unlimited resources.
-	// As such, it uses RDSEED on x86, whereas FastHardwareRng uses RDRAND.
+	// For the purposes of this class, "hardware RNG" is a true RNG, with each bit coming directly from a hardware entropy source.
 	struct HardwareRng
 	{
 		[[nodiscard]] static bool isAvailable() noexcept;
@@ -17,13 +17,10 @@ NAMESPACE_SOUP
 		[[nodiscard]] static uint64_t generate64() noexcept;
 	};
 
-	// For the purposes of this class, "fast hardware RNG" is such that no bit is predictable to an attacker with limited resources,
-	// but some bits may be predictable to an attacker with unlimited resources.
-	// As such, it uses RDRAND on x86, whereas HardwareRng uses RDSEED.
+	// For the purposes of this class, "fast hardware RNG" is backed by a hardware entropy source, but uses processing (a DRBG) to extrapolate more bits.
 	struct FastHardwareRng
 	{
-		[[nodiscard]] static bool isAvailable() noexcept;
-
+		static void generate(void* buf, size_t buflen) noexcept;
 		[[nodiscard]] static uint16_t generate16() noexcept;
 		[[nodiscard]] static uint32_t generate32() noexcept;
 		[[nodiscard]] static uint64_t generate64() noexcept;

--- a/src/vendor/Soup/soup/rand.cpp
+++ b/src/vendor/Soup/soup/rand.cpp
@@ -1,7 +1,14 @@
 #include "rand.hpp"
 
+#include "HardwareRng.hpp"
+
 NAMESPACE_SOUP
 {
+	uint64_t rand_impl::getSeed() noexcept
+	{
+		return FastHardwareRng::generate64();
+	}
+
 	uint8_t rand_impl::byte(uint8_t min) noexcept
 	{
 		return t<uint8_t>(min, -1);

--- a/src/vendor/Soup/soup/rand.hpp
+++ b/src/vendor/Soup/soup/rand.hpp
@@ -13,12 +13,7 @@ NAMESPACE_SOUP
 	class rand_impl
 	{
 	public:
-		[[nodiscard]] static uint64_t getSeed() noexcept
-		{
-			std::random_device rd{};
-			static_assert(sizeof(std::random_device::result_type) == 4);
-			return ((uint64_t)rd() << 32) | rd();
-		}
+		[[nodiscard]] static uint64_t getSeed() noexcept;
 
 //#define getConstexprSeedCounted() getConstexprSeed(__COUNTER__ + 1)
 
@@ -43,7 +38,7 @@ NAMESPACE_SOUP
 		}
 
 	public:
-		[[nodiscard]] static std::mt19937_64& getMersenneTwister() noexcept
+		[[nodiscard]] static SOUP_PURE std::mt19937_64& getMersenneTwister() noexcept
 		{
 			static std::mt19937_64 mt = getMersenneTwisterImpl();
 			return mt;

--- a/src/vendor/Soup/soup/rsa.cpp
+++ b/src/vendor/Soup/soup/rsa.cpp
@@ -334,16 +334,8 @@ NAMESPACE_SOUP
 
 	RsaKeypair RsaKeypair::generate(unsigned int bits, bool lax_length_requirement)
 	{
-		if (FastHardwareRng::isAvailable())
-		{
-			FastHardwareRngInterface rngif;
-			return generate(rngif, bits, lax_length_requirement);
-		}
-		else
-		{
-			DefaultRngInterface rngif;
-			return generate(rngif, bits, lax_length_requirement);
-		}
+		FastHardwareRngInterface rngif;
+		return generate(rngif, bits, lax_length_requirement);
 	}
 
 	RsaKeypair RsaKeypair::generate(StatelessRngInterface& rng, unsigned int bits, bool lax_length_requirement)


### PR DESCRIPTION
Unlike std::random_device, soup::FastHardwareRng::generate has only one possible implementation, which is easy to verify. The weakest link here is probably `/dev/urandom`.