### PR TITLE
fix(scripts): fixes onto scripts

### DIFF
--- a/scripts/common.php
+++ b/scripts/common.php
@@ -56,11 +56,12 @@ function prepare_link()
 
 function resolve_installed_program($exe)
 {
-	if(defined("PHP_WINDOWS_VERSION_MAJOR"))
+	$compiler_exe = escapeshellarg(explode(" ", $exe)[0]);
+	if (defined("PHP_WINDOWS_VERSION_MAJOR") && system("where $compiler_exe") || system("command -v $compiler_exe"))
 	{
-		return escapeshellarg(system("where ".escapeshellarg($exe)));
+		return $exe;
 	}
-	return escapeshellarg(system("which ".escapeshellarg($exe)));
+	die("Cannot find so-called $compiler_exe compiler");
 }
 
 function for_each_obj($f)


### PR DESCRIPTION
Changes included:
- Allow passing compiler flags into script via argv
- Fix non-POSIX compliant `which` command with `command -v`
  - A reason to this is because `which` is part of the GNU coreutils project which might not available in many distros (e.g Alpine Linux, Chimera Linux), instead use built-in `command` to search binary. 