### PR TITLE
Fix `uint8_t` type missing error

### DIFF
--- a/src/vendor/Soup/soup/CryptoHashAlgo.hpp
+++ b/src/vendor/Soup/soup/CryptoHashAlgo.hpp
@@ -4,6 +4,7 @@
 
 #include <cstring> // memset, memcpy
 #include <string>
+#include <cstdint>
 
 NAMESPACE_SOUP
 {


### PR DESCRIPTION
Before this patch, the compiler will produce an error of missing `uint8_t`
```
In file included from /home/komo/Projects/Pluto/src/vendor/Soup/soup/sha384.cpp:1:
In file included from /home/komo/Projects/Pluto/src/vendor/Soup/soup/sha384.hpp:3:
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:115:19: error: unknown type name 'uint8_t'
  115 |                         void getDigest(uint8_t out[T::DIGEST_BYTES]) const noexcept
      |                                        ^
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:79:5: error: unknown type name 'uint8_t'
   79 |                                 uint8_t header[T::BLOCK_BYTES];
      |                                 ^
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:108:5: error: unknown type name 'uint8_t'
  108 |                                 uint8_t buf[T::DIGEST_BYTES];
      |                                 ^
3 errors generated.
In file included from /home/komo/Projects/Pluto/src/vendor/Soup/soup/sha512.cpp:1:
In file included from /home/komo/Projects/Pluto/src/vendor/Soup/soup/sha512.hpp:3:
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:115:19: error: unknown type name 'uint8_t'
  115 |                         void getDigest(uint8_t out[T::DIGEST_BYTES]) const noexcept
      |                                        ^
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:79:5: error: unknown type name 'uint8_t'
   79 |                                 uint8_t header[T::BLOCK_BYTES];
      |                                 ^
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:108:5: error: unknown type name 'uint8_t'
  108 |                                 uint8_t buf[T::DIGEST_BYTES];
      |                                 ^
3 errors generated.
In file included from /home/komo/Projects/Pluto/src/vendor/Soup/soup/sha256.cpp:1:
In file included from /home/komo/Projects/Pluto/src/vendor/Soup/soup/sha256.hpp:3:
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:115:19: error: unknown type name 'uint8_t'
  115 |                         void getDigest(uint8_t out[T::DIGEST_BYTES]) const noexcept
      |                                        ^
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:79:5: error: unknown type name 'uint8_t'
   79 |                                 uint8_t header[T::BLOCK_BYTES];
      |                                 ^
/home/komo/Projects/Pluto/src/vendor/Soup/soup/CryptoHashAlgo.hpp:108:5: error: unknown type name 'uint8_t'
  108 |                                 uint8_t buf[T::DIGEST_BYTES];
      |                                 ^
3 errors generated.
```