### PR TITLE
PHP build scripts: Pass on additional arguments to compiler

### DIFF
--- a/scripts/common.php
+++ b/scripts/common.php
@@ -25,6 +25,10 @@ function check_compiler()
 	}
 
 	$compiler = resolve_installed_program($argv[1]);
+	for($i = 2; $i != count($argv); ++$i)
+	{
+		$compiler .= " ".escapeshellarg($argv[$i]);
+	}
 	$compiler .= " -std=c++17 -O3 -fvisibility=hidden -fno-rtti";
 	if(defined("PHP_WINDOWS_VERSION_MAJOR"))
 	{


### PR DESCRIPTION
This allows for usage like `php scripts/compile.php clang -DPLUTO_VMDUMP`