### PR TITLE
Remove implicit string literal concatenation

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -542,9 +542,6 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
   ls->appendLineBuff((char)del);
   next(ls);  /* skip delimiter */
   seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff), luaZ_bufflen(ls->buff));
-  if (ls->current == del) {  // Chained, implicit string literal concatenation.
-    read_string(ls, del, seminfo);
-  }
 }
 
 

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -3126,6 +3126,30 @@ do
     end
     assert(well_in_that("case") == "case")
 end
+do
+    local function tofs(t)
+        local f
+        f=|s|->do
+            t:insert(s)
+            return f
+        end
+        return f
+    end
+    do
+        local t = {}
+        tofs(t) "abc" "def"
+        assert(#t == 2)
+        assert(t[1] == "abc")
+        assert(t[2] == "def")
+    end
+    do
+        local t = {}
+        tofs(t) "abc""def"
+        assert(#t == 2)
+        assert(t[1] == "abc")
+        assert(t[2] == "def")
+    end
+end
 
 print "Testing universal functions."
 do


### PR DESCRIPTION
Apparently this was intentionally added as a feature in 0.2.0 but it was not listed in the changelog and not documented.