### PR TITLE
Fix version information

### DIFF
--- a/src/lapi.cpp
+++ b/src/lapi.cpp
@@ -35,7 +35,8 @@
 
 const char lua_ident[] =
   "$LuaVersion: " LUA_COPYRIGHT " $"
-  "$LuaAuthors: " LUA_AUTHORS " $";
+  "$LuaAuthors: " LUA_AUTHORS " $"
+  "$PlutoVersion: " PLUTO_COPYRIGHT_NO_BASED " $";
 
 
 

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -172,7 +172,7 @@ static int docall (lua_State *L, int narg, int nres) {
 
 
 static void print_version (void) {
-  lua_writestring(LUA_COPYRIGHT, strlen(LUA_COPYRIGHT));
+  lua_writestring(PLUTO_COPYRIGHT, strlen(PLUTO_COPYRIGHT));
   lua_writeline();
 }
 

--- a/src/lua.h
+++ b/src/lua.h
@@ -15,8 +15,6 @@
 #include "luaconf.h"
 
 
-#define PLUTO_VERSION "Pluto 0.9.4"
-
 #define LUA_VERSION_MAJOR	"5"
 #define LUA_VERSION_MINOR	"4"
 #define LUA_VERSION_RELEASE	"7"
@@ -28,6 +26,11 @@
 #define LUA_RELEASE	LUA_VERSION "." LUA_VERSION_RELEASE
 #define LUA_COPYRIGHT	LUA_RELEASE "  Copyright (C) 1994-2024 Lua.org, PUC-Rio"
 #define LUA_AUTHORS	"R. Ierusalimschy, L. H. de Figueiredo, W. Celes"
+
+
+#define PLUTO_VERSION "Pluto 0.9.4"
+#define PLUTO_COPYRIGHT_NO_BASED PLUTO_VERSION ", Copyright (C) 2022-2024 PlutoLang.org, PlutoLang (https://github.com/PlutoLang)"
+#define PLUTO_COPYRIGHT PLUTO_COPYRIGHT_NO_BASED "\r\nBased on " LUA_COPYRIGHT
 
 
 /* mark for precompiled code ('<esc>Lua') */

--- a/src/luac.cpp
+++ b/src/luac.cpp
@@ -123,7 +123,7 @@ static int doargs(int argc, char* argv[])
  }
  if (version)
  {
-  printf("%s\n",LUA_COPYRIGHT);
+  printf("%s\n",PLUTO_COPYRIGHT);
   if (version==argc-1) exit(EXIT_SUCCESS);
  }
  return i;


### PR DESCRIPTION
Current version information is missing, apparently the rebase had a funny. Either way, the old way was mangling Lua's identifiers. A separate field has been added for `ident` and we change appropriate references of LUA_COPYRIGHT (etc) to PLUTO_COPYRIGHT. Not modifying LUA_COPYRIGHT (etc) also removes an unnecessary conflict in a future rebase. 