### PR TITLE
Improve walrus error message

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2831,7 +2831,7 @@ static void primaryexp (LexState *ls, expdesc *v, int flags = 0) {
       if (flags & E_OR_KILLED_WALRUS)
         throwerr(ls, "':=' is not allowed in this context", "due to the 'or', it is no longer guaranteed that the local will be initialized by the time it's in scope.");
       if (!(flags & E_WALRUS) || ls->fs->freereg != luaY_nvarstack(ls->fs))
-        throwerr(ls, "':=' is not allowed in this context", "unexpected ':='");
+        throwerr(ls, "':=' is only allowed in 'if' and 'while' statements", "unexpected ':='");
       luaX_next(ls);
       new_localvar(ls, varname);
       expr(ls, v);


### PR DESCRIPTION
Instead of only saying "not allowed in this context", mention which contexts it actually is allowed in.