### PR TITLE
Allow nil for FFI_STR to mean nullptr

### DIFF
--- a/src/lffi.cpp
+++ b/src/lffi.cpp
@@ -152,6 +152,8 @@ static uintptr_t check_ffi_value (lua_State *L, int i, FfiType type) {
         luaL_checktype(L, i, LUA_TLIGHTUSERDATA);
       return reinterpret_cast<uintptr_t>(lua_touserdata(L, i));
     case FFI_STR:
+      if (lua_type(L, i) == LUA_TNIL)
+        return 0;
       return reinterpret_cast<uintptr_t>(luaL_checkstring(L, i));
   }
   SOUP_UNREACHABLE;


### PR DESCRIPTION
Makes this code work:
```lua
local ffi = require "pluto:ffi"
local user32 = ffi.open("user32")

local MessageBoxA = user32:wrap("i32", "MessageBoxA", "i32", "str", "str", "i32")
MessageBoxA(0, "Hello from Pluto", nil, 0)
```