### PR TITLE
Add canvas.tobwstring

### DIFF
--- a/src/lcanvas.cpp
+++ b/src/lcanvas.cpp
@@ -131,6 +131,11 @@ static int canvas_topng (lua_State* L) {
   return 1;
 }
 
+static int canvas_tobwstring(lua_State* L) {
+  pluto_pushstring(L, checkcanvas(L, 1)->toStringDownsampledDoublewidthUtf8(true, false, soup::Rgb(static_cast<uint32_t>(luaL_checkinteger(L, 2)))));
+  return 1;
+}
+
 static const luaL_Reg funcs_canvas[] = {
   {"new", canvas_new},
   {"bmp", canvas_bmp},
@@ -142,6 +147,7 @@ static const luaL_Reg funcs_canvas[] = {
   {"mulsize", canvas_mulsize},
   {"tobmp", canvas_tobmp},
   {"topng", canvas_topng},
+  {"tobwstring", canvas_tobwstring},
   {nullptr, nullptr}
 };
 PLUTO_NEWLIB(canvas);

--- a/src/vendor/Soup/soup/Canvas.hpp
+++ b/src/vendor/Soup/soup/Canvas.hpp
@@ -62,8 +62,9 @@ NAMESPACE_SOUP
 		[[nodiscard]] std::string toString(bool explicit_nl) const;
 		[[nodiscard]] std::string toStringDoublewidth(bool explicit_nl) const;
 		[[nodiscard]] std::u16string toStringDownsampled(bool explicit_nl, bool reset_on_nl);
-		[[nodiscard]] std::u16string toStringDownsampledDoublewidth(bool explicit_nl, bool reset_on_nl);
-		[[nodiscard]] std::string toStringDownsampledDoublewidthUtf8(bool explicit_nl, bool reset_on_nl);
+		[[nodiscard]] std::string toStringDownsampledUtf8(bool explicit_nl, bool reset_on_nl);
+		[[nodiscard]] std::u16string toStringDownsampledDoublewidth(bool explicit_nl, bool reset_on_nl, std::optional<Rgb> filter = std::nullopt);
+		[[nodiscard]] std::string toStringDownsampledDoublewidthUtf8(bool explicit_nl, bool reset_on_nl, std::optional<Rgb> filter = std::nullopt);
 	private:
 		[[nodiscard]] static char16_t downsampleChunkToChar(uint8_t chunkset) noexcept;
 

--- a/src/vendor/Soup/soup/Rgb.hpp
+++ b/src/vendor/Soup/soup/Rgb.hpp
@@ -100,5 +100,10 @@ NAMESPACE_SOUP
 
 		[[nodiscard]] double distance(const Rgb& e2) const noexcept;
 		[[nodiscard]] double similarity(const Rgb& e2) const noexcept;
+		
+		[[nodiscard]] Rgb invert() const noexcept
+		{
+			return Rgb(~r, ~g, ~b);
+		}
 	};
 }


### PR DESCRIPTION
A bit of a compromise on colour, but at least portable.
```lua
local canvas = require "canvas"
local c = canvas.qrcode("Hello from Pluto!", { fg = 0xffffff, bg = 0x000000 })
print(c:tobwstring(0xffffff))
--> █▀▀▀▀▀█ ▄ █▄▄ █▀▀▀▀▀█
--> █ ███ █ ▄█▄▄█ █ ███ █
--> █ ▀▀▀ █ ▄▀ █▄ █ ▀▀▀ █
--> ▀▀▀▀▀▀▀ ▀▄▀▄█ ▀▀▀▀▀▀▀
--> ▀▀███ ▀███ █▀▀ ▀▄█▄▀▄
--> █▄▀▄▀█▀█▀▀ ▀█▄▀▄▄██▀ 
--> ▀▀▀▀▀ ▀ █▀█▀ ▄█▄▄▄  ▀
--> █▀▀▀▀▀█ ▀  ▀██▀▄ ▄██ 
--> █ ███ █ █▄ ▄█▄██▄▄ ▄ 
--> █ ▀▀▀ █ █▄ ▀█▀ ▀▄▄█  
--> ▀▀▀▀▀▀▀ ▀   ▀ ▀ ▀  ▀ 
```