### PR TITLE
Optimize base64.encode

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,6 +11,7 @@ jobs:
       - run: php scripts/compile.php clang
       - run: php scripts/link_pluto.php clang
       - run: src/pluto testes/_driver.pluto
+      - run: src/pluto testes/bench/_stdlib.pluto
   ubuntu-20-04:
     runs-on: ubuntu-20.04
     steps:
@@ -18,6 +19,7 @@ jobs:
       - run: php scripts/compile.php clang
       - run: php scripts/link_pluto.php clang
       - run: src/pluto testes/_driver.pluto
+      - run: src/pluto testes/bench/_stdlib.pluto
   debian-10:
     runs-on: [debian-10]
     steps:
@@ -36,6 +38,7 @@ jobs:
             src/libpluto.so
             src/libpluto.a
       - run: src/pluto testes/_driver.pluto
+      - run: src/pluto testes/bench/_stdlib.pluto
       - run: php scripts/bundle_deb.php
       - uses: actions/upload-artifact@v4
         with:
@@ -59,6 +62,7 @@ jobs:
             src/libpluto.so
             src/libpluto.a
       - run: src/pluto testes/_driver.pluto
+      - run: src/pluto testes/bench/_stdlib.pluto
   windows:
     runs-on: windows-latest
     steps:
@@ -77,6 +81,7 @@ jobs:
             src/plutoc.exe
             src/libpluto.a
       - run: src/pluto.exe testes/_driver.pluto
+      - run: src/pluto testes/bench/_stdlib.pluto
       - run: php scripts/bundle_nupkg.php
       - uses: actions/upload-artifact@v4
         with:

--- a/src/lbase64.cpp
+++ b/src/lbase64.cpp
@@ -2,14 +2,20 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
+#include "lstring.h"
 
 #include <string>
 #include "vendor/Soup/soup/base64.hpp"
 
 static int encode(lua_State* L) {
 	size_t len;
-	auto str = luaL_checklstring(L, 1, &len);
-	pluto_pushstring(L, soup::base64::encode(str, len, (bool)(lua_gettop(L) >= 2 ? lua_toboolean(L, 2) : true)));
+	const char *str = luaL_checklstring(L, 1, &len);
+	const bool pad = (lua_gettop(L) >= 2 ? lua_toboolean(L, 2) : true);
+	size_t out_len = soup::base64::getEncodedSize(len, pad);
+	char shrtbuf[LUAI_MAXSHORTLEN];
+	char *enc = plutoS_prealloc(L, shrtbuf, out_len);
+	soup::base64::encode(enc, str, len, pad);
+	plutoS_commit(L, enc, out_len);
 	return 1;
 }
 

--- a/src/lstring.h
+++ b/src/lstring.h
@@ -54,3 +54,6 @@ LUAI_FUNC Udata *luaS_newudata (lua_State *L, size_t s, int nuvalue);
 LUAI_FUNC TString *luaS_newlstr (lua_State *L, const char *str, size_t l);
 LUAI_FUNC TString *luaS_new (lua_State *L, const char *str);
 LUAI_FUNC TString *luaS_createlngstrobj (lua_State *L, size_t l);
+
+LUAI_FUNC char *plutoS_prealloc (lua_State *L, char shrtbuf[LUAI_MAXSHORTLEN], size_t l);
+LUAI_FUNC void plutoS_commit (lua_State *L, char *prealloc, size_t l);

--- a/src/vendor/Soup/soup/base64.cpp
+++ b/src/vendor/Soup/soup/base64.cpp
@@ -56,6 +56,11 @@ NAMESPACE_SOUP
 		return encode(data, size, pad, table_encode_base64);
 	}
 
+	void base64::encode(char* out, const char* const data, const size_t size, const bool pad) noexcept
+	{
+		return encode(out, data, size, pad, table_encode_base64);
+	}
+
 	static constexpr char table_encode_base64url[] = {
 		'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
 		'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
@@ -84,48 +89,47 @@ NAMESPACE_SOUP
 
 	std::string base64::encode(const char* const data, const size_t size, const bool pad, const char* table) SOUP_EXCAL
 	{
-		size_t out_len = 4 * ((size + 2) / 3);
-		std::string enc(out_len, '\0');
+		std::string enc(getEncodedSize(size, pad), '\0');
+		encode(enc.data(), data, size, pad, table);
+		return enc;
+	}
+
+	void base64::encode(char* out, const char* data, const size_t size, const bool pad, const char* table) noexcept
+	{
 		size_t i = 0;
-		char* p = enc.data();
 
 		if (size > 2)
 		{
 			for (; i < size - 2; i += 3)
 			{
-				*p++ = table[(data[i] >> 2) & 0x3F];
-				*p++ = table[((data[i] & 0x3) << 4) | ((int)(data[i + 1] & 0xF0) >> 4)];
-				*p++ = table[((data[i + 1] & 0xF) << 2) | ((int)(data[i + 2] & 0xC0) >> 6)];
-				*p++ = table[data[i + 2] & 0x3F];
+				*out++ = table[(data[i] >> 2) & 0x3F];
+				*out++ = table[((data[i] & 0x3) << 4) | ((int)(data[i + 1] & 0xF0) >> 4)];
+				*out++ = table[((data[i + 1] & 0xF) << 2) | ((int)(data[i + 2] & 0xC0) >> 6)];
+				*out++ = table[data[i + 2] & 0x3F];
 			}
 		}
+
 		if (i < size)
 		{
-			*p++ = table[(data[i] >> 2) & 0x3F];
+			*out++ = table[(data[i] >> 2) & 0x3F];
 			if (i == (size - 1))
 			{
-				*p++ = table[((data[i] & 0x3) << 4)];
+				*out++ = table[((data[i] & 0x3) << 4)];
 				if (pad)
 				{
-					*p++ = '=';
+					*out++ = '=';
 				}
 			}
 			else
 			{
-				*p++ = table[((data[i] & 0x3) << 4) | ((int)(data[i + 1] & 0xF0) >> 4)];
-				*p++ = table[((data[i + 1] & 0xF) << 2)];
+				*out++ = table[((data[i] & 0x3) << 4) | ((int)(data[i + 1] & 0xF0) >> 4)];
+				*out++ = table[((data[i + 1] & 0xF) << 2)];
 			}
 			if (pad)
 			{
-				*p++ = '=';
+				*out++ = '=';
 			}
 		}
-		if (!pad)
-		{
-			enc.erase(strlen(enc.c_str()));
-		}
-
-		return enc;
 	}
 
 	static constexpr unsigned char table_decode_base64[] = {

--- a/src/vendor/Soup/soup/base64.hpp
+++ b/src/vendor/Soup/soup/base64.hpp
@@ -9,6 +9,26 @@ NAMESPACE_SOUP
 {
 	struct base64
 	{
+		[[nodiscard]] static constexpr size_t getEncodedSize(size_t size) noexcept
+		{
+			return 4 * ((size + 2) / 3);
+		}
+
+		[[nodiscard]] static constexpr size_t getPadBytes(size_t size) noexcept
+		{
+			return (3 - (size % 3)) % 3;
+		}
+
+		[[nodiscard]] static constexpr size_t getEncodedSize(size_t size, bool pad) noexcept
+		{
+			size_t enc_size = getEncodedSize(size);
+			if (!pad)
+			{
+				enc_size -= getPadBytes(size);
+			}
+			return enc_size;
+		}
+
 		[[nodiscard]] static std::string encode(const char* data, const bool pad = true) SOUP_EXCAL;
 		[[nodiscard]] static std::string encode(const std::string& data, const bool pad = true) SOUP_EXCAL;
 		template <typename T>
@@ -17,12 +37,14 @@ NAMESPACE_SOUP
 			return encode(&data, pad);
 		}
 		[[nodiscard]] static std::string encode(const char* const data, const size_t size, const bool pad = true) SOUP_EXCAL;
+		static void encode(char* out, const char* const data, const size_t size, const bool pad) noexcept;
 
 		[[nodiscard]] static std::string urlEncode(const char* data, const bool pad = false) SOUP_EXCAL;
 		[[nodiscard]] static std::string urlEncode(const std::string& data, const bool pad = false) SOUP_EXCAL;
 		[[nodiscard]] static std::string urlEncode(const char* const data, const size_t size, const bool pad = false) SOUP_EXCAL;
 
 		[[nodiscard]] static std::string encode(const char* const data, const size_t size, const bool pad, const char* table) SOUP_EXCAL;
+		static void encode(char* out, const char* data, const size_t size, const bool pad, const char* table) noexcept;
 
 		[[nodiscard]] static std::string decode(std::string enc) SOUP_EXCAL;
 		[[nodiscard]] static std::string urlDecode(std::string enc) SOUP_EXCAL;

--- a/testes/bench/_stdlib.pluto
+++ b/testes/bench/_stdlib.pluto
@@ -1,0 +1,28 @@
+local function bench(name, f)
+    $define NUM_MS = 100
+    local deadline = os.millis() + NUM_MS
+    local its = 0
+    while os.millis() < deadline do
+        f()
+        ++its
+    end
+    print($"{name}: {its / NUM_MS} iterations/ms")
+end
+
+local { base64 } = require "*"
+
+bench("base64 encode, with padding, short string", function()
+    base64.encode("abc", true)
+end)
+
+bench("base64 encode, without padding, short string", function()
+    base64.encode("abc", false)
+end)
+
+bench("base64 encode, with padding, long string", function()
+    base64.encode("The quick brown fox jumps over the lazy dog.", true)
+end)
+
+bench("base64 encode, without padding, long string", function()
+    base64.encode("The quick brown fox jumps over the lazy dog.", false)
+end)

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1513,6 +1513,8 @@ do
     assert(base64.encode("Hello", false) == "SGVsbG8")
     assert(base64.decode("SGVsbG8") == "Hello")
     assert(base64.decode("SGVsbG8=") == "Hello")
+    assert(base64.encode("The quick brown fox jumps over the lazy dog.", true) == "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZy4=")
+    assert(base64.encode("The quick brown fox jumps over the lazy dog.", false) == "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZy4")
 
     assert(base64.urlencode("Hello") == "SGVsbG8")
     assert(base64.urldecode("SGVsbG8") == "Hello")


### PR DESCRIPTION
Before and after on my machine:
```
base64 encode, with padding, short string: 14098.08 iterations/ms
base64 encode, without padding, short string: 13927.85 iterations/ms
base64 encode, with padding, long string: 6886.31 iterations/ms
base64 encode, without padding, long string: 6192.5 iterations/ms
```
```
base64 encode, with padding, short string: 16572.16 iterations/ms
base64 encode, without padding, short string: 17044.62 iterations/ms
base64 encode, with padding, long string: 9949.3 iterations/ms
base64 encode, without padding, long string: 9615.22 iterations/ms
```