### PR TITLE
Optimize crypto.sha*

### DIFF
--- a/src/vendor/Soup/soup/string.hpp
+++ b/src/vendor/Soup/soup/string.hpp
@@ -315,6 +315,33 @@ NAMESPACE_SOUP
 			return res;
 		}
 
+		static void bin2hexAt(char* out, const char* data, size_t size, const char* map) noexcept
+		{
+			for (; size; ++data, --size)
+			{
+				*out++ = map[(unsigned char)(*data) >> 4];
+				*out++ = map[(*data) & 0b1111];
+			}
+		}
+
+		[[nodiscard]] static constexpr size_t bin2hexWithSpacesSize(size_t size) noexcept
+		{
+			return size != 0 ? (size * 3) - 1 : 0;
+		}
+
+		static void bin2hexWithSpaces(char* out, const char* data, size_t size, const char* map) noexcept
+		{
+			for (; size; ++data)
+			{
+				*out++ = map[(unsigned char)(*data) >> 4];
+				*out++ = map[(*data) & 0b1111];
+				if (--size)
+				{
+					*out++ = ' ';
+				}
+			}
+		}
+
 		[[nodiscard]] static std::string hex2bin(const std::string& hex) SOUP_EXCAL;
 
 		enum ToIntFlags : uint8_t

--- a/testes/bench/_stdlib.pluto
+++ b/testes/bench/_stdlib.pluto
@@ -9,20 +9,42 @@ local function bench(name, f)
     print($"{name}: {its / NUM_MS} iterations/ms")
 end
 
-local { base64 } = require "*"
+local { base64, crypto  } = require "*"
 
 bench("base64 encode, with padding, short string", function()
     base64.encode("abc", true)
 end)
-
 bench("base64 encode, without padding, short string", function()
     base64.encode("abc", false)
 end)
-
 bench("base64 encode, with padding, long string", function()
     base64.encode("The quick brown fox jumps over the lazy dog.", true)
 end)
-
 bench("base64 encode, without padding, long string", function()
     base64.encode("The quick brown fox jumps over the lazy dog.", false)
+end)
+
+bench("sha1, hex digest", function()
+    crypto.sha1("The quick brown fox jumps over the lazy dog.")
+end)
+bench("sha1, binary", function()
+    crypto.sha1("The quick brown fox jumps over the lazy dog.", true)
+end)
+bench("sha256, hex digest", function()
+    crypto.sha256("The quick brown fox jumps over the lazy dog.")
+end)
+bench("sha256, binary", function()
+    crypto.sha256("The quick brown fox jumps over the lazy dog.", true)
+end)
+bench("sha384, hex digest", function()
+    crypto.sha384("The quick brown fox jumps over the lazy dog.")
+end)
+bench("sha384, binary", function()
+    crypto.sha384("The quick brown fox jumps over the lazy dog.", true)
+end)
+bench("sha512, hex digest", function()
+    crypto.sha512("The quick brown fox jumps over the lazy dog.")
+end)
+bench("sha512, binary", function()
+    crypto.sha512("The quick brown fox jumps over the lazy dog.", true)
 end)


### PR DESCRIPTION
Before and after on my machine:
```
sha1, hex digest: 2982.88 iterations/ms
sha1, binary: 4010.92 iterations/ms
sha256, hex digest: 3329.36 iterations/ms
sha256, binary: 5399.97 iterations/ms
sha384, hex digest: 1703.63 iterations/ms
sha384, binary: 2131.63 iterations/ms
sha512, hex digest: 1620.11 iterations/ms
sha512, binary: 1987.16 iterations/ms
```
```
sha1, hex digest: 4145.22 iterations/ms
sha1, binary: 4448.47 iterations/ms
sha256, hex digest: 5148.19 iterations/ms
sha256, binary: 6552.82 iterations/ms
sha384, hex digest: 1979.73 iterations/ms
sha384, binary: 2418.13 iterations/ms
sha512, hex digest: 2197.91 iterations/ms
sha512, binary: 2198.66 iterations/ms
```