### PR TITLE
Handle reserved keyword being indexed as a global

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -207,7 +207,8 @@ static void disablekeyword (LexState *ls, int token) {
 static void check_for_non_portable_code (LexState *ls) {
   if (ls->t.IsNonCompatible() && !ls->t.IsOverridable()) {
     if (ls->getKeywordState(ls->t.token) == KS_ENABLED_BY_PLUTO_UNINFORMED) {
-      if (luaX_lookahead(ls) == '=') {  /* attempting a global assignment? */
+      const auto next = luaX_lookahead(ls);
+      if (next == '=' || next == '.' || next == ':' || next == '[') {  /* attempting to create or use a global? */
         disablekeyword(ls, ls->t.token);
         ls->uninformed_reserved.emplace(ls->t.token, ls->getLineNumber());
         ls->setKeywordState(ls->t.token, KS_DISABLED_BY_PLUTO_INFORMED);

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -3526,6 +3526,15 @@ do
     assert(load[[-- @pluto_warnings disable-unused
         class = {}
     ]])
+    assert(load[[-- @pluto_warnings disable-unused
+        class.mem = 1
+    ]])
+    assert(load[[-- @pluto_warnings disable-unused
+        class[1] = 1
+    ]])
+    assert(load[[-- @pluto_warnings disable-unused
+        class:mem()
+    ]])
 end
 
 print "Testing universal functions."


### PR DESCRIPTION
Because globals can be defined in a different "compilation unit", we need to infer from more than just '='