### PR TITLE
Allow 'type' to be called at compile-time

### DIFF
--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -315,7 +315,7 @@ static int luaB_collectgarbage (lua_State *L) {
 }
 
 
-static int luaB_type (lua_State *L) {
+int luaB_type (lua_State *L) {
   int t = lua_type(L, 1);
   luaL_argcheck(L, t != LUA_TNONE, 1, "value expected");
   lua_pushstring(L, lua_typename(L, t));

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2714,6 +2714,7 @@ int luaB_tonumber (lua_State *L);
 int luaB_utonumber (lua_State *L);
 int luaB_tostring (lua_State *L);
 int luaB_utostring (lua_State *L);
+int luaB_type (lua_State *L);
 
 static void const_expr (LexState *ls, expdesc *v) {
   switch (ls->t.token) {
@@ -2748,6 +2749,7 @@ static void const_expr (LexState *ls, expdesc *v) {
           && !check_constexpr_call(ls, v, "utonumber", luaB_utonumber)
           && !check_constexpr_call(ls, v, "tostring", luaB_tostring)
           && !check_constexpr_call(ls, v, "utostring", luaB_utostring)
+          && !check_constexpr_call(ls, v, "type", luaB_type)
         )
       {
         throwerr(ls, luaO_fmt(ls->L, "%s is not available in constant expression", getstr(ls->t.seminfo.ts)), "unrecognized name.");


### PR DESCRIPTION
```lua
print($type("abc")) --> string
```
Not that useful, but also no reason not to allow it.