### PR TITLE
Optimize equality check of compile-time constants

### DIFF
--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -3266,6 +3266,12 @@ end
 
 print "Testing compile-time conditionals."
 do
+    $if "abc" == "abc" then $end
+    $if 69 == 69 then $end
+    $if true == true then $end
+    $if false == false then $end
+    $if nil == nil then $end
+
     local debug_bytecode = string.dump(load([[
         $define DEBUG = true
         $if DEBUG then


### PR DESCRIPTION
This also allows them to be used for compile-time conditionals