### PR TITLE
Don't implicitly convert bools to strings in function arguments

### DIFF
--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -647,7 +647,7 @@ int luaV_equalobj (lua_State *L, const TValue *t1, const TValue *t2) {
 
 /* macro used by 'luaV_concat' to ensure that element at 'o' is a string */
 #define tostring(L,o)  \
-    (ttisstring(o) || (cvt2str(o) && (luaO_tostring(L, o), 1)))
+    (ttisstring(o) || ((cvt2str(o) || ttisboolean(o)) && (luaO_tostring(L, o), 1)))
 
 #define isemptystr(o)	(ttisshrstring(o) && tsvalue(o)->shrlen == 0)
 
@@ -673,7 +673,7 @@ void luaV_concat (lua_State *L, int total) {
   do {
     StkId top = L->top.p;
     int n = 2;  /* number of elements handled in this pass (at least 2) */
-    if (!(ttisstring(s2v(top - 2)) || cvt2str(s2v(top - 2))) ||
+    if (!(ttisstring(s2v(top - 2)) || cvt2str(s2v(top - 2)) || ttisboolean(s2v(top - 2))) ||
         !tostring(L, s2v(top - 1)))
       luaT_tryconcatTM(L);  /* may invalidate 'top' */
     else if (isemptystr(s2v(top - 1)))  /* second operand is empty? */

--- a/src/lvm.h
+++ b/src/lvm.h
@@ -11,7 +11,7 @@
 
 
 #if !defined(LUA_NOCVTN2S)
-#define cvt2str(o)	(ttisnumber(o) || ttisboolean(o))
+#define cvt2str(o)	(ttisnumber(o))
 #else
 #define cvt2str(o)	0	/* no conversion from numbers to strings */
 #endif

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2756,6 +2756,9 @@ print "Testing boolean concatenation."
 do
     assert(("aussie version is " .. true) == "aussie version is true")
     assert((true .. false) == "truefalse")
+
+    -- despite this, functions taking a string as an argument should not implicitly stringify a bool
+    assert(not pcall(|| -> require"base64".encode(true)))
 end
 
 print "Testing constant expressions."


### PR DESCRIPTION
This was an accidental semantic change from PUC-Lua due to boolean concatenation.