### PR TITLE
PHP Build Scripts: Workaround lack of dead code elimination

### DIFF
--- a/scripts/common.php
+++ b/scripts/common.php
@@ -29,7 +29,7 @@ function check_compiler()
 	{
 		$compiler .= " ".escapeshellarg($argv[$i]);
 	}
-	$compiler .= " -std=c++17 -O3 -fvisibility=hidden -fno-rtti";
+	$compiler .= " -std=c++17 -O3 -fvisibility=hidden -fno-rtti -ffunction-sections -fdata-sections";
 	if(defined("PHP_WINDOWS_VERSION_MAJOR"))
 	{
 		$compiler .= " -D _CRT_SECURE_NO_WARNINGS";

--- a/scripts/common.php
+++ b/scripts/common.php
@@ -43,7 +43,7 @@ function check_compiler()
 		}
 		if (PHP_OS_FAMILY != "Darwin")
 		{
-			$compiler .= " -fPIC -fuse-ld=lld";
+			$compiler .= " -fPIC -fuse-ld=lld -Wl,--gc-sections,--icf=safe";
 			if (!getenv("ANDROID_ROOT"))
 			{
 				$compiler .= " -lstdc++fs";

--- a/src/vendor/Soup/build_common.php
+++ b/src/vendor/Soup/build_common.php
@@ -21,7 +21,7 @@ if (!defined("PHP_WINDOWS_VERSION_MAJOR"))
 	}
 	if (PHP_OS_FAMILY != "Darwin")
 	{
-		$clanglink .= " -fuse-ld=lld";
+		$clanglink .= " -fuse-ld=lld -Wl,--gc-sections,--icf=safe";
 		if (!getenv("ANDROID_ROOT"))
 		{
 			$clanglink .= " -lstdc++fs";

--- a/src/vendor/Soup/build_common.php
+++ b/src/vendor/Soup/build_common.php
@@ -1,7 +1,7 @@
 <?php
 // Config
 $clang = $argv[1] ?? "clang";
-$clang .= " -std=c++17 -fno-rtti -DSOUP_USE_INTRIN -O3";
+$clang .= " -std=c++17 -fno-rtti -DSOUP_USE_INTRIN -O3 -ffunction-sections -fdata-sections";
 if (defined("PHP_WINDOWS_VERSION_MAJOR"))
 {
 	$clang .= " -D_CRT_SECURE_NO_WARNINGS";


### PR DESCRIPTION
This mainly affects Windows, where it has the biggest impact on binary size and a slight performance boost derives from that.