### PR TITLE
Compile with C99 features on Windows.

### DIFF
--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -61,7 +61,6 @@
 
 #if defined(LUA_USE_WINDOWS)
 #define LUA_DL_DLL	/* enable support for DLL */
-#define LUA_USE_C89	/* broadly, Windows is C89 */
 #endif
 
 


### PR DESCRIPTION
Windows (MSVC) has had support for C99 features for quite a while now (since 2013?) so no reason to restrict it to C89, Also some features that are specific to Pluto (such as `math.round`) already have a hard requirement for C99 anyways.

In regular PUC Lua the only places that really take advantage of C99 cross-platform are `math.log` when it's second argument is `2` and some core functions around the codebase trying to hint to the compiler to be inlined as far as I can tell.

I did a few test compiles myself with MSVC on Windows using the provided solution file just to make sure it didn't throw a fit and all seemed to work fine.