### PR TITLE
Don't allow pipe expression after string literal for consistency

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -3566,7 +3566,7 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, TypeHint *prop) {
       if (prop) prop->emplaceTypeDesc(VT_STR);
       codestring(v, ls->t.seminfo.ts);
       luaX_next(ls);
-      if (ls->t.token == '[' || ls->t.token == ':' || ls->t.token == TK_PIPE)
+      if (ls->t.token == '[' || ls->t.token == ':')
         break;
       return;
     }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1457,7 +1457,10 @@ do
     assert(_SERVER.REDIRECT_INVOKE_FILENAME |> io.part|"parent"| == "/deez")
 end
 do
-    assert(("Hello" |> string.upper) == "HELLO")
+    local function test_util(str)
+        assert(str == "hellogoodbye")
+    end
+    ;("hello") |> |str| -> str .. "goodbye" |> test_util
 end
 
 print "Testing standard library additions."


### PR DESCRIPTION
e.g. can't do `30 |> print`, so strings shouldn't be any different. Also resolves the fact that the conatenation in `("hello") |> |str| -> str .. "goodbye" |> print` did not work as expected without quotes.