### PR TITLE
Respect bufflen when scanning for `@pluto_warnings`

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -630,7 +630,8 @@ static int llex (LexState *ls, SemInfo *seminfo, int *column) {
             ls->appendLineBuff(ls->current);
             save_and_next(ls);  /* skip until end of line (or end of file) */
           }
-          if (strstr(luaZ_buffer(ls->buff), "@pluto_warnings") != nullptr)
+          std::string buff(luaZ_buffer(ls->buff), luaZ_bufflen(ls->buff));
+          if (buff.find("@pluto_warnings") != std::string::npos)
             ls->lexPushWarningOverride().processComment(luaZ_buffer(ls->buff));
           luaZ_resetbuffer(ls->buff);
           if (ls->getLineBuff().find("@fallthrough") != std::string::npos)


### PR DESCRIPTION
`strstr` expects null-termination and I don't think it's guaranteed here