### PR TITLE
Added os.arch constant

### DIFF
--- a/src/loslib.cpp
+++ b/src/loslib.cpp
@@ -495,6 +495,18 @@ LUAMOD_API int luaopen_os (lua_State *L) {
 #endif
   lua_settable(L, -3);
 
+  /* define os.arch constant */
+  lua_pushliteral(L, "arch");
+#if defined(_M_X64) || defined(__x86_64__) || defined(__amd64__)
+  lua_pushliteral(L, "x86, 64-bit");
+#elif defined(_M_IX86) || defined(__i386__)
+  lua_pushliteral(L, "x86, 32-bit");
+#else
+  lua_pushliteral(L, "arm, 64-bit");
+#endif
+
+  lua_settable(L, -3);
+
   return 1;
 }
 


### PR DESCRIPTION
`print(os.arch)`: 
x64 build: `x86, 64-bit`
x86 build: `x86, 32-bit`
ARM64 build: `arm, 64-bit`

Closes: https://github.com/PlutoLang/Pluto/issues/1064

There is no ARM32 build configuration.
The output format can be changed to a more suitable format if desired.