### PR TITLE
Fix using undefined variable when emitting bytecode

### DIFF
--- a/src/ldump.cpp
+++ b/src/ldump.cpp
@@ -244,6 +244,7 @@ int luaU_dump(lua_State *L, const Proto *f, lua_Writer w, void *data,
   D.strip = strip;
   D.status = 0;
   D.lua_vm_compatible = true;
+  D.min_required_version = 0;
   check_vm_compatibility(f, D.lua_vm_compatible, D.min_required_version);
   dumpHeader(&D);
   dumpByte(&D, f->sizeupvalues);


### PR DESCRIPTION
This caused Lua-incompatible bytecode to also fail to load in Pluto because 'version' was (likely) not emitted as 0.