### PR TITLE
Remove let & const

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -56,7 +56,7 @@ static const char *const luaX_tokens [] = {
     "pluto_use",
     "pluto_switch", "pluto_continue", "pluto_enum", "pluto_new", "pluto_class", "pluto_parent", "pluto_export", "pluto_try", "pluto_catch",
           "switch",       "continue",       "enum",       "new",       "class",       "parent",       "export",       "try",       "catch",
-    "let", "const", "global",
+    "global",
 #ifdef PLUTO_PARSER_SUGGESTIONS
     "pluto_suggest_0", "pluto_suggest_1",
 #endif

--- a/src/llex.h
+++ b/src/llex.h
@@ -45,7 +45,7 @@ enum RESERVED {
   TK_PUSE, // New compatibility keywords.
   TK_PSWITCH, TK_PCONTINUE, TK_PENUM, TK_PNEW, TK_PCLASS, TK_PPARENT, TK_PEXPORT, TK_PTRY, TK_PCATCH,
   TK_SWITCH, TK_CONTINUE, TK_ENUM, TK_NEW, TK_CLASS, TK_PARENT, TK_EXPORT, TK_TRY, TK_CATCH, // New non-compatible keywords.
-  TK_LET, TK_CONST, TK_GLOBAL, // New optional keywords.
+  TK_GLOBAL, // New optional keywords.
 #ifdef PLUTO_PARSER_SUGGESTIONS
   TK_SUGGEST_0, TK_SUGGEST_1, // New special keywords.
 #endif
@@ -66,7 +66,7 @@ enum RESERVED {
 
 #define FIRST_COMPAT TK_PUSE
 #define FIRST_NON_COMPAT TK_SWITCH
-#define FIRST_OPTIONAL TK_LET
+#define FIRST_OPTIONAL TK_GLOBAL
 #define FIRST_SPECIAL TK_SUGGEST_0
 #define LAST_RESERVED TK_WHILE
 

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4931,40 +4931,6 @@ static void localstat (LexState *ls, bool isexport = false) {
   checktoclose(fs, toclose);
 }
 
-static void conststat (LexState *ls) {
-  FuncState *fs = ls->fs;
-  auto line = ls->getLineNumber(); /* in case we need to emit a warning */
-  int vidx = new_localvar(ls, str_checkname(ls, N_OVERRIDABLE), line);
-  TypeHint hint = gettypehint(ls);
-  Vardesc *var = getlocalvardesc(fs, vidx);
-  var->vd.kind = RDKCONST;
-  *var->vd.hint = hint;
-
-  expdesc e;
-  if (testnext(ls, '=')) {
-    ls->pushContext(PARCTX_CREATE_VAR);
-    TypeHint t;
-    expr_propagate(ls, &e, t);
-    ls->popContext(PARCTX_CREATE_VAR);
-    if (luaK_exp2const(fs, &e, &var->k)) {  /* compile-time constant? */
-      var->vd.kind = RDKCTC;  /* variable is a compile-time constant */
-      fs->nactvar++;  /* don't adjustlocalvars, but count it */
-    }
-    else {
-      exp_propagate(ls, e, t);
-      process_assign(ls, vidx, t, line);
-      adjust_assign(ls, 1, 1, &e);
-      adjustlocalvars(ls, 1);
-    }
-  }
-  else {
-    e.k = VVOID;
-    process_assign(ls, vidx, TypeHint{ VT_NIL }, line);
-    adjust_assign(ls, 1, 0, &e);
-    adjustlocalvars(ls, 1);
-  }
-}
-
 
 static int funcname (LexState *ls, expdesc *v) {
   /* funcname -> NAME {fieldsel} [':' NAME] */
@@ -5183,14 +5149,7 @@ static void usestat (LexState *ls) {
       else throwerr(ls, luaO_fmt(ls->L, "'pluto_use \"%s\"' is not valid", getstr(ls->t.seminfo.ts)), "did you mean \"0.8.0\", \"0.6.0\", \"0.5.0\" or \"0.2.0\"?");
       if (getstr(ls->t.seminfo.ts)[ls->t.seminfo.ts->size() - 1] == '+') {
         if (soup::version_compare(getstr(ls->t.seminfo.ts), "0.9.0") >= 0) {
-          tokens.emplace_back(TK_GLOBAL);
-          /* 'let' and 'const' are deprecated as of 0.9.0, so we don't wanna enable them with `pluto_use "0.9.0+"` */
-        }
-        else if (soup::version_compare(getstr(ls->t.seminfo.ts), "0.7.0") >= 0) {
-          tokens.emplace_back(TK_LET);
-          if (soup::version_compare(getstr(ls->t.seminfo.ts), "0.8.0") >= 0) {
-            tokens.emplace_back(TK_CONST);
-          }
+            tokens.emplace_back(TK_GLOBAL);
         }
       }
       luaX_next(ls);
@@ -5630,9 +5589,6 @@ static void statement (LexState *ls, TypeHint *prop) {
       classstat(ls, line, false);
       break;
     }
-    case TK_LET:
-      throw_warn(ls, "'let' will be removed in future versions of Pluto. use 'local' instead.", WT_DEPRECATED);
-      [[fallthrough]];
     case TK_LOCAL: {  /* stat -> localstat */
       luaX_next(ls);  /* skip LOCAL */
 #ifdef PLUTO_PARSER_SUGGESTIONS
@@ -5666,12 +5622,6 @@ static void statement (LexState *ls, TypeHint *prop) {
       }
       else
         localstat(ls);
-      break;
-    }
-    case TK_CONST: {
-      throw_warn(ls, "'const' will be removed in future versions of Pluto. use 'local' instead.", WT_DEPRECATED);
-      luaX_next(ls);  /* skip CONST */
-      conststat(ls);
       break;
     }
     case TK_EXPORT:
@@ -6231,12 +6181,6 @@ LClosure *luaY_parser (lua_State *L, LexState& lexstate, ZIO *z, Mbuffer *buff,
     applyenvkeywordpreference(&lexstate, TK_TRY, L->l_G->preference_try);
   if (L->l_G->have_preference_catch)
     applyenvkeywordpreference(&lexstate, TK_CATCH, L->l_G->preference_catch);
-#ifndef PLUTO_USE_LET
-  disablekeyword(&lexstate, TK_LET);
-#endif
-#ifndef PLUTO_USE_CONST
-  disablekeyword(&lexstate, TK_CONST);
-#endif
 #ifndef PLUTO_USE_GLOBAL
   disablekeyword(&lexstate, TK_GLOBAL);
 #endif

--- a/src/luaconf.h
+++ b/src/luaconf.h
@@ -926,14 +926,6 @@
 ** =====================================================================}
 */
 
-// If defined, Pluto will imply 'pluto_use let' at the beginning of every script.
-// Note that this keyword is deprecated as of 0.9.0.
-//#define PLUTO_USE_LET
-
-// If defined, Pluto will imply 'pluto_use const' at the beginning of every script.
-// Note that this keyword is deprecated as of 0.9.0.
-//#define PLUTO_USE_CONST
-
 // If defined, Pluto will imply 'pluto_use global' at the beginning of every script.
 //#define PLUTO_USE_GLOBAL
 


### PR DESCRIPTION
Because 'let' is still considered a keyword by the lexer, this was causing `$alias let = local` to fail.