### PR TITLE
Add __mindex metamethod

### DIFF
--- a/src/loslib.cpp
+++ b/src/loslib.cpp
@@ -247,8 +247,7 @@ static int getboolfield (lua_State *L, const char *key) {
 
 static int getfield (lua_State *L, const char *key, int d, int delta) {
   int isnum;
-  lua_pushstring(L, key);
-  int t = lua_rawget(L, -2);  /* get field and its type */
+  int t = lua_getfield(L, -1, key);  /* get field and its type */
   lua_Integer res = lua_tointegerx(L, -1, &isnum);
   if (!isnum) {  /* field is not an integer? */
     if (l_unlikely(t != LUA_TNIL))  /* some other value? */

--- a/src/ltable.cpp
+++ b/src/ltable.cpp
@@ -650,7 +650,7 @@ void luaH_initmetatable (lua_State *L, Table *t) {
     sethvalue(L, s2v(L->top.p - 1), table_mt);
     /* set __index */
     L->ci->top.p++;
-    lua_pushliteral(L, "__index");
+    lua_pushliteral(L, "__mindex");
     lua_getglobal(L, "table");
     lua_settable(L, -3);
     L->ci->top.p--;

--- a/src/ltm.h
+++ b/src/ltm.h
@@ -14,6 +14,7 @@
 */
 typedef enum {
   TM_INDEX,
+  TM_MINDEX,
   TM_NEWINDEX,
   TM_GC,
   TM_MODE,
@@ -43,7 +44,7 @@ typedef enum {
 
 
 inline const char *const luaT_eventname[] = {  /* ORDER TM */
-  "__index", "__newindex",
+  "__index", "__mindex", "__newindex",
   "__gc", "__mode", "__len", "__eq",
   "__add", "__sub", "__mul", "__mod", "__pow",
   "__div", "__idiv",

--- a/src/lvm.h
+++ b/src/lvm.h
@@ -123,7 +123,7 @@ LUAI_FUNC int luaV_tointegerns (const TValue *obj, lua_Integer *p,
                                 F2Imod mode);
 LUAI_FUNC int luaV_flttointeger (lua_Number n, lua_Integer *p, F2Imod mode);
 LUAI_FUNC void luaV_finishget (lua_State *L, const TValue *t, TValue *key,
-                               StkId val, const TValue *slot);
+                               StkId val, const TValue *slot, bool mindex = false);
 LUAI_FUNC void luaV_finishset (lua_State *L, const TValue *t, TValue *key,
                                TValue *val, const TValue *slot);
 LUAI_FUNC void luaV_finishOp (lua_State *L);

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2540,17 +2540,18 @@ do
     assert(t:contains("apple") == 1)
     assert(t:contains("banana") == 2)
     assert(t:contains("orange") == nil)
-end
-do
-    -- os.time in Lua may use __index to find fields, which is problematic as it will find the non-number field 'min'
-    -- So, we patch it to rawget, instead.
-    assert(os.time{year=2000, month=1, day=1})
-end
 
--- 'thread' type is given a metatable by Pluto
-do
+    -- 'thread' type is also given a metatable by Pluto
     local coro = coroutine.create(function() end)
     assert(coro:status() == "suspended")
+
+    -- We set __mindex, not __index, so only method calls are affected.
+    assert(t.contains == nil)
+    assert(os.time{year=2000, month=1, day=1})
+    t = setmetatable({}, { __index = { a = 1 } })
+    assert(t.a == 1)
+    assert(t.min == nil)
+    assert(t:min())
 end
 
 print "Testing default arguments."


### PR DESCRIPTION
This metamethod is only used by OP_SELF, which will still fall back to __index if __mindex is not used.
Also using __mindex instead of __index for default table metatable now.