### PR TITLE
Add math.isinf

### DIFF
--- a/src/lmathlib.cpp
+++ b/src/lmathlib.cpp
@@ -259,6 +259,12 @@ static int math_isnan (lua_State *L) {
 }
 
 
+static int math_isinf (lua_State *L) {
+  lua_pushboolean(L, lua_type(L, 1) == LUA_TNUMBER && isinf(lua_tonumber(L, 1)));
+  return 1;
+}
+
+
 
 /*
 ** {==================================================================
@@ -754,6 +760,7 @@ static const luaL_Reg mathlib[] = {
   {"tan",   math_tan},
   {"type", math_type},
   {"isnan", math_isnan},
+  {"isinf", math_isinf},
 #if defined(LUA_COMPAT_MATHLIB)
   {"atan2", math_atan},
   {"cosh",   math_cosh},

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2236,6 +2236,9 @@ end
 do
     assert(math.isnan(0 / 0) == true)
     assert(math.isnan(69) == false)
+
+    assert(math.isinf(1/0) == true)
+    assert(math.isinf(69) == false)
 end
 do
     local t = range(3)


### PR DESCRIPTION
Out of all the things we were missing from `fpclassify`, this seemed to be the only useful thing.