### PR TITLE
Fix "coroutine yielded values" warning for return values

### DIFF
--- a/src/lschedulerlib.cpp
+++ b/src/lschedulerlib.cpp
@@ -44,10 +44,7 @@ return class
             if self.errorfunc then
                 local f = t
                 t = coroutine.create(function()
-                    local r = table.pack(xpcall(f, self.errorfunc))
-                    if r[1] and r.n ~= 1 then
-                        warn("Coroutine yielded values to scheduler. Discarding them.")
-                    end
+                    xpcall(f, self.errorfunc)
                 end)
             else
                 t = coroutine.create(t)


### PR DESCRIPTION
This was incorrect because:
- Values were not yielded, but returned.
- This was just checking the presence of return values, so even nil would count, which interacted poorly with lambda syntax.