### PR TITLE
Use libc++ instead of libstdc++ on MacOS

### DIFF
--- a/scripts/common.php
+++ b/scripts/common.php
@@ -36,7 +36,15 @@ function check_compiler()
 	}
 	else
 	{
-		$compiler .= " -Wno-unused-command-line-argument -lm -lstdc++ -pthread -ldl";
+		if (PHP_OS_FAMILY == "Darwin")
+		{
+			$compiler .= " -lc++";
+		}
+		else
+		{
+			$compiler .= " -lstdc++";
+		}
+		$compiler .= " -Wno-unused-command-line-argument -lm -pthread -ldl";
 		if (!getenv("ANDROID_ROOT"))
 		{
 			$compiler .= " -lresolv";

--- a/src/vendor/Soup/build_common.php
+++ b/src/vendor/Soup/build_common.php
@@ -6,7 +6,7 @@ if (defined("PHP_WINDOWS_VERSION_MAJOR"))
 {
 	$clang .= " -D_CRT_SECURE_NO_WARNINGS";
 }
-else if (PHP_OS_FAMILY != "Darwin")
+else
 {
 	$clang .= " -fPIC";
 }
@@ -14,7 +14,15 @@ else if (PHP_OS_FAMILY != "Darwin")
 $clanglink = $clang;
 if (!defined("PHP_WINDOWS_VERSION_MAJOR"))
 {
-	$clanglink .= " -lstdc++ -pthread -lm -ldl";
+	if (PHP_OS_FAMILY == "Darwin")
+	{
+		$clanglink .= " -lc++";
+	}
+	else
+	{
+		$clanglink .= " -lstdc++";
+	}
+	$clanglink .= " -pthread -lm -ldl";
 	if (!getenv("ANDROID_ROOT"))
 	{
 		$clanglink .= " -lresolv";

--- a/src/vendor/Soup/build_lib.php
+++ b/src/vendor/Soup/build_lib.php
@@ -22,8 +22,11 @@ foreach(scandir(__DIR__."/soup") as $file)
 	if(substr($file, -4) == ".cpp")
 	{
 		$file = substr($file, 0, -4);
-		run_command_async("$clang -c ".__DIR__."/soup/$file.cpp -o ".__DIR__."/bin/int/$file.o");
-		array_push($objects, escapeshellarg("bin/int/$file.o"));
+		run_command_async("$clang -c ".__DIR__."/soup/$file.cpp -o ".__DIR__."/bin/int/$file.o -DSOUP_STANDALONE");
+		if ($file != "soup")
+		{
+			array_push($objects, escapeshellarg("bin/int/$file.o"));
+		}
 	}
 }
 await_commands();
@@ -31,11 +34,17 @@ await_commands();
 echo "Bundling static lib...\n";
 $archiver = "ar";
 $libname = "libsoup.a";
+$dllname = "libsoupbindings.so";
 if (defined("PHP_WINDOWS_VERSION_MAJOR"))
 {
 	$archiver = "llvm-ar";
 	$libname = "soup.lib";
+	$dllname = "soupbindings.dll";
 }
 passthru("$archiver rc $libname ".join(" ", $objects));
+
+// [Pluto] We don't need this
+//echo "Linking shared lib...\n";
+//passthru("$clanglink -o $dllname --shared bin/int/soup.o ".join(" ", $objects));
 
 chdir($cd);


### PR DESCRIPTION
Apparently libstdc++ is deprecated there, although in some weird way that doesn't get reported?

Also pulled in relevant Soup changes although I don't think they really make a difference here.