### PR TITLE
Add $getproptype

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -2900,7 +2900,18 @@ int luaB_assert (lua_State *L);
 static void const_expr (LexState *ls, expdesc *v) {
   switch (ls->t.token) {
     case TK_NAME: {
-      if (!check_constexpr_call(ls, v, "tonumber", luaB_tonumber)
+      if (strcmp(getstr(ls->t.seminfo.ts), "getproptype") == 0) {
+        luaX_next(ls); /* skip TK_NAME */
+        checknext(ls, '(');
+        TypeHint hint;
+        expr_propagate(ls, v, hint);
+        checknext(ls, ')');
+        auto& str = *pluto_newclassinst(ls->L, std::string);
+        str = hint.toString();
+        codestring(v, luaX_newstring(ls, str.data(), str.size()));
+        ls->L->top.p--;  /* pop 'str' */
+      }
+      else if (!check_constexpr_call(ls, v, "tonumber", luaB_tonumber)
           && !check_constexpr_call(ls, v, "utonumber", luaB_utonumber)
           && !check_constexpr_call(ls, v, "tostring", luaB_tostring)
           && !check_constexpr_call(ls, v, "utostring", luaB_utostring)

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -301,7 +301,7 @@ struct TypeHint {
 
   [[nodiscard]] std::string toString() const {
     if (empty()) {
-      return "NOINFO";
+      return "never";
     }
     std::string str{};
     if (isNullable()) {


### PR DESCRIPTION
```lua
local a = function()
    return 1
end
print($getproptype(a)) --> function(int)
```
Maybe not a function one should rely upon, but should scratch that reflection itch, to query the parser for what it knows.