### PR TITLE
Add table field type propagation and hinting

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -64,6 +64,19 @@
 
 
 std::string TypeDesc::toString() const {
+  if (type == VT_TABLE && nfields != -1) {
+    std::string str(1, '{');
+    for (int8_t i = 0;; ) {
+      str.append(getstr(names[i]), tsslen(names[i]));
+      str.append(": ");
+      str.append(hints[i]->toString());
+      if (++i == nfields)
+        break;
+      str.append(", ");
+    }
+    str.push_back('}');
+    return str;
+  }
   std::string str = vtToString(type);
   if (type == VT_FUNC) {
     if (nparam >= 0) {  /* know parameters? */
@@ -518,6 +531,25 @@ static void checktypehint (LexState *ls, TypeHint &th) {
   if (testnext(ls, '?'))
     th.emplaceTypeDesc(VT_NIL);
   do {
+    if (ls->t.token == '{') {
+      luaX_next(ls);  /* skip '{' */
+      TypeDesc td = VT_TABLE;
+      td.nfields = 0;
+      do {
+        TString *ts = str_checkname(ls, N_RESERVED);
+        checknext(ls, ':');
+        TypeHint *fieldth = new_typehint(ls);
+        checktypehint(ls, *fieldth);
+        if (td.nfields != MAX_TYPED_FIELDS) {
+          td.names[td.nfields] = ts;
+          td.hints[td.nfields] = fieldth;
+          ++td.nfields;
+        }
+      } while (testnext(ls, ',') || testnext(ls, ';'));
+      checknext(ls, '}');
+      th.emplaceTypeDesc(std::move(td));
+      continue;
+    }
     TString *ts = str_checkname(ls, N_RESERVED);
     const char *tname = getstr(ts);
     if (strcmp(tname, "number") == 0)
@@ -1584,13 +1616,22 @@ static void breakstat (LexState *ls) {
 }
 
 
-static void fieldsel (LexState *ls, expdesc *v) {
+static void fieldsel (LexState *ls, expdesc *v, TypeHint *prop = nullptr) {
   /* fieldsel -> ['.' | ':'] NAME */
   FuncState *fs = ls->fs;
   expdesc key;
+  TypeHint th;
+  if (prop) exp_propagate(ls, *v, th);
   luaK_exp2anyregup(fs, v);
   luaX_next(ls);  /* skip the dot or colon */
   codename(ls, &key, N_RESERVED);
+  if (prop && th.descs[0].type == VT_TABLE && th.descs[0].nfields != -1 && key.k == VKSTR) {
+    for (lu_byte i = 0; i != th.descs[0].nfields; ++i) {
+      if (eqstr(key.u.strval, th.descs[0].names[i])) {
+        *prop = *th.descs[0].hints[i];
+      }
+    }
+  }
   luaK_indexed(fs, v, &key);
 }
 
@@ -1614,6 +1655,7 @@ static void yindex (LexState *ls, expdesc *v) {
 typedef struct ConsControl {
   expdesc v;  /* last list item read */
   expdesc *t;  /* table descriptor */
+  TypeDesc *td = nullptr;
   int nh;  /* total number of 'record' elements */
   int na;  /* number of array elements already stored */
   int tostore;  /* number of array elements pending to be stored */
@@ -1631,13 +1673,16 @@ static void preassignfield (LexState *ls, expdesc& key) {
   }
 }
 
+static void expr_propagate (LexState *ls, expdesc *v, TypeHint& t);
+
 static void recfield (LexState *ls, ConsControl *cc, bool for_class) {
   /* recfield -> (NAME | '['exp']') = exp */
   FuncState *fs = ls->fs;
   auto reg = ls->fs->freereg;
   expdesc tab, key, val;
+  TString *name = nullptr;
   if (ls->t.token == TK_NAME) {
-    TString *name = str_checkname(ls, N_RESERVED);  /* we already know this is a TK_NAME, but don't wanna raise non-portable-name, so passing N_RESERVED */
+    name = str_checkname(ls, N_RESERVED);  /* we already know this is a TK_NAME, but don't wanna raise non-portable-name, so passing N_RESERVED */
     if (for_class) {
       if (strcmp(getstr(name), "public") == 0) {
         name = str_checkname(ls);
@@ -1670,7 +1715,20 @@ static void recfield (LexState *ls, ConsControl *cc, bool for_class) {
   }
   else {
     checknext(ls, '=');
-    expr(ls, &val);
+    if (name && cc->td) {
+      if (cc->td->nfields == -1) {
+        cc->td->nfields = 0;
+      }
+      if (cc->td->nfields != MAX_TYPED_FIELDS) {
+        TypeHint *th = new_typehint(ls);
+        expr_propagate(ls, &val, *th);
+        cc->td->names[cc->td->nfields] = name;
+        cc->td->hints[cc->td->nfields] = th;
+        ++cc->td->nfields;
+      }
+      else expr(ls, &val);
+    }
+    else expr(ls, &val);
   }
   luaK_storevar(fs, &tab, &val);
   fs->freereg = reg;  /* free registers */
@@ -1808,7 +1866,7 @@ static void field (LexState *ls, ConsControl *cc, bool for_class = false) {
 }
 
 
-static void constructor (LexState *ls, expdesc *t) {
+static void constructor (LexState *ls, expdesc *t, TypeDesc *td) {
   /* constructor -> '{' [ field { sep field } [sep] ] '}'
      sep -> ',' | ';' */
   FuncState *fs = ls->fs;
@@ -1819,6 +1877,7 @@ static void constructor (LexState *ls, expdesc *t) {
   luaK_code(fs, 0);  /* space for extra arg. */
   cc.na = cc.nh = cc.tostore = 0;
   cc.t = t;
+  cc.td = td;
   init_exp(t, VNONRELOC, fs->freereg);  /* table will be at stack top */
   luaK_reserveregs(fs, 1);
   init_exp(&cc.v, VVOID, 0);  /* no value (yet) */
@@ -2692,9 +2751,9 @@ static void funcargs (LexState *ls, expdesc *f, TypeDesc *funcdesc = nullptr) {
     }
     case '{': {  /* funcargs -> constructor */
       auto hint = new_typehint(ls);
-      hint->emplaceTypeDesc(VT_TABLE);
+      hint->descs[0].type = VT_TABLE;
+      constructor(ls, &args, &hint->descs[0]);
       fas.argdescs = { hint };
-      constructor(ls, &args);
       break;
     }
     case TK_STRING: {  /* funcargs -> STRING */
@@ -3439,7 +3498,7 @@ static void expsuffix (LexState *ls, expdesc *v, int line, int flags, int8_t *np
         break;
       }
       case '.': {  /* fieldsel */
-        fieldsel(ls, v);
+        fieldsel(ls, v, prop);
         break;
       }
       case '[': {  /* '[' exp ']' */
@@ -3953,8 +4012,12 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, int8_t *nprop, TypeH
       break;
     }
     case '{': {  /* constructor */
-      if (prop) prop->emplaceTypeDesc(VT_TABLE);
-      constructor(ls, v);
+      if (prop) {
+        TypeDesc td = VT_TABLE;
+        constructor(ls, v, &td);
+        prop->emplaceTypeDesc(std::move(td));
+      }
+      else constructor(ls, v, nullptr);
       if (ls->t.token == '[' || ls->t.token == ':' || ls->t.token == '.' || ls->t.token == TK_PIPE)
         break;
       return;

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -140,23 +140,33 @@ struct TypeHint;
 
 inline constexpr int MAX_TYPED_RETURNS = 3;
 inline constexpr int MAX_TYPED_PARAMS = 7;
+inline constexpr int MAX_TYPED_FIELDS = 5;
 
-struct TypeDesc {
-  ValType type;
+union TypeDesc {
+  struct {
+    ValType type;
+    /* function info */
+    int8_t nparam;
+    int8_t nret;
+    bool nodiscard;
+    Proto* proto;
+    TypeHint* returns[MAX_TYPED_RETURNS];
+    TypeHint* params[MAX_TYPED_PARAMS];
+  };
+  struct {
+    ValType type_;
+    /* table info */
+    int8_t nfields;
+    TString* names[MAX_TYPED_FIELDS];
+    TypeHint* hints[MAX_TYPED_FIELDS];
+  };
 
-  /* function info */
-  bool nodiscard = false;
-  int8_t nparam = -1;
-  int8_t nret = -1;
-  Proto* proto = nullptr;
-  TypeHint* returns[MAX_TYPED_RETURNS];
-  TypeHint* params[MAX_TYPED_PARAMS];
-
-  TypeDesc() = default;
-
-  TypeDesc(ValType type)
-    : type(type)
-  {
+  TypeDesc(ValType type = VT_NONE)
+    : type(type) {
+    nparam = -1;  /* also sets nfields to -1 */
+    nret = -1;
+    nodiscard = false;
+    proto = nullptr;
   }
 
   void clear() noexcept {

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -124,6 +124,13 @@ f(tonumber)]]
 end
 f(tonumber)]]
 
+    -- Complex table type hints
+    assert_warn[[local h = { name = "" }
+    local _: number = h.name]]
+    assert_warn[[local function _f(h: { name: string })
+        local _: number = h.name
+    end]]
+
     -- Nested localstat
     assert_no_warn[[local _f: function = function()
     local _: int = 0


### PR DESCRIPTION
One interesting thing about this:
```luau
local h = { name = "John" }
h.name = 69
local _: number = h.name -- '_' type-hinted as 'number', but provided with 'string' value.
```

Which is maybe not too bad; TS for reference:
```ts
const h = { name: "John" };
h.name = 69; // Type 'number' is not assignable to type 'string'.
const _: number = h.name; // Type 'string' is not assignable to type 'number'.
```