### PR TITLE
Fix global function type propagation

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -5363,10 +5363,11 @@ static void funcstat (LexState *ls, int line, const bool global) {
   check_readonly(ls, &v);
   if (v.k == VINDEXUP) {
     TValue *key = &ls->fs->f->k[v.u.ind.idx];
-    lua_assert(ttype(key) == LUA_TSTRING);
-    TypeHint th;
-    th.emplaceTypeDesc(std::move(funcdesc));
-    get_global_prop(ls, tsvalue(key)).merge(th);
+    if (ttype(key) == LUA_TSTRING) {
+      TypeHint th;
+      th.emplaceTypeDesc(std::move(funcdesc));
+      get_global_prop(ls, tsvalue(key)).merge(th);
+    }
   }
   luaK_storevar(ls->fs, &v, &b);
   luaK_fixline(ls->fs, line);  /* definition "happens" in the first line */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -5355,8 +5355,19 @@ static void funcstat (LexState *ls, int line, const bool global) {
   ismethod = funcname(ls, &v);
   if (!global)
     check_assignment(ls, &v);
-  body(ls, &b, ismethod, line);
+  TypeDesc funcdesc;
+  if (v.k == VINDEXUP)
+    body(ls, &b, ismethod, line, &funcdesc);
+  else
+    body(ls, &b, ismethod, line);
   check_readonly(ls, &v);
+  if (v.k == VINDEXUP) {
+    TValue *key = &ls->fs->f->k[v.u.ind.idx];
+    lua_assert(ttype(key) == LUA_TSTRING);
+    TypeHint th;
+    th.emplaceTypeDesc(std::move(funcdesc));
+    get_global_prop(ls, tsvalue(key)).merge(th);
+  }
   luaK_storevar(ls->fs, &v, &b);
   luaK_fixline(ls->fs, line);  /* definition "happens" in the first line */
 }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -4327,3 +4327,11 @@ do
         2,
     ) == 3)
 end
+
+print "Testing global function type propagation."
+do
+    assert_warn[[
+        function f(_a: bool, _b: bool, _c: string) end
+        f(true, false, true)
+    ]]
+end


### PR DESCRIPTION
## Summary
- ensure `funcstat` propagates type info for globals
- add regression test for global function type propagation

## Testing
- `make generic` *(fails: libpluto build issues)*

------
https://chatgpt.com/codex/tasks/task_e_687fee828bb08325ab9d315f8b81f4fc