### PR TITLE
Add io.symlink

### DIFF
--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -4505,6 +4505,12 @@ do
     io.copy("example_module.pluto", "file_that_doesnt_exist")
     assert(io.contents("example_module.pluto") == io.contents("file_that_doesnt_exist"))
 
+    -- symlink
+    -- @pluto_warnings disable-next
+    DEFER(io.remove("example_module_link.pluto"))
+    io.symlink("example_module.pluto", "example_module_link.pluto")
+    assert(io.contents("example_module_link.pluto") == io.contents("example_module.pluto"))
+
     assert(io.unique("example_module", "pluto") == "example_module (2).pluto")
     assert(io.unique("file_that_doesnt_exist", "pluto") == "file_that_doesnt_exist.pluto")
 end


### PR DESCRIPTION
## Summary
- add `io.symlink` to filesystem library for creating symbolic links
- test `io.symlink` behavior in basic platform tests
- always choose directory or file symlink based on source type for portability

## Testing
- `php scripts/compile.php clang`
- `php scripts/link_pluto.php clang`
- `php scripts/link_plutoc.php clang`
- `src/pluto testes/_driver.pluto`


------
https://chatgpt.com/codex/tasks/task_e_68a79ff3cde08325b5cc7537b3dc21c7