### PR TITLE
Support indexing in prefixed ++ expression

### DIFF
--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -3276,15 +3276,9 @@ do
     assert(++a == 2)
     assert(a == 2)
 
-    -- https://github.com/PlutoLang/Pluto/issues/1293
-    assert(
-        nil == load[[
-            local t = { a = 1 }
-            assert(++t.a == 2)
-            assert(t.a == 2)
-        ]]
-    )
-    
+    local t = { a = 1 }
+    assert(++t.a == 2)
+    assert(t.a == 2)
 end
 do
     -- statement


### PR DESCRIPTION
```lua
print(++t.a)
```
is now finally valid (and not problematic) thanks to rewriting the code like so:
```lua
print((function() t.a += 1; return t.a end)())
```