### PR TITLE
Skip dead code generation for constant ternary conditions

### DIFF
--- a/src/lcode.h
+++ b/src/lcode.h
@@ -59,6 +59,27 @@ typedef enum UnOpr { OPR_MINUS, OPR_BNOT, OPR_NOT, OPR_LEN, OPR_NOUNOPR } UnOpr;
 
 #define luaK_jumpto(fs,t)	luaK_patchlist(fs, luaK_jump(fs), t)
 
+#define luaK_checkpoint(fs, snap) \
+  struct { \
+    int pc; int lasttarget; int previousline; int nabslineinfo; \
+    int nk; int np; int sizek; int sizep; \
+    lu_byte iwthabs; lu_byte freereg; \
+  } snap { \
+    (fs)->pc, (fs)->lasttarget, (fs)->previousline, (fs)->nabslineinfo, \
+    (fs)->nk, (fs)->np, (fs)->f->sizek, (fs)->f->sizep, \
+    (fs)->iwthabs, (fs)->freereg \
+  }
+
+#define luaK_restore(fs, snap) \
+  do { \
+    (fs)->pc = (snap).pc; (fs)->lasttarget = (snap).lasttarget; \
+    (fs)->previousline = (snap).previousline; (fs)->nabslineinfo = (snap).nabslineinfo; \
+    (fs)->nk = (snap).nk; (fs)->np = (snap).np; \
+    (fs)->f->sizek = (snap).sizek; (fs)->f->sizep = (snap).sizep; \
+    (fs)->iwthabs = (snap).iwthabs; (fs)->freereg = (snap).freereg; \
+  } while (false)
+
+
 LUAI_FUNC int luaK_code (FuncState *fs, Instruction i);
 LUAI_FUNC int luaK_codeABx (FuncState *fs, OpCode o, int A, unsigned Bx);
 LUAI_FUNC int luaK_codeABCk (FuncState *fs, OpCode o, int A,

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4550,26 +4550,44 @@ static void expr (LexState *ls, expdesc *v, int8_t *nprop, TypeHint *prop, int f
   if (testnext(ls, '?')) { /* ternary expression? */
     check_condition(ls, !(flags & E_NO_CONSUME_COLON), "cannot use a ternary expression in this context");
     if (prop) prop->clear(); /* we don't care what type the condition is/was */
-    int escape = NO_JUMP;
     v->normalizeFalse();
-    if (luaK_isalwaystrue(ls, v))
-      throw_warn(ls, "unreachable code", "the condition before the '?' is always truthy, hence the expression after the ':' is never used.", WT_UNREACHABLE_CODE);
-    else if (luaK_isalwaysfalse(ls, v))
-      throw_warn(ls, "unreachable code", "the condition before the '?' is always falsy, hence the expression before the ':' is never used.", WT_UNREACHABLE_CODE);
-    luaK_goiftrue(ls->fs, v);
-    int condition = v->f;
-    expr(ls, v, nprop, prop, E_NO_METHOD_CALL);
-    auto fs = ls->fs;
-    luaK_exp2nextreg(fs, v);
-    auto reg = v->u.reg;
-    luaK_concat(fs, &escape, luaK_jump(fs));
-    luaK_patchtohere(fs, condition);
-    checknext(ls, ':');
-    ls->pushContext(PARCTX_TERNARY_C);
-    expr(ls, v, nprop, prop, flags & E_NO_METHOD_CALL);
-    ls->popContext(PARCTX_TERNARY_C);
-    luaK_exp2reg(fs, v, reg);
-    luaK_patchtohere(fs, escape);
+    if (luaK_isalwaysfalse(ls, v)) {  /* skip 'b' expression */
+      luaK_checkpoint(ls->fs, cp);
+      expdesc dummy;
+      expr(ls, &dummy, nullptr, nullptr, E_NO_METHOD_CALL);
+      luaK_restore(ls->fs, cp);
+      checknext(ls, ':');
+      ls->pushContext(PARCTX_TERNARY_C);
+      expr(ls, v, nprop, prop, flags & E_NO_METHOD_CALL);
+      ls->popContext(PARCTX_TERNARY_C);
+    }
+    else if (luaK_isalwaystrue(ls, v)) {  /* skip 'c' expression */
+      expr(ls, v, nprop, prop, E_NO_METHOD_CALL);
+      checknext(ls, ':');
+      ls->pushContext(PARCTX_TERNARY_C);
+      luaK_checkpoint(ls->fs, cp);
+      expdesc dummy;
+      expr(ls, &dummy, nullptr, nullptr, flags & E_NO_METHOD_CALL);
+      luaK_restore(ls->fs, cp);
+      ls->popContext(PARCTX_TERNARY_C);
+    }
+    else {
+      int escape = NO_JUMP;
+      luaK_goiftrue(ls->fs, v);
+      int condition = v->f;
+      expr(ls, v, nprop, prop, E_NO_METHOD_CALL);
+      auto fs = ls->fs;
+      luaK_exp2nextreg(fs, v);
+      auto reg = v->u.reg;
+      luaK_concat(fs, &escape, luaK_jump(fs));
+      luaK_patchtohere(fs, condition);
+      checknext(ls, ':');
+      ls->pushContext(PARCTX_TERNARY_C);
+      expr(ls, v, nprop, prop, flags & E_NO_METHOD_CALL);
+      ls->popContext(PARCTX_TERNARY_C);
+      luaK_exp2reg(fs, v, reg);
+      luaK_patchtohere(fs, escape);
+    }
   }
 }
 

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -965,8 +965,6 @@ end
 
 print "Testing ternary expression."
 do
-    -- @pluto_warnings: disable-unreachable-code
-
     local a = 3
     assert((true ? "yes" : "no") == "yes")
     assert((false ? "yes" : "no") == "no")
@@ -993,7 +991,10 @@ do
         "no"
     end == "yes")
 
-    -- @pluto_warnings: enable-unreachable-code
+    -- Dead code elimination
+    assert(not "off" in string.dump(function()
+        print(true ? "on" : "off")
+    end))
 end
 do
     local t = {}


### PR DESCRIPTION
## Summary
- avoid emitting unreachable code when a ternary expression's condition is a compile-time constant

## Testing
- `php scripts/compile.php clang`
- `php scripts/link_pluto.php clang`
- `php scripts/link_plutoc.php clang`
- `src/pluto testes/_driver.pluto`


------
https://chatgpt.com/codex/tasks/task_e_68bfd2b8bda4832582a4710f362335d2