### PR TITLE
Ensure bigint operations error on missing operands

### DIFF
--- a/src/lbigint.cpp
+++ b/src/lbigint.cpp
@@ -12,7 +12,7 @@ soup::Bigint* checkbigint (lua_State *L, int i) {
     const char *str = lua_tolstring(L, -1, &len);
     pushbigint(L, soup::Bigint::fromString(str, len));
     lua_replace(L, -2);
-    i = -1;
+    lua_replace(L, i);
   }
   return (soup::Bigint*)luaL_checkudata(L, i, "pluto:bigint");
 }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -2772,6 +2772,8 @@ do
     -- Force integer representation
     assert(bigint.new(1.0):tostring() == "1")
     assert(not pcall(bigint.new, 1.2))
+    -- Missing operands should raise error
+    assert(not pcall(bigint.add, 1))
 
     -- Mixed bigint/number operands
     assert(tostring(new bigint(4) * 2) == "8")


### PR DESCRIPTION
## Summary
- Fix bigint argument conversion to avoid using first argument twice
- Add regression test asserting bigint.add errors when called with too few arguments

## Testing
- `php scripts/compile.php clang`
- `php scripts/link_pluto.php clang`
- `php scripts/link_plutoc.php clang`
- `src/pluto testes/_driver.pluto`

------
https://chatgpt.com/codex/tasks/task_e_68c3f7f585e483258ca494ad523ed1b1