### PR TITLE
Fix stack corruption when 'in' expression has to run Lua for comparisons

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4307,17 +4307,16 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, int8_t *nprop, TypeH
 
 
 static void inexpr (LexState *ls, expdesc *v, int flags) {
-  expdesc v2;
   checknext(ls, TK_IN);
   luaK_exp2nextreg(ls->fs, v);
   lua_assert(v->k == VNONRELOC);
-  int base = v->u.reg;
+  expdesc v2;
   simpleexp(ls, &v2, flags);
-  luaK_dischargevars(ls->fs, &v2);
   luaK_exp2nextreg(ls->fs, &v2);
+  lua_assert(v2.k == VNONRELOC);
   luaK_codeABC(ls->fs, OP_IN, v->u.reg, v2.u.reg, 0);
   ls->fs->f->onPlutoOpUsed(0);
-  ls->fs->freereg = base + 1;
+  luaK_freeexp(ls->fs, &v2);
 }
 
 

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -865,11 +865,13 @@ static void inopr (lua_State *L, StkId ra, TValue *a, TValue *b) {
       else
         luaG_runerror(L, "expected second 'in' operand to be table, got %s", ttypename(ttype(b)));
     } else {
+      L->top.p++;  /* may need to call a Lua function, prevent stack corruption */
       if (luaV_searchelement(L, hvalue(b), a)) {
         setbtvalue(s2v(ra));
       } else {
         setbfvalue(s2v(ra));
       }
+      L->top.p--;
     }
   }
 }

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -1075,6 +1075,43 @@ do
     t[1] = "world"
     assert((1 in t) == false)
 end
+do
+    local class Point
+        function __construct(public x, public y) end
+
+        function __eq(other)
+            return self.x == other.x and self.y == other.y
+        end
+
+        function __tostring() return $"({self.x}, {self.y})" end
+    end
+
+    local points  = {new Point(1, 1), new Point(1, 2)}
+    local points2 = {new Point(1, 1), new Point(1, 3)}
+
+    do
+        local n = 0
+        for i = 1, #points do
+            local p = points[i]
+            if p in points2 then
+                assert(tostring(p) == "(1, 1)")
+                ++n
+            end
+        end
+        assert(n == 1)
+    end
+
+    do
+        local n = 0
+        for points as p do
+            if p in points2 then
+                assert(tostring(p) == "(1, 1)")
+                ++n
+            end
+        end
+        assert(n == 1)
+    end
+end
 
 print "Testing break N syntax."
 do


### PR DESCRIPTION
Changes to codegen are only for my own sanity but should not change functionality.