### PR TITLE
Fix parsing of pipeline operator after string literals

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -4195,7 +4195,7 @@ static void simpleexp (LexState *ls, expdesc *v, int flags, int8_t *nprop, TypeH
       }
       codestring(v, ls->t.seminfo.ts);
       luaX_next(ls);
-      if (ls->t.token == '[' || ls->t.token == ':')
+      if (ls->t.token == '[' || ls->t.token == ':' || ls->t.token == TK_PIPE)
         break;
       return;
     }


### PR DESCRIPTION
## Summary
- allow the expression parser to treat string literals followed by `|>` as suffixed expressions
- ensure string literal pipelines can be used in expression contexts such as assignments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d68ace488c832583f5ba231092ff3d