### PR TITLE
Fix handling when invalid UTF-8 is passed to IO functions

### DIFF
--- a/src/lbufferlib.cpp
+++ b/src/lbufferlib.cpp
@@ -104,7 +104,7 @@ static int buffer_append (lua_State *L) {
   try {
     checkbuffer(L, 1)->buffer.append(data, size);
   }
-  catch (std::bad_alloc&) {
+  catch (const std::bad_alloc&) {
     fail = true;
   }
   if (l_unlikely(fail))
@@ -118,7 +118,7 @@ static int buffer_tostring (lua_State *L) {
   try {
     lua_pushlstring(L, (const char*)buf.data(), buf.size());
   }
-  catch (std::bad_alloc&) {
+  catch (const std::bad_alloc&) {
     fail = true;
   }
   if (l_unlikely(fail))

--- a/src/lcryptolib.cpp
+++ b/src/lcryptolib.cpp
@@ -674,7 +674,7 @@ static int l_encrypt (lua_State *L) {
           rsa_priv_encrypt_raw(data, p, q);
         }
       }
-      catch (std::exception&) {  /* Either "Assertion failed" or "Modular multiplicative inverse does not exist as the numbers are not coprime" */
+      catch (const std::exception&) {  /* Either "Assertion failed" or "Modular multiplicative inverse does not exist as the numbers are not coprime" */
         data.clear(); data.shrink_to_fit();
         fail = true;
       }
@@ -887,7 +887,7 @@ static int l_decrypt (lua_State *L) {
           rsa_priv_decrypt_raw(data, p, q);
         }
       }
-      catch (std::exception&) {  /* Either "Assertion failed" or "Modular multiplicative inverse does not exist as the numbers are not coprime" */
+      catch (const std::exception&) {  /* Either "Assertion failed" or "Modular multiplicative inverse does not exist as the numbers are not coprime" */
         data.clear(); data.shrink_to_fit();
         invalidkey = true;
       }
@@ -952,7 +952,7 @@ static int l_sign (lua_State *L) {
           data = soup::RsaPrivateKey::fromPrimes(*p, *q).sign<soup::sha256>(data).toBinary();
         }
       }
-      catch (std::exception&) {  /* Either "Assertion failed" or "Modular multiplicative inverse does not exist as the numbers are not coprime" */
+      catch (const std::exception&) {  /* Either "Assertion failed" or "Modular multiplicative inverse does not exist as the numbers are not coprime" */
         data.clear(); data.shrink_to_fit();
         fail = true;
       }

--- a/src/lffi.cpp
+++ b/src/lffi.cpp
@@ -255,7 +255,7 @@ static int ffi_funcwrapper_call (lua_State *L) {
   try {
     retval = soup::ffi::call(fw->addr, args, i);
   }
-  catch (std::exception& e) {
+  catch (const std::exception& e) {
     callback_L = nullptr;
     luaL_error(L, "C++ exception: %s", e.what());
   }

--- a/src/liolib.cpp
+++ b/src/liolib.cpp
@@ -862,11 +862,18 @@ static int f_flush (lua_State *L) {
     f = luaL_checkstring(L, idx);
   }
 
+  std::filesystem::path& p = *pluto_newclassinst(L, std::filesystem::path);
+  try {
 #if SOUP_CPP20
-  return *pluto_newclassinst(L, std::filesystem::path, soup::string::toUtf8Type(f));
+    p = soup::string::toUtf8Type(f);
 #else
-  return *pluto_newclassinst(L, std::filesystem::path, std::filesystem::u8path(f));
+    p = std::filesystem::u8path(f);
 #endif
+  }
+  catch (const std::exception& e) {
+    luaL_error(L, "%s", e.what());
+  }
+  return p;
 }
 
 static void checkPathForRead (lua_State *L, std::filesystem::path& path) {


### PR DESCRIPTION
e.g. `print(io.contents("\188"))` would cause a C++ error to be thrown