### PR TITLE
Change os.platform value for WASM build to "emscripten"

### DIFF
--- a/src/loslib.cpp
+++ b/src/loslib.cpp
@@ -525,7 +525,7 @@ LUAMOD_API int luaopen_os (lua_State *L) {
 #if SOUP_WINDOWS
   lua_pushliteral(L, "windows");
 #elif SOUP_WASM
-  lua_pushliteral(L, "wasm");
+  lua_pushliteral(L, "emscripten");
 #elif SOUP_LINUX
   lua_pushliteral(L, "linux");
 #elif SOUP_MACOS


### PR DESCRIPTION
WASM is the architecture. Emscripten is the platform. Another WASM-based platform would be WASI (albeit it's too immature to target Pluto against at present).