### PR TITLE
Preserve numeric literals in warning snippets

### DIFF
--- a/src/llex.cpp
+++ b/src/llex.cpp
@@ -531,25 +531,43 @@ static int check_next2 (LexState *ls, const char *set) {
 **
 ** The caller might have already read an initial dot.
 */
+static void save_numeral_and_next (LexState *ls) {
+  ls->appendLineBuff(cast_char(ls->current));
+  save_and_next(ls);
+}
+
+
+static int check_next2_numeral (LexState *ls, const char *set) {
+  lua_assert(set[2] == '\0');
+  if (ls->current == set[0] || ls->current == set[1]) {
+    save_numeral_and_next(ls);
+    return 1;
+  }
+  else return 0;
+}
+
+
 static int read_numeral (LexState *ls, SemInfo *seminfo) {
   TValue obj;
   const char *expo = "Ee";
   int first = ls->current;
   lua_assert(lisdigit(ls->current));
-  save_and_next(ls);
-  if (first == '0' && check_next2(ls, "xX"))  /* hexadecimal? */
+  save_numeral_and_next(ls);
+  if (first == '0' && check_next2_numeral(ls, "xX"))  /* hexadecimal? */
     expo = "Pp";
   for (;;) {
-    if (check_next2(ls, expo))  /* exponent mark? */
-      check_next2(ls, "-+");  /* optional exponent sign */
+    if (check_next2_numeral(ls, expo))  /* exponent mark? */
+      check_next2_numeral(ls, "-+");  /* optional exponent sign */
     else if (lisxdigit(ls->current) || ls->current == '.' || ls->current == 'o')  /* '%x|%.' */
-      save_and_next(ls);
-    else if (ls->current == '_')
+      save_numeral_and_next(ls);
+    else if (ls->current == '_') {
+      ls->appendLineBuff('_');
       next(ls);
+    }
     else break;
   }
   if (lislalpha(ls->current))  /* is numeral touching a letter? */
-    save_and_next(ls);  /* force an error */
+    save_numeral_and_next(ls);  /* force an error */
   save(ls, '\0');
   if (luaO_str2num(luaZ_buffer(ls->buff), &obj) == 0)  /* format error? */
     lexerror(ls, "malformed number", TK_FLT);
@@ -1106,22 +1124,13 @@ static int llex (LexState *ls, SemInfo *seminfo, int *column) {
           return '.';
         }
         else {
-          int ret = read_numeral(ls, seminfo);
-          if (ret == TK_INT)
-            ls->appendLineBuff(std::to_string(seminfo->i));
-          else
-            ls->appendLineBuff(std::to_string(seminfo->r));
-          return ret;
+          ls->appendLineBuff('.');
+          return read_numeral(ls, seminfo);
         }
       }
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9': {
-        int ret = read_numeral(ls, seminfo);
-        if (ret == TK_INT)
-          ls->appendLineBuff(std::to_string(seminfo->i));
-        else
-          ls->appendLineBuff(std::to_string(seminfo->r));
-        return ret;
+        return read_numeral(ls, seminfo);
       }
       case '_': {  /* arbitrary underscores for more readable long numbers */
         if (lislalpha(ls->current)) {
@@ -1142,12 +1151,8 @@ static int llex (LexState *ls, SemInfo *seminfo, int *column) {
         } else {  /* needed to emulate default check because _ is fairly multi-purpose. */
           next(ls);
           if (lisdigit(ls->current)) {
-            int ret = read_numeral(ls, seminfo);
-            if (ret == TK_INT)
-              ls->appendLineBuff(std::to_string(seminfo->i));
-            else
-              ls->appendLineBuff(std::to_string(seminfo->r));
-            return ret;  /* arbitrary character detected in numeral */
+            ls->appendLineBuff('_');
+            return read_numeral(ls, seminfo);  /* arbitrary character detected in numeral */
           } else {
             ls->appendLineBuff('_');
             return '_';  /* this is a normal underscore */

--- a/testes/pluto/basic.pluto
+++ b/testes/pluto/basic.pluto
@@ -17,6 +17,14 @@ end
 print "Testing warnings."
 do
     assert_warn([[local a; local a]]) -- var-shadow
+    do
+        local warning = wcall(function()
+            assert(load[[local a = 0x61
+local a = 0x61]])()
+        end)
+        assert(warning:find("local a = 0x61", 1, true))
+        assert(not warning:find("local a = 97", 1, true))
+    end
 
     -- unused
     assert_warn[[local a]]


### PR DESCRIPTION
### Motivation
- Warning snippets for numeric literals lost original source text because the lexer appended numeric values (`97`) instead of the original literal (`0x61`), causing confusing messages like `local a = 97` for `local a = 0x61` in duplicate-local warnings.

### Description
- Update numeral lexing in `src/llex.cpp` to preserve the original numeric characters into the line buffer by adding `save_numeral_and_next` and `check_next2_numeral` and using them from `read_numeral` so the exact literal text is retained.
- Stop post-conversion appends of `std::to_string(...)` for numeric tokens in `llex` and instead let the updated numeral reader populate the source buffer, so snippets show the original literal form.
- Adjust underscore/separator handling in the numeral reader to also preserve underscores in the buffer used for error/warning snippets.
- Add a regression check in `testes/pluto/basic.pluto` that asserts a duplicate-local warning contains `0x61` and does not contain `97`.

### Testing
- Built the project with `make linux -j2` (succeeded).
- Verified warning output for a minimal repro: `printf 'local a = 0x61\nlocal a = 0x61\n' > /tmp/dup.lua && src/pluto /tmp/dup.lua` and confirmed snippets contain `0x61` (succeeded).
- Ran `src/pluto testes/pluto/basic.pluto` which exercised the new regression check (succeeded).
- Ran full test targets `make test` and `src/pluto testes/_driver.pluto` (test suite ran; no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a270352c1508325b84b170a37990a1b)