### PR TITLE
0.14.0

### DIFF
--- a/src/lffi.cpp
+++ b/src/lffi.cpp
@@ -19,6 +19,7 @@ static thread_local lua_State* callback_L = nullptr;
 enum FfiType : uint8_t {
   FFI_UNKNOWN = 0,
   FFI_VOID,
+  FFI_BOOL,
   FFI_I8,
   FFI_I16,
   FFI_I32,
@@ -36,6 +37,7 @@ enum FfiType : uint8_t {
 [[nodiscard]] static FfiType check_ffi_type (lua_State *L, int i) {
   const char *str = luaL_checkstring(L, i);
   if (strcmp(str, "void") == 0) return FFI_VOID;
+  if (strcmp(str, "bool") == 0) return FFI_BOOL;
   if (strcmp(str, "i8") == 0) return FFI_I8;
   if (strcmp(str, "i16") == 0) return FFI_I16;
   if (strcmp(str, "i32") == 0) return FFI_I32;
@@ -54,7 +56,7 @@ enum FfiType : uint8_t {
 [[nodiscard]] static FfiType rfl_type_to_ffi_type (const soup::rflType& type) noexcept {
   if (type.at == soup::rflType::DIRECT) {
     if (type.name == "void") { return FFI_VOID; }
-    if (type.name == "bool") { return FFI_U8; }
+    if (type.name == "bool") { return FFI_BOOL; }
     if (type.name == "char") { return FFI_I8; }
     if (type.name == "unsigned char") { return FFI_U8; }
     if (type.name == "int8_t") { return FFI_I8; }
@@ -91,6 +93,9 @@ static int push_ffi_value (lua_State *L, FfiType type, const void *value) {
       break;
     case FFI_VOID:
       return 0;
+    case FFI_BOOL:
+      lua_pushboolean(L, *reinterpret_cast<const bool*>(value));
+      return 1;
     case FFI_I8:
       lua_pushinteger(L, *reinterpret_cast<const int8_t*>(value));
       return 1;
@@ -138,6 +143,9 @@ static uint64_t check_ffi_value (lua_State *L, int i, FfiType type) {
       break;
     case FFI_VOID:
       return 0;
+    case FFI_BOOL:
+      luaL_checktype(L, i, LUA_TBOOLEAN);
+      return static_cast<uint64_t>(lua_istrue(L, i));
     case FFI_I8:
       return static_cast<uint64_t>(static_cast<int8_t>(luaL_checkinteger(L, i)));
     case FFI_I16:

--- a/src/lffi.cpp
+++ b/src/lffi.cpp
@@ -632,11 +632,22 @@ static int ffi_alloc (lua_State *L) {
 }
 
 static int ffi_write (lua_State *L) {
-  luaL_checktype(L, 1, LUA_TUSERDATA);
-  auto dst_len = lua_rawlen(L, 1);
-  auto dst = lua_touserdata(L, 1);
+  void* dst;
+  size_t dst_len;
+  int i;
+  if (lua_type(L, 1) == LUA_TUSERDATA) {
+    dst_len = lua_rawlen(L, 1);
+    dst = lua_touserdata(L, 1);
+    i = 2;
+  }
+  else if (lua_type(L, 1) == LUA_TLIGHTUSERDATA) {
+    dst = lua_touserdata(L, 1);
+    dst_len = luaL_checkinteger(L, 2);
+    i = 3;
+  }
+  else luaL_typeerror(L, 1, "userdata or lightuserdata");
   size_t src_len;
-  auto src = luaL_checklstring(L, 2, &src_len);
+  auto src = luaL_checklstring(L, i, &src_len);
   if (src_len > dst_len) {
     src_len = dst_len;
   }
@@ -645,9 +656,17 @@ static int ffi_write (lua_State *L) {
 }
 
 static int ffi_read (lua_State *L) {
-  luaL_checktype(L, 1, LUA_TUSERDATA);
-  auto size = lua_rawlen(L, 1);
-  auto data = lua_touserdata(L, 1);
+  void* data;
+  size_t size;
+  if (lua_type(L, 1) == LUA_TUSERDATA) {
+    size = lua_rawlen(L, 1);
+    data = lua_touserdata(L, 1);
+  }
+  else if (lua_type(L, 1) == LUA_TLIGHTUSERDATA) {
+    data = lua_touserdata(L, 1);
+    size = luaL_checkinteger(L, 2);
+  }
+  else luaL_typeerror(L, 1, "userdata or lightuserdata");
   lua_pushlstring(L, static_cast<char*>(data), size);
   return 1;
 }

--- a/src/liolib.cpp
+++ b/src/liolib.cpp
@@ -1361,6 +1361,7 @@ static const luaL_Reg iolib[] = {
   {"cwd", currentdir},
   {"rename", l_rename},
   {"remove", l_remove},
+  {"unlink", l_remove},
   {"listdir", listdir},
   {"scandir", listdir},
   {"makedir", makedir},

--- a/src/lsocketlib.cpp
+++ b/src/lsocketlib.cpp
@@ -540,7 +540,12 @@ static int l_listen (lua_State *L) {
   }
   lua_setmetatable(L, -2);
 
-  return (addr.ip.isZero() ? l.serv.bind(port, &l.srv) : l.serv.bind(addr.ip, port, &l.srv)) ? 1 : 0;
+  uint16_t bound_port = (addr.ip.isZero() ? l.serv.bind(port, &l.srv) : l.serv.bind(addr.ip, port, &l.srv));
+  if (l_unlikely(bound_port == 0)) {
+    return 0;
+  }
+  lua_pushinteger(L, bound_port);
+  return 2;
 }
 
 static int l_udpserver (lua_State *L) {
@@ -597,7 +602,7 @@ LUAMOD_API int luaopen_socket (lua_State *L) {
   lua_pushliteral(L, "bind");
   luaL_loadstring(L, R"EOC(
 return function(sched, port, callback)
-    local l = require"pluto:socket".listen(port)
+    local l, bound_port = require"pluto:socket".listen(port)
     assert(l, "Failed to bind port "..port)
     return sched:add(function()
         while s := l:accept() do
@@ -605,7 +610,7 @@ return function(sched, port, callback)
                 callback(s)
             end)
         end
-    end)
+    end), bound_port
 end)EOC");
   lua_call(L, 0, 1);
   lua_settable(L, -3);

--- a/testes/pluto/ffi/lib.cpp
+++ b/testes/pluto/ffi/lib.cpp
@@ -82,3 +82,17 @@ SOUP_CEXPORT float float_cb_test(float(*func)(float, float))
 {
     return func(1.0f, 2.0f);
 }
+
+static char foreign_rw_buffer[75];
+
+SOUP_CEXPORT const void* foreign_read_test(size_t* out_len)
+{
+    memcpy(foreign_rw_buffer, "Hello from C/C++! Oops, there's unrelated data past the end of this string!", 75);
+    *out_len = 17;
+    return foreign_rw_buffer;
+}
+
+SOUP_CEXPORT int foreign_write_test()
+{
+    return memcmp(foreign_rw_buffer, "Hello from Pluto! Oops, there's unrelated data past the end of this string!", 75);
+}

--- a/testes/pluto/ffi/lib.cpp
+++ b/testes/pluto/ffi/lib.cpp
@@ -92,7 +92,7 @@ SOUP_CEXPORT const void* foreign_read_test(size_t* out_len)
     return foreign_rw_buffer;
 }
 
-SOUP_CEXPORT int foreign_write_test()
+SOUP_CEXPORT bool foreign_write_test()
 {
-    return memcmp(foreign_rw_buffer, "Hello from Pluto! Oops, there's unrelated data past the end of this string!", 75);
+    return memcmp(foreign_rw_buffer, "Hello from Pluto! Oops, there's unrelated data past the end of this string!", 75) == 0;
 }

--- a/testes/pluto/ffi/test.pluto
+++ b/testes/pluto/ffi/test.pluto
@@ -158,17 +158,32 @@ assert(float_test_inst.f == 69)
 assert(float_test_inst.d == 420)
 
 print "Testing FFI allocations."
-local pIn = ffi.alloc(13)
-local pOut = ffi.alloc(13)
-assert(ffi.read(pIn) == "\0":rep(13))
-assert(ffi.read(pOut) == "\0":rep(13))
-ffi.write(pIn, "Hello, world!")
-assert(ffi.read(pIn) == "Hello, world!")
-lib:cdef[[
-void buffer_test(uint8_t* in, size_t inlen, uint8_t* out, size_t outlen);
-]]
-lib.buffer_test(pIn, 13, pOut, 13)
-assert(ffi.read(pOut) == "Hello, world!")
+do
+    local pIn = ffi.alloc(13)
+    local pOut = ffi.alloc(13)
+    assert(ffi.read(pIn) == "\0":rep(13))
+    assert(ffi.read(pOut) == "\0":rep(13))
+    ffi.write(pIn, "Hello, world!")
+    assert(ffi.read(pIn) == "Hello, world!")
+    lib:cdef[[
+    void buffer_test(uint8_t* in, size_t inlen, uint8_t* out, size_t outlen);
+    ]]
+    lib.buffer_test(pIn, 13, pOut, 13)
+    assert(ffi.read(pOut) == "Hello, world!")
+end
+do
+    lib:cdef[[
+    const void* foreign_read_test(size_t* out_len);
+    int foreign_write_test();
+    ]]
+    local out_len = ffi.alloc(8)
+    local out = lib.foreign_read_test(out_len)
+    out_len = "I8":unpack(ffi.read(out_len))
+    assert(out_len == 17)
+    assert(ffi.read(out, out_len) == "Hello from C/C++!")
+    ffi.write(out, 17, "Hello from Pluto!")
+    assert(lib.foreign_write_test() == 0)
+end
 
 if ffi.callback then
     print "Testing FFI callbacks."

--- a/testes/pluto/ffi/test.pluto
+++ b/testes/pluto/ffi/test.pluto
@@ -174,7 +174,7 @@ end
 do
     lib:cdef[[
     const void* foreign_read_test(size_t* out_len);
-    int foreign_write_test();
+    bool foreign_write_test();
     ]]
     local out_len = ffi.alloc(8)
     local out = lib.foreign_read_test(out_len)
@@ -182,7 +182,7 @@ do
     assert(out_len == 17)
     assert(ffi.read(out, out_len) == "Hello from C/C++!")
     ffi.write(out, 17, "Hello from Pluto!")
-    assert(lib.foreign_write_test() == 0)
+    assert(lib.foreign_write_test() == true)
 end
 
 if ffi.callback then


### PR DESCRIPTION
(or maybe 1.0.0, depending on how we feel about it in however many months)

- Added ffi.read(lightuserdata, size) and ffi.write(lightuserdata, size, data) overloads
- FFI: Added 'bool' as a distinctive type from 'u8' (somewhat breaking change if your cdefs include "bool" and your Pluto code is using 0/1)
- Added io.unlink as an alias for io.remove
- socket.listen and socket.bind now return the port that was bound as the second return value (so you can use port 0 to take a random, available port)